### PR TITLE
feat: 支持将花笺设为 Windows 默认 Markdown 编辑器

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "floral-notepaper",
-  "version": "0.1.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "floral-notepaper",
-      "version": "0.1.0",
+      "version": "1.0.2",
       "dependencies": {
         "@tauri-apps/api": "~2.11.0",
         "@tauri-apps/plugin-dialog": "^2.7.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1017,6 +1017,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-opener",
+ "tauri-plugin-single-instance",
  "uuid",
 ]
 
@@ -3637,6 +3638,21 @@ dependencies = [
  "thiserror 2.0.18",
  "url",
  "windows",
+ "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8f29386f5e9fdc699182388a33ee80a56de436d91b67459e86afef426282af"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
  "zbus",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-autostart = "2"
 tauri-plugin-global-shortcut = "2"
+tauri-plugin-single-instance = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -239,6 +239,13 @@ pub async fn open_tile_window(
     open_tile_window_now(&app, &note_id, bounds)
 }
 
+pub fn extract_file_arg(args: &[String]) -> Option<String> {
+    args.iter().find(|arg| {
+        let lower = arg.to_lowercase();
+        lower.ends_with(".md") || lower.ends_with(".markdown")
+    }).cloned()
+}
+
 pub fn setup_desktop(app: &mut App) -> Result<(), Box<dyn Error>> {
     app.manage(RuntimeState::default());
     app.manage(NotepadPool::default());
@@ -253,6 +260,15 @@ pub fn setup_desktop(app: &mut App) -> Result<(), Box<dyn Error>> {
         if let Err(error) = show_main_window(app.handle()) {
             eprintln!("failed to show main window on startup: {error}");
         }
+    }
+
+    let args: Vec<String> = std::env::args().collect();
+    if let Some(file_path) = extract_file_arg(&args) {
+        let app_handle = app.handle().clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(500));
+            let _ = app_handle.emit("open-external-file", file_path);
+        });
     }
 
     Ok(())
@@ -368,7 +384,7 @@ fn handle_tray_menu_event(app: &AppHandle, id: &str) -> Result<(), Box<dyn Error
     Ok(())
 }
 
-fn show_main_window(app: &AppHandle) -> Result<(), AppError> {
+pub fn show_main_window(app: &AppHandle) -> Result<(), AppError> {
     if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
         window.unminimize()?;
         window.show()?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -46,6 +46,28 @@ fn notes_export_markdown(id: String, path: String) -> Result<(), AppError> {
 }
 
 #[tauri::command]
+fn read_external_file(path: String) -> Result<String, AppError> {
+    std::fs::read_to_string(&path).map_err(|e| AppError {
+        code: "io".into(),
+        message: e.to_string(),
+    })
+}
+
+#[tauri::command]
+fn save_external_file(path: String, content: String) -> Result<(), AppError> {
+    if let Some(parent) = PathBuf::from(&path).parent() {
+        std::fs::create_dir_all(parent).map_err(|e| AppError {
+            code: "io".into(),
+            message: e.to_string(),
+        })?;
+    }
+    std::fs::write(&path, content).map_err(|e| AppError {
+        code: "io".into(),
+        message: e.to_string(),
+    })
+}
+
+#[tauri::command]
 fn config_get() -> Result<AppConfig, AppError> {
     default_store()?.load_config()
 }
@@ -91,6 +113,12 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
+            if let Some(file_path) = desktop::extract_file_arg(&args) {
+                let _ = app.emit("open-external-file", file_path);
+            }
+            let _ = desktop::show_main_window(app);
+        }))
         .setup(|app| {
             desktop::setup_desktop(app)?;
             Ok(())
@@ -105,6 +133,8 @@ pub fn run() {
             notes_delete,
             notes_import_markdown,
             notes_export_markdown,
+            read_external_file,
+            save_external_file,
             config_get,
             config_save,
             open_notepad_window,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -37,6 +37,14 @@
         "installerHooks": "nsis-hooks.nsh"
       }
     },
+    "fileAssociations": [
+      {
+        "ext": ["md", "markdown"],
+        "name": "Markdown Document",
+        "description": "Markdown document file",
+        "role": "Editor"
+      }
+    ],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { MouseEvent } from "react";
-import { emit } from "@tauri-apps/api/event";
+import { emit, listen } from "@tauri-apps/api/event";
 import { exportMarkdownNote, importMarkdownNote } from "../features/importExport/api";
 import { MarkdownPreview } from "../features/markdown/MarkdownPreview";
 import {
@@ -19,9 +19,11 @@ import {
   getErrorMessage,
   getNote,
   listNotes,
+  readExternalFile,
+  saveExternalFile,
   updateNote,
 } from "../features/notes/api";
-import type { Note, NoteMetadata } from "../features/notes/types";
+import type { ExternalFile, Note, NoteMetadata } from "../features/notes/types";
 import {
   countNoteChars,
   filterNotes,
@@ -213,6 +215,7 @@ export function MainWindow({
   initialConfig = undefined,
 }: MainWindowProps = {}) {
   const [notes, setNotes] = useState<NoteMetadata[]>([]);
+  const [externalFiles, setExternalFiles] = useState<ExternalFile[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [viewMode, setViewMode] = useState<ViewMode>(
@@ -243,6 +246,13 @@ export function MainWindow({
     () => notes.find((note) => note.id === selectedId) ?? null,
     [notes, selectedId],
   );
+
+  const selectedExternalFile = useMemo(
+    () => externalFiles.find((f) => f.id === selectedId) ?? null,
+    [externalFiles, selectedId],
+  );
+
+  const isExternal = selectedExternalFile !== null;
 
   const noteMenuTarget = useMemo(
     () => notes.find((note) => note.id === noteMenu?.noteId) ?? null,
@@ -306,6 +316,37 @@ export function MainWindow({
     setSaveState("idle");
   }, []);
 
+  const loadExternalFile = useCallback(async (filePath: string) => {
+    setErrorMessage(null);
+    try {
+      const fileContent = await readExternalFile(filePath);
+      const fileName = filePath.split(/[\\/]/).pop() ?? filePath;
+      const displayTitle = fileName.replace(/\.md$/i, "");
+
+      setExternalFiles((current) => {
+        if (current.some((f) => f.id === filePath)) {
+          return current;
+        }
+        return [
+          ...current,
+          {
+            id: filePath,
+            title: displayTitle,
+            filePath,
+          },
+        ];
+      });
+
+      setSelectedId(filePath);
+      setTitle(displayTitle);
+      setContent(fileContent);
+      setSaveState("saved");
+      setNoteTransitionKey((k) => k + 1);
+    } catch (error) {
+      setErrorMessage(getErrorMessage(error));
+    }
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
 
@@ -339,6 +380,15 @@ export function MainWindow({
   }, [applyNote, clearCurrentNote]);
 
   useEffect(() => {
+    const unlisten = listen<string>("open-external-file", (event) => {
+      void loadExternalFile(event.payload);
+    });
+    return () => {
+      void unlisten.then((fn) => fn());
+    };
+  }, [loadExternalFile]);
+
+  useEffect(() => {
     function closeNoteMenu() {
       setNoteMenuClosing(true);
     }
@@ -367,6 +417,20 @@ export function MainWindow({
   const saveCurrentNote = useCallback(async () => {
     if (!selectedId) return null;
 
+    if (isExternal && selectedExternalFile) {
+      setSaveState("saving");
+      try {
+        await saveExternalFile(selectedExternalFile.filePath, content);
+        setSaveState("saved");
+        setErrorMessage(null);
+        return { id: selectedId, title, content } as Note;
+      } catch (error) {
+        setSaveState("error");
+        setErrorMessage(getErrorMessage(error));
+        return null;
+      }
+    }
+
     setSaveState("saving");
     try {
       const note = await updateNote(selectedId, { title, content });
@@ -379,7 +443,7 @@ export function MainWindow({
       setErrorMessage(getErrorMessage(error));
       return null;
     }
-  }, [content, replaceNoteMetadata, selectedId, title]);
+  }, [content, isExternal, replaceNoteMetadata, selectedExternalFile, selectedId, title]);
 
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
@@ -395,6 +459,7 @@ export function MainWindow({
 
   useEffect(() => {
     if (!selectedId || saveState !== "dirty") return undefined;
+    if (isExternal) return undefined;
     if (!settingsConfig?.noteAutoSave) return undefined;
 
     const timer = window.setTimeout(() => {
@@ -402,7 +467,7 @@ export function MainWindow({
     }, 900);
 
     return () => window.clearTimeout(timer);
-  }, [saveCurrentNote, saveState, selectedId, settingsConfig?.noteAutoSave]);
+  }, [isExternal, saveCurrentNote, saveState, selectedId, settingsConfig?.noteAutoSave]);
 
   const handleNewNote = async () => {
     setErrorMessage(null);
@@ -528,6 +593,48 @@ export function MainWindow({
       setErrorMessage(getErrorMessage(error));
     } finally {
       setIsLoading(false);
+    }
+  };
+
+  const handleSelectExternalFile = async (id: string) => {
+    if (id === selectedId) return;
+    setDeleteConfirm(false);
+    if (saveState === "dirty") {
+      await saveCurrentNote();
+    }
+
+    const file = externalFiles.find((f) => f.id === id);
+    if (!file) return;
+
+    setIsLoading(true);
+    try {
+      const fileContent = await readExternalFile(file.filePath);
+      setSelectedId(id);
+      setTitle(file.title);
+      setContent(fileContent);
+      setSaveState("saved");
+      setErrorMessage(null);
+      setNoteTransitionKey((k) => k + 1);
+    } catch (error) {
+      setErrorMessage(getErrorMessage(error));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleRemoveExternalFile = async (id: string) => {
+    if (selectedId === id && saveState === "dirty") {
+      const shouldSave = window.confirm(
+        `「${title || "未命名文件"}」有未保存的更改，是否保存到原文件？`,
+      );
+      if (shouldSave) {
+        const saved = await saveCurrentNote();
+        if (!saved) return;
+      }
+    }
+    setExternalFiles((current) => current.filter((f) => f.id !== id));
+    if (selectedId === id) {
+      clearCurrentNote();
     }
   };
 
@@ -855,12 +962,80 @@ export function MainWindow({
 
             <div className="px-5 pb-1.5 shrink-0">
               <span className="text-[10px] text-ink-ghost font-mono tracking-wider uppercase">
-                {filteredNotes.length} 篇笔记
+                {filteredNotes.length} 篇笔记{externalFiles.length > 0 ? ` · ${externalFiles.length} 个外部文件` : ""}
               </span>
             </div>
 
             <div className="flex-1 overflow-y-auto px-2 pb-2">
               <div className="space-y-0.5">
+                {externalFiles.length > 0 && (
+                  <>
+                    <div className="px-3 py-1.5 text-[10px] text-ink-ghost/50 font-mono tracking-wider uppercase">
+                      外部文件
+                    </div>
+                    {externalFiles.map((file) => {
+                      const isSelected = file.id === selectedId;
+                      const isHovered = file.id === hoveredId;
+
+                      return (
+                        <button
+                          key={file.id}
+                          onClick={() => void handleSelectExternalFile(file.id)}
+                          onMouseEnter={() => setHoveredId(file.id)}
+                          onMouseLeave={() => setHoveredId(null)}
+                          className={`w-full text-left rounded-xl px-3 py-2.5 transition-all duration-[600ms] cursor-pointer group relative ${
+                            isSelected
+                              ? "bg-bamboo-mist/70"
+                              : isHovered
+                                ? "bg-paper-warm/70"
+                                : "bg-transparent"
+                          }`}
+                        >
+                          <div className={`absolute left-0 top-1/2 -translate-y-1/2 w-[3px] rounded-r-full bg-bamboo/60 transition-all duration-[600ms] ${
+                            isSelected ? "h-5 opacity-100" : "h-0 opacity-0"
+                          }`} />
+
+                          <div className="flex items-baseline justify-between mb-0.5">
+                            <span
+                              className={`text-[13px] font-display font-medium truncate pr-2 transition-colors flex items-center gap-1.5 ${
+                                isSelected ? "text-bamboo" : "text-ink-soft"
+                              }`}
+                            >
+                              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="shrink-0 opacity-60">
+                                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                                <polyline points="14 2 14 8 20 8" />
+                              </svg>
+                              {file.title}
+                            </span>
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleRemoveExternalFile(file.id);
+                              }}
+                              className="opacity-0 group-hover:opacity-100 text-ink-ghost hover:text-red-400 transition-all p-0.5"
+                              title="从列表移除"
+                            >
+                              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                                <line x1="18" y1="6" x2="6" y2="18" />
+                                <line x1="6" y1="6" x2="18" y2="18" />
+                              </svg>
+                            </button>
+                          </div>
+
+                          <p className="text-[11px] text-ink-ghost leading-relaxed line-clamp-2 group-hover:text-ink-faint transition-colors pl-[18px]">
+                            {file.filePath}
+                          </p>
+                        </button>
+                      );
+                    })}
+                  </>
+                )}
+
+                {filteredNotes.length > 0 && (
+                  <div className="px-3 py-1.5 text-[10px] text-ink-ghost/50 font-mono tracking-wider uppercase">
+                    笔记
+                  </div>
+                )}
                 {filteredNotes.map((note) => {
                   const isSelected = note.id === selectedId;
                   const isHovered = note.id === hoveredId;
@@ -914,7 +1089,7 @@ export function MainWindow({
                   );
                 })}
 
-                {!isLoading && filteredNotes.length === 0 && (
+                {!isLoading && filteredNotes.length === 0 && externalFiles.length === 0 && (
                   <div className="px-3 py-8 text-center text-[12px] text-ink-ghost leading-relaxed">
                     {searchQuery ? "没有匹配的笔记" : "还没有笔记"}
                   </div>
@@ -1062,8 +1237,12 @@ export function MainWindow({
                 className="w-full text-[20px] font-display font-bold text-ink placeholder:text-ink-ghost/50 tracking-wide disabled:opacity-60"
               />
               <div className="flex items-center gap-3 mt-1.5">
-                <span className="text-[10px] text-ink-ghost font-mono tabular-nums">
-                  {selectedNote ? `${formatShortDate(selectedNote.updatedAt)} ${formatTime(selectedNote.updatedAt)}` : "--"}
+                <span className="text-[10px] text-ink-ghost font-mono tabular-nums truncate max-w-[200px]">
+                  {selectedExternalFile
+                    ? `外部文件 · ${selectedExternalFile.filePath}`
+                    : selectedNote
+                      ? `${formatShortDate(selectedNote.updatedAt)} ${formatTime(selectedNote.updatedAt)}`
+                      : "--"}
                 </span>
                 <span className="text-[10px] text-ink-ghost/40">·</span>
                 <span className="text-[10px] text-ink-ghost font-mono tabular-nums">

--- a/src/features/notes/api.ts
+++ b/src/features/notes/api.ts
@@ -21,6 +21,14 @@ export function deleteNote(id: string): Promise<void> {
   return invoke("notes_delete", { id });
 }
 
+export function readExternalFile(path: string): Promise<string> {
+  return invoke("read_external_file", { path });
+}
+
+export function saveExternalFile(path: string, content: string): Promise<void> {
+  return invoke("save_external_file", { path, content });
+}
+
 export function getErrorMessage(error: unknown): string {
   if (typeof error === "string") return error;
   if (error && typeof error === "object" && "message" in error) {

--- a/src/features/notes/types.ts
+++ b/src/features/notes/types.ts
@@ -16,3 +16,9 @@ export interface SaveNoteRequest {
   title: string;
   content: string;
 }
+
+export interface ExternalFile {
+  id: string;
+  title: string;
+  filePath: string;
+}


### PR DESCRIPTION
## 功能

支持将花笺设为 Windows 系统中 `.md` / `.markdown` 文件的默认打开方式。双击 markdown 文件即可唤起花笺并直接编辑原文件。

## 改动摘要

### Tauri 配置
- `tauri.conf.json`: 注册 `.md` / `.markdown` 文件关联

### Rust 后端
- `Cargo.toml`: 添加 `tauri-plugin-single-instance` 依赖
- `lib.rs`: 注册单实例插件，添加 `read_external_file` / `save_external_file` 命令
- `desktop.rs`: 提取启动文件路径参数，延迟发送事件给前端；已有实例运行时唤醒窗口

### 前端
- `MainWindow.tsx`: 
  - 笔记列表顶部新增"外部文件"独立分组
  - 外部文件悬停显示移除按钮
  - 外部文件仅手动保存（Ctrl+S），自动保存不生效
  - 切换/移除时未保存提示确认
  - 状态栏显示"外部文件 · 文件路径"
- `types.ts` / `api.ts`: 添加 `ExternalFile` 类型和外部文件 API

## 使用方式

安装后右键 `.md` 文件选择"用花笺打开"，或在资源管理器中双击打开。

Closes #6