### PR TITLE
feat: 设置面板增加编辑器字体自定义功能

### DIFF
--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -886,6 +886,7 @@ fn apply_autostart(_app: &AppHandle, _enabled: bool) -> Result<(), Box<dyn Error
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::services::notes::{default_editor_font_family, default_editor_font_mode};
 
     #[test]
     fn maps_tray_menu_ids_to_actions() {
@@ -983,6 +984,8 @@ mod tests {
             theme: "light".into(),
             font_size: 14,
             surface_font_size: 14,
+            editor_font_mode: default_editor_font_mode(),
+            editor_font_family: default_editor_font_family(),
         };
         let next = AppConfig {
             notes_dir: "D:\\other-notes".into(),
@@ -997,6 +1000,8 @@ mod tests {
             theme: "dark".into(),
             font_size: 16,
             surface_font_size: 16,
+            editor_font_mode: default_editor_font_mode(),
+            editor_font_family: default_editor_font_family(),
         };
 
         assert_eq!(

--- a/src-tauri/src/services/notes.rs
+++ b/src-tauri/src/services/notes.rs
@@ -28,6 +28,10 @@ pub struct AppConfig {
     pub font_size: u32,
     #[serde(default = "default_surface_font_size")]
     pub surface_font_size: u32,
+    #[serde(default = "default_editor_font_mode")]
+    pub editor_font_mode: String,
+    #[serde(default = "default_editor_font_family")]
+    pub editor_font_family: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -451,6 +455,8 @@ impl NoteStore {
             theme: default_theme(),
             font_size: default_font_size(),
             surface_font_size: default_surface_font_size(),
+            editor_font_mode: default_editor_font_mode(),
+            editor_font_family: default_editor_font_family(),
         }
     }
 
@@ -718,6 +724,14 @@ fn default_surface_font_size() -> u32 {
     14
 }
 
+pub(crate) fn default_editor_font_mode() -> String {
+    "system".into()
+}
+
+pub(crate) fn default_editor_font_family() -> String {
+    "\"JetBrains Mono\", \"Fira Code\", monospace".into()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -845,6 +859,8 @@ mod tests {
             theme: "dark".into(),
             font_size: 16,
             surface_font_size: 16,
+            editor_font_mode: default_editor_font_mode(),
+            editor_font_family: default_editor_font_family(),
         };
 
         store.save_config(saved.clone()).expect("save config");

--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -1721,7 +1721,7 @@ export function MainWindow({
                             markDirty();
                           }}
                           className="w-full h-full leading-[1.9] text-ink-soft font-mono placeholder:text-ink-ghost/40"
-                          style={{ fontSize: `${settingsConfig?.fontSize ?? 14}px` }}
+                          style={{ fontSize: `${settingsConfig?.fontSize ?? 14}px`, fontFamily: settingsConfig?.editorFontMode === "custom" ? settingsConfig?.editorFontFamily ?? undefined : undefined }}
                           placeholder="开始写作……"
                           spellCheck={false}
                           disabled={!selectedId}

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import type { AppConfig, ThemeOption, TileColorMode, ViewMode } from "../features/settings/types";
+import type { AppConfig, EditorFontMode, ThemeOption, TileColorMode, ViewMode } from "../features/settings/types";
 import { supportedShortcuts } from "../features/settings/api";
 import {
   DEFAULT_TILE_COLOR,
@@ -31,6 +31,13 @@ const viewModes: Array<{ value: ViewMode; label: string }> = [
   { value: "split", label: "分栏" },
   { value: "preview", label: "预览" },
 ];
+
+const editorFontModes: Array<{ value: EditorFontMode; label: string }> = [
+  { value: "system", label: "系统默认" },
+  { value: "custom", label: "自定义" },
+];
+
+const EDITOR_FONT_PLACEHOLDER = "\"@HarmonyOS Sans SC\", \"Inter\"";
 
 export function SettingsPanel({
   config,
@@ -168,6 +175,38 @@ export function SettingsPanel({
 
         <section className="space-y-2">
           <label className="block text-[11px] font-body text-ink-faint">
+            编辑器字体
+          </label>
+          <SlidingButtonGroup
+            options={editorFontModes}
+            value={config.editorFontMode ?? "system"}
+            onChange={(v: EditorFontMode) => setConfigValue("editorFontMode", v)}
+          />
+          {config.editorFontMode === "custom" && (
+            <div className="flex items-center gap-2">
+              <input
+                type="text"
+                value={config.editorFontFamily ?? ""}
+                onChange={(event) =>
+                  setConfigValue("editorFontFamily", event.target.value)
+                }
+                placeholder={EDITOR_FONT_PLACEHOLDER}
+                spellCheck={false}
+                className="min-w-0 flex-1 h-8 px-2.5 rounded-lg bg-paper-warm/70 border border-paper-deep/40 text-[12px] font-mono text-ink-soft outline-none"
+              />
+              <button
+                type="button"
+                onClick={() => onChange({ ...config })}
+                className="h-8 px-2.5 rounded-lg border border-paper-deep/45 text-[11px] text-ink-faint hover:text-bamboo hover:bg-bamboo-mist/50 transition-colors cursor-pointer whitespace-nowrap"
+              >
+                应用
+              </button>
+            </div>
+          )}
+        </section>
+
+        <section className="space-y-2">
+          <label className="block text-[11px] font-body text-ink-faint">
             小窗/磁贴字号
           </label>
           <div className="flex items-center gap-3 h-9 rounded-lg px-2.5 bg-paper-warm/45 border border-paper-deep/25">
@@ -278,15 +317,27 @@ function ToggleRow({ label, checked, onChange }: ToggleRowProps) {
   );
 }
 
+interface ShortcutOption {
+  value: string;
+  label: string;
+}
+
 interface ShortcutDropdownProps {
   value: string;
-  options: string[];
+  options: string[] | ShortcutOption[];
   onChange: (value: string) => void;
 }
 
 function ShortcutDropdown({ value, options, onChange }: ShortcutDropdownProps) {
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+
+  const resolved = options.map((opt) =>
+    typeof opt === "string" ? { value: opt, label: opt } : opt,
+  );
+
+  const currentLabel =
+    resolved.find((r) => r.value === value)?.label ?? value;
 
   useEffect(() => {
     if (!open) return;
@@ -306,7 +357,7 @@ function ShortcutDropdown({ value, options, onChange }: ShortcutDropdownProps) {
         onClick={() => setOpen((v) => !v)}
         className="w-full h-8 px-2.5 rounded-lg bg-paper-warm/70 border border-paper-deep/40 text-[12px] text-ink-soft flex items-center justify-between cursor-pointer hover:border-paper-deep/60 transition-colors"
       >
-        <span>{value}</span>
+        <span className="truncate">{currentLabel}</span>
         <svg
           width="10"
           height="10"
@@ -316,7 +367,7 @@ function ShortcutDropdown({ value, options, onChange }: ShortcutDropdownProps) {
           strokeWidth="1.5"
           strokeLinecap="round"
           strokeLinejoin="round"
-          className={`text-ink-ghost transition-transform duration-250 ease-[cubic-bezier(0.22,1,0.36,1)] ${open ? "rotate-180" : ""}`}
+          className={`shrink-0 text-ink-ghost transition-transform duration-250 ease-[cubic-bezier(0.22,1,0.36,1)] ${open ? "rotate-180" : ""}`}
         >
           <path d="M2 3.5l3 3 3-3" />
         </svg>
@@ -330,18 +381,18 @@ function ShortcutDropdown({ value, options, onChange }: ShortcutDropdownProps) {
           pointerEvents: open ? "auto" : "none",
         }}
       >
-        {options.map((opt) => (
-          <li key={opt} className="list-none">
+        {resolved.map((opt) => (
+          <li key={opt.value} className="list-none">
             <button
               type="button"
-              onClick={() => { onChange(opt); setOpen(false); }}
+              onClick={() => { onChange(opt.value); setOpen(false); }}
               className={`w-full h-8 px-2.5 text-left text-[12px] transition-colors cursor-pointer ${
-                opt === value
+                opt.value === value
                   ? "text-bamboo bg-bamboo-mist/40 font-medium"
                   : "text-ink-soft hover:bg-paper-warm/60"
               }`}
             >
-              {opt}
+              {opt.label}
             </button>
           </li>
         ))}

--- a/src/features/settings/types.ts
+++ b/src/features/settings/types.ts
@@ -4,6 +4,8 @@ export type ThemeOption = "light" | "dark" | "system";
 
 export type TileColorMode = "system" | "custom";
 
+export type EditorFontMode = "system" | "custom";
+
 export interface AppConfig {
   notesDir: string;
   globalShortcut: string;
@@ -17,4 +19,6 @@ export interface AppConfig {
   theme: ThemeOption;
   fontSize: number;
   surfaceFontSize: number;
+  editorFontMode?: EditorFontMode;
+  editorFontFamily?: string;
 }


### PR DESCRIPTION
- 支持"系统默认"和"自定义"两种模式，自定义时可通过文本输入指定 CSS font-family 回退链，仅影响主编辑器正文区域。