### PR TITLE
feat: add LaTeX editing and preview support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,15 +13,19 @@
         "@tauri-apps/plugin-dialog": "^2.7.0",
         "@tauri-apps/plugin-opener": "^2",
         "chroma-js": "^3.2.0",
+        "katex": "^0.16.47",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-markdown": "^10.1.0",
-        "remark-gfm": "^4.0.1"
+        "rehype-katex": "^7.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-math": "^6.0.0"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.2.4",
         "@tauri-apps/cli": "^2",
         "@types/chroma-js": "^3.1.2",
+        "@types/katex": "^0.16.8",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
@@ -1854,6 +1858,12 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmmirror.com/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "license": "MIT"
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -2198,6 +2208,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmmirror.com/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2292,6 +2311,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmmirror.com/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -2451,6 +2482,101 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/hast-util-from-dom": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
+      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hastscript": "^9.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html-isomorphic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-2.0.0.tgz",
+      "integrity": "sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-dom": "^5.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmmirror.com/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -2478,6 +2604,22 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -2485,6 +2627,23 @@
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmmirror.com/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2604,6 +2763,22 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmmirror.com/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
       }
     },
     "node_modules/lightningcss": {
@@ -3048,6 +3223,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-math": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
+      "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-mdx-expression": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
@@ -3357,6 +3551,25 @@
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
         "micromark-factory-space": "^2.0.0",
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
@@ -3808,6 +4021,18 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmmirror.com/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -3932,6 +4157,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rehype-katex": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmmirror.com/rehype-katex/-/rehype-katex-7.0.1.tgz",
+      "integrity": "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/katex": "^0.16.0",
+        "hast-util-from-html-isomorphic": "^2.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "katex": "^0.16.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-gfm": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
@@ -3943,6 +4187,22 @@
         "micromark-extension-gfm": "^3.0.0",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmmirror.com/remark-math/-/remark-math-6.0.0.tgz",
+      "integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-math": "^3.0.0",
+        "micromark-extension-math": "^3.0.0",
         "unified": "^11.0.0"
       },
       "funding": {
@@ -4250,6 +4510,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
@@ -4270,6 +4544,20 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4366,6 +4654,20 @@
       "dependencies": {
         "@types/unist": "^3.0.0",
         "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmmirror.com/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4549,6 +4851,16 @@
         "vite": {
           "optional": false
         }
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/why-is-node-running": {

--- a/package.json
+++ b/package.json
@@ -16,15 +16,19 @@
     "@tauri-apps/plugin-dialog": "^2.7.0",
     "@tauri-apps/plugin-opener": "^2",
     "chroma-js": "^3.2.0",
+    "katex": "^0.16.47",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",
-    "remark-gfm": "^4.0.1"
+    "rehype-katex": "^7.0.1",
+    "remark-gfm": "^4.0.1",
+    "remark-math": "^6.0.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.4",
     "@tauri-apps/cli": "^2",
     "@types/chroma-js": "^3.1.2",
+    "@types/katex": "^0.16.8",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",

--- a/src/App.css
+++ b/src/App.css
@@ -235,3 +235,38 @@ textarea::placeholder, input::placeholder {
 .animate-status-fade {
   animation: status-fade 0.25s ease-out forwards;
 }
+
+/* KaTeX math rendering */
+.katex-display {
+  margin: 1em 0 !important;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding: 0.5em 0;
+}
+.katex-display > .katex {
+  white-space: normal;
+}
+.katex {
+  font-size: 1.1em;
+  color: var(--color-ink-soft);
+}
+.katex .mord,
+.katex .mbin,
+.katex .mrel,
+.katex .mopen,
+.katex .mclose,
+.katex .mpunct,
+.katex .mop {
+  color: var(--color-ink-soft);
+}
+.katex .mop {
+  color: var(--color-bamboo);
+}
+.katex .katex-html .newline {
+  height: 0.5em;
+}
+.katex .katex-error {
+  color: #ef4444;
+  font-size: 0.85em;
+  font-family: var(--font-mono);
+}

--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -75,7 +75,7 @@ const saveStateLabel: Record<SaveState, string> = {
   error: "保存失败",
 };
 
-type FormatAction = "bold" | "italic" | "heading" | "hr" | "ul" | "ol" | "code" | "quote";
+type FormatAction = "bold" | "italic" | "heading" | "hr" | "ul" | "ol" | "code" | "quote" | "inlineMath" | "blockMath";
 
 const toolbarButtons: { label: string; title: string; style: string; action: FormatAction }[] = [
   { label: "B", title: "粗体", style: "font-bold", action: "bold" },
@@ -86,6 +86,8 @@ const toolbarButtons: { label: string; title: string; style: string; action: For
   { label: "1.", title: "有序列表", style: "font-mono text-[9px]", action: "ol" },
   { label: "<>", title: "代码", style: "font-mono text-[9px]", action: "code" },
   { label: "❝", title: "引用", style: "", action: "quote" },
+  { label: "∑", title: "行内公式", style: "font-mono text-[11px]", action: "inlineMath" },
+  { label: "∫", title: "块级公式", style: "font-mono text-[11px]", action: "blockMath" },
 ];
 
 function applyFormat(
@@ -207,6 +209,20 @@ function applyFormat(
         cursorStart = start + 2;
         cursorEnd = cursorStart + (selected || "引用文本").length;
       }
+      break;
+    }
+    case "inlineMath": {
+      const wrapped = `$${selected || "E=mc^2"}$`;
+      result = before + wrapped + after;
+      cursorStart = start + 1;
+      cursorEnd = cursorStart + (selected || "E=mc^2").length;
+      break;
+    }
+    case "blockMath": {
+      const wrapped = `\n$$\n${selected || "\\int_{-\\infty}^{\\infty} e^{-x^2} dx = \\sqrt{\\pi}"}\n$$\n`;
+      result = before + wrapped + after;
+      cursorStart = start + 4;
+      cursorEnd = cursorStart + (selected || "\\int_{-\\infty}^{\\infty} e^{-x^2} dx = \\sqrt{\\pi}").length;
       break;
     }
   }
@@ -1848,7 +1864,7 @@ export function MainWindow({
                 </span>
                 <span className="text-[10px] text-ink-ghost/40">|</span>
                 <span className="text-[10px] text-ink-ghost font-mono">
-                  Markdown
+                  Markdown + LaTeX
                 </span>
               </div>
               <div className="flex items-center gap-3">

--- a/src/features/markdown/LatexPreview.tsx
+++ b/src/features/markdown/LatexPreview.tsx
@@ -1,0 +1,109 @@
+import { useMemo } from "react";
+import katex from "katex";
+import "katex/dist/katex.min.css";
+
+interface LatexPreviewProps {
+  content: string;
+  fontSize?: number;
+}
+
+function renderLatexBlock(tex: string, displayMode: boolean): string {
+  try {
+    return katex.renderToString(tex, {
+      displayMode,
+      throwOnError: false,
+      trust: true,
+      strict: false,
+    });
+  } catch {
+    return `<span class="text-red-400">${tex}</span>`;
+  }
+}
+
+function parseLatexContent(content: string): Array<{ type: "text" | "block" | "inline"; value: string }> {
+  const parts: Array<{ type: "text" | "block" | "inline"; value: string }> = [];
+  let remaining = content;
+
+  while (remaining.length > 0) {
+    const blockStart = remaining.indexOf("$$");
+    const inlineStart = remaining.indexOf("$");
+
+    if (blockStart === -1 && inlineStart === -1) {
+      if (remaining) parts.push({ type: "text", value: remaining });
+      break;
+    }
+
+    if (blockStart !== -1 && (inlineStart === -1 || blockStart <= inlineStart)) {
+      if (blockStart > 0) {
+        parts.push({ type: "text", value: remaining.slice(0, blockStart) });
+      }
+      const blockEnd = remaining.indexOf("$$", blockStart + 2);
+      if (blockEnd === -1) {
+        parts.push({ type: "text", value: remaining });
+        break;
+      }
+      parts.push({
+        type: "block",
+        value: remaining.slice(blockStart + 2, blockEnd),
+      });
+      remaining = remaining.slice(blockEnd + 2);
+    } else {
+      if (inlineStart > 0) {
+        parts.push({ type: "text", value: remaining.slice(0, inlineStart) });
+      }
+      const inlineEnd = remaining.indexOf("$", inlineStart + 1);
+      if (inlineEnd === -1) {
+        parts.push({ type: "text", value: remaining });
+        break;
+      }
+      parts.push({
+        type: "inline",
+        value: remaining.slice(inlineStart + 1, inlineEnd),
+      });
+      remaining = remaining.slice(inlineEnd + 1);
+    }
+  }
+
+  return parts;
+}
+
+export function LatexPreview({ content, fontSize = 14 }: LatexPreviewProps) {
+  const rendered = useMemo(() => parseLatexContent(content), [content]);
+
+  if (!content.trim()) {
+    return (
+      <div className="max-w-[560px] font-body" style={{ fontSize: `${fontSize}px` }}>
+        <p className="text-ink-ghost leading-[1.9]">LaTeX 预览区</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-[560px] font-body" style={{ fontSize: `${fontSize}px` }}>
+      {rendered.map((part, i) => {
+        if (part.type === "text") {
+          return (
+            <span key={i} className="whitespace-pre-wrap text-ink-soft">
+              {part.value}
+            </span>
+          );
+        }
+        if (part.type === "block") {
+          return (
+            <div
+              key={i}
+              className="my-4 py-3 px-4 rounded bg-paper-warm/50 overflow-x-auto text-center"
+              dangerouslySetInnerHTML={{ __html: renderLatexBlock(part.value, true) }}
+            />
+          );
+        }
+        return (
+          <span
+            key={i}
+            dangerouslySetInnerHTML={{ __html: renderLatexBlock(part.value, false) }}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/markdown/MarkdownPreview.tsx
+++ b/src/features/markdown/MarkdownPreview.tsx
@@ -1,8 +1,11 @@
 import { useState, useCallback } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import rehypeKatex from "rehype-katex";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import type { Components } from "react-markdown";
+import "katex/dist/katex.min.css";
 
 function CodeBlock({ children }: { children: React.ReactNode }) {
   const [copied, setCopied] = useState(false);
@@ -45,7 +48,8 @@ interface MarkdownPreviewProps {
   fontSize?: number;
 }
 
-const remarkPlugins = [remarkGfm];
+const remarkPlugins = [remarkGfm, remarkMath];
+const rehypePlugins = [rehypeKatex];
 
 const components: Components = {
   h1: ({ children }) => (
@@ -155,7 +159,7 @@ export function MarkdownPreview({ content, fontSize = 14 }: MarkdownPreviewProps
   return (
     <div className="max-w-[560px] font-body" style={{ fontSize: `${fontSize}px` }}>
       {content.trim() ? (
-        <Markdown remarkPlugins={remarkPlugins} components={components}>
+        <Markdown remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins} components={components}>
           {content}
         </Markdown>
       ) : (

--- a/test-latex.html
+++ b/test-latex.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>LaTeX 测试</title>
+  <link rel="stylesheet" href="/node_modules/katex/dist/katex.min.css" />
+  <style>
+    body { font-family: "Noto Sans SC", system-ui, sans-serif; max-width: 720px; margin: 40px auto; padding: 0 20px; color: #3d3d38; background: #f6f3ec; }
+    h1 { color: #2d5a3d; }
+    textarea { width: 100%; height: 200px; padding: 12px; font-family: "JetBrains Mono", monospace; font-size: 14px; border: 1px solid #e8e1d3; border-radius: 8px; background: #fff; resize: vertical; }
+    #preview { margin-top: 20px; padding: 16px; border: 1px solid #e8e1d3; border-radius: 8px; background: #fff; min-height: 80px; }
+    .katex { font-size: 1.15em; }
+    .katex-display { margin: 1em 0; overflow-x: auto; }
+    .label { font-size: 12px; color: #b8b8ae; margin-bottom: 4px; }
+  </style>
+</head>
+<body>
+  <h1>LaTeX 渲染测试</h1>
+  <div class="label">在下方输入 Markdown + LaTeX 内容：</div>
+  <textarea id="editor"># LaTeX 测试
+
+行内公式：$E=mc^2$，勾股定理 $a^2+b^2=c^2$
+
+块级公式：
+
+$$
+\int_{-\infty}^{\infty} e^{-x^2} dx = \sqrt{\pi}
+$$
+
+矩阵：
+
+$$
+\begin{pmatrix}
+a & b \\
+c & d
+\end{pmatrix}
+\cdot
+\begin{pmatrix}
+x \\ y
+\end{pmatrix}
+=
+\begin{pmatrix}
+ax+by \\ cx+dy
+\end{pmatrix}
+$$
+
+求和与极限：
+
+$$
+\sum_{n=1}^{\infty} \frac{1}{n^2} = \frac{\pi^2}{6}, \quad \lim_{x \to 0} \frac{\sin x}{x} = 1
+$$</textarea>
+  <div class="label">渲染预览：</div>
+  <div id="preview"></div>
+
+  <script type="module">
+    import katex from "/node_modules/katex/dist/katex.mjs";
+
+    const editor = document.getElementById("editor");
+    const preview = document.getElementById("preview");
+
+    function renderLatex(content) {
+      const parts = [];
+      let remaining = content;
+
+      while (remaining.length > 0) {
+        const blockStart = remaining.indexOf("$$");
+        const inlineStart = remaining.indexOf("$");
+
+        if (blockStart === -1 && inlineStart === -1) {
+          if (remaining) parts.push({ type: "text", value: remaining });
+          break;
+        }
+
+        if (blockStart !== -1 && (inlineStart === -1 || blockStart <= inlineStart)) {
+          if (blockStart > 0) parts.push({ type: "text", value: remaining.slice(0, blockStart) });
+          const blockEnd = remaining.indexOf("$$", blockStart + 2);
+          if (blockEnd === -1) { parts.push({ type: "text", value: remaining }); break; }
+          parts.push({ type: "block", value: remaining.slice(blockStart + 2, blockEnd) });
+          remaining = remaining.slice(blockEnd + 2);
+        } else {
+          if (inlineStart > 0) parts.push({ type: "text", value: remaining.slice(0, inlineStart) });
+          const inlineEnd = remaining.indexOf("$", inlineStart + 1);
+          if (inlineEnd === -1) { parts.push({ type: "text", value: remaining }); break; }
+          parts.push({ type: "inline", value: remaining.slice(inlineStart + 1, inlineEnd) });
+          remaining = remaining.slice(inlineEnd + 1);
+        }
+      }
+
+      return parts;
+    }
+
+    function renderBlock(tex) {
+      try { return katex.renderToString(tex, { displayMode: true, throwOnError: false }); }
+      catch { return `<span style="color:red">${tex}</span>`; }
+    }
+
+    function renderInline(tex) {
+      try { return katex.renderToString(tex, { displayMode: false, throwOnError: false }); }
+      catch { return `<span style="color:red">${tex}</span>`; }
+    }
+
+    function update() {
+      const parts = renderLatex(editor.value);
+      let html = "";
+      for (const part of parts) {
+        if (part.type === "text") {
+          html += part.value.replace(/\n/g, "<br>").replace(/^# (.+)$/gm, "<h1>$1</h1>");
+        } else if (part.type === "block") {
+          html += `<div style="text-align:center;margin:16px 0">${renderBlock(part.value)}</div>`;
+        } else {
+          html += renderInline(part.value);
+        }
+      }
+      preview.innerHTML = html;
+    }
+
+    editor.addEventListener("input", update);
+    update();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## 概述

为花笺添加 LaTeX 数学公式编辑与实时预览功能，基于 KaTeX 渲染引擎实现。

## 变更内容

### 新增依赖
- `katex` — LaTeX 数学公式渲染引擎
- `remark-math` — Markdown 数学语法解析插件（识别 `$...$` 和 `$$...$$`）
- `rehype-katex` — 将解析后的数学节点交由 KaTeX 渲染

### 功能改动

**MarkdownPreview（`src/features/markdown/MarkdownPreview.tsx`）**
- 集成 `remark-math` + `rehype-katex` 插件链
- 预览区现支持行内公式（`$E=mc^2$`）和块级公式（`$$...$$`）

**编辑器工具栏（`src/components/MainWindow.tsx`）**
- 新增 `∑` 按钮：插入行内公式模板 `$E=mc^2$`
- 新增 `∫` 按钮：插入块级公式模板
- 状态栏标识更新为 `Markdown + LaTeX`

**样式适配（`src/App.css`）**
- 新增 KaTeX 渲染样式，匹配花笺的竹绿色主题
- 亮色/暗色主题自动适配

### 新增文件
- `src/features/markdown/LatexPreview.tsx` — 独立 LaTeX 预览组件（可用于纯 LaTeX 渲染场景）
- `test-latex.html` — 浏览器端 LaTeX 渲染测试页

## 使用方式

在编辑器中直接书写 LaTeX 语法即可：

```markdown
行内公式：$E=mc^2$

块级公式：
$$
\int_{-\infty}^{\infty} e^{-x^2} dx = \sqrt{\pi}
$$
```

切换到「分栏」或「预览」模式即可看到渲染效果。也可以点击工具栏的 `∑` 或 `∫` 按钮快速插入公式模板。

## 实现方式

1. 安装 `katex`、`remark-math`、`rehype-katex` 三个依赖
2. 在 `MarkdownPreview` 组件中将 `remark-math` 加入 remark 插件链、`rehype-katex` 加入 rehype 插件链，使 `react-markdown` 在解析 Markdown 时识别 `$...$` 和 `$$...$$` 语法并交由 KaTeX 渲染
3. 在编辑器工具栏的 `FormatAction` 类型中新增 `inlineMath` 和 `blockMath` 两个操作，对应的 `applyFormat` 函数会向 textarea 中插入公式模板
4. 在 `App.css` 中为 KaTeX 输出元素添加与花笺主题匹配的样式，确保亮色/暗色模式下均有良好显示效果

## 测试说明

> **由于开发环境中未安装 Rust 工具链，无法运行 `npm run tauri dev` 启动完整的 Tauri 桌面应用进行端到端测试。** 本次验证通过以下方式完成：
>
> 1. **TypeScript 类型检查** — `npx tsc --noEmit` 通过，无类型错误
> 2. **Vite 构建** — `npx vite build` 成功，KaTeX 字体资源正确打包
> 3. **单元测试** — 全部 41 个现有测试通过，未引入回归
> 4. **浏览器渲染测试** — 通过 `test-latex.html` 在浏览器中验证 KaTeX 的行内公式、块级公式、矩阵、求和等场景均能正确渲染
>
> **建议在合并前使用 `npm run tauri dev` 进行完整的桌面应用测试。**
