### PR TITLE
[Draft] feat: 便签窗口边缘吸附(only windows)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1019,6 +1019,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-single-instance",
  "uuid",
+ "windows",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,3 +28,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.61", features = ["Win32_UI_WindowsAndMessaging", "Win32_Foundation"] }

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -292,6 +292,194 @@ pub fn runtime_config_changes(previous: &AppConfig, next: &AppConfig) -> Runtime
     }
 }
 
+pub fn snap_window_to_edge(window: &tauri::WebviewWindow) -> Result<(), AppError> {
+    const SNAP_THRESHOLD: i32 = 20;
+
+    let Ok(position) = window.outer_position() else {
+        return Ok(());
+    };
+    let Ok(size) = window.outer_size() else {
+        return Ok(());
+    };
+    let Ok(Some(monitor)) = window.current_monitor() else {
+        return Ok(());
+    };
+
+    let mut candidates: Vec<SnapCandidate> = Vec::new();
+
+    // Screen edges
+    let monitor_pos = monitor.position();
+    let monitor_size = monitor.size();
+
+    candidates.push(SnapCandidate {
+        dist: position.x - monitor_pos.x,
+        snap_x: Some(monitor_pos.x),
+        snap_y: None,
+    });
+    candidates.push(SnapCandidate {
+        dist: (monitor_pos.x + monitor_size.width as i32) - (position.x + size.width as i32),
+        snap_x: Some(monitor_pos.x + monitor_size.width as i32 - size.width as i32),
+        snap_y: None,
+    });
+    candidates.push(SnapCandidate {
+        dist: position.y - monitor_pos.y,
+        snap_x: None,
+        snap_y: Some(monitor_pos.y),
+    });
+    candidates.push(SnapCandidate {
+        dist: (monitor_pos.y + monitor_size.height as i32) - (position.y + size.height as i32),
+        snap_x: None,
+        snap_y: Some(monitor_pos.y + monitor_size.height as i32 - size.height as i32),
+    });
+
+    // Other window edges (Windows only)
+    #[cfg(target_os = "windows")]
+    {
+        let our_pid = std::process::id();
+        let win_left = position.x;
+        let win_top = position.y;
+        let win_right = position.x + size.width as i32;
+        let win_bottom = position.y + size.height as i32;
+
+        unsafe {
+            collect_window_edge_candidates(
+                our_pid,
+                win_left,
+                win_top,
+                win_right,
+                win_bottom,
+                &mut candidates,
+            );
+        }
+    }
+
+    let closest = candidates
+        .iter()
+        .filter(|c| c.dist.abs() <= SNAP_THRESHOLD)
+        .min_by_key(|c| c.dist.abs());
+
+    let Some(best) = closest else {
+        return Ok(());
+    };
+
+    let new_x = best.snap_x.unwrap_or(position.x);
+    let new_y = best.snap_y.unwrap_or(position.y);
+
+    let _ = window.set_position(PhysicalPosition::new(new_x, new_y));
+    Ok(())
+}
+
+struct SnapCandidate {
+    dist: i32,
+    snap_x: Option<i32>,
+    snap_y: Option<i32>,
+}
+
+#[cfg(target_os = "windows")]
+unsafe fn collect_window_edge_candidates(
+    our_pid: u32,
+    win_left: i32,
+    win_top: i32,
+    win_right: i32,
+    win_bottom: i32,
+    candidates: &mut Vec<SnapCandidate>,
+) {
+    use windows::Win32::Foundation::LPARAM;
+    use windows::Win32::UI::WindowsAndMessaging::EnumWindows;
+
+    let data = EnumData {
+        our_pid,
+        win_left,
+        win_top,
+        win_right,
+        win_bottom,
+        candidates,
+    };
+
+    let _ = EnumWindows(
+        Some(enum_window_proc),
+        LPARAM(&data as *const EnumData as isize),
+    );
+}
+
+#[cfg(target_os = "windows")]
+struct EnumData<'a> {
+    our_pid: u32,
+    win_left: i32,
+    win_top: i32,
+    win_right: i32,
+    win_bottom: i32,
+    candidates: &'a mut Vec<SnapCandidate>,
+}
+
+#[cfg(target_os = "windows")]
+unsafe extern "system" fn enum_window_proc(
+    hwnd: windows::Win32::Foundation::HWND,
+    lparam: windows::Win32::Foundation::LPARAM,
+) -> windows::core::BOOL {
+    use windows::Win32::Foundation::{RECT, TRUE};
+    use windows::Win32::UI::WindowsAndMessaging::*;
+
+    let data = &mut *(lparam.0 as *mut EnumData);
+
+    if !IsWindowVisible(hwnd).as_bool() {
+        return TRUE;
+    }
+
+    let style = GetWindowLongW(hwnd, GWL_STYLE);
+    let ws_minimize_val: i32 = 0x20000000;
+    if (style & ws_minimize_val) != 0 {
+        return TRUE;
+    }
+
+    let mut pid: u32 = 0;
+    GetWindowThreadProcessId(hwnd, Some(&mut pid));
+    if pid == data.our_pid {
+        return TRUE;
+    }
+
+    let mut rect = RECT::default();
+    if GetWindowRect(hwnd, &mut rect).is_err() {
+        return TRUE;
+    }
+
+    let w = rect.right - rect.left;
+    let h = rect.bottom - rect.top;
+    if w <= 100 || h <= 100 {
+        return TRUE;
+    }
+
+    let dist_to_left = rect.left - data.win_right;
+    data.candidates.push(SnapCandidate {
+        dist: dist_to_left,
+        snap_x: Some(rect.left - (data.win_right - data.win_left)),
+        snap_y: None,
+    });
+
+    let dist_to_right = data.win_left - rect.right;
+    data.candidates.push(SnapCandidate {
+        dist: dist_to_right,
+        snap_x: Some(rect.right),
+        snap_y: None,
+    });
+
+    let dist_to_top = rect.top - data.win_bottom;
+    data.candidates.push(SnapCandidate {
+        dist: dist_to_top,
+        snap_x: None,
+        snap_y: Some(rect.top - (data.win_bottom - data.win_top)),
+    });
+
+    let dist_to_bottom = data.win_top - rect.bottom;
+    data.candidates.push(SnapCandidate {
+        dist: dist_to_bottom,
+        snap_x: None,
+        snap_y: Some(rect.bottom),
+    });
+
+    TRUE
+}
+
 pub fn apply_runtime_config(
     app: &AppHandle,
     previous: &AppConfig,

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1392,6 +1392,7 @@ mod tests {
             font_size: 14,
             surface_font_size: 14,
             external_file_auto_save: true,
+            snap_enabled: false,
         };
         let next = AppConfig {
             notes_dir: "D:\\other-notes".into(),
@@ -1407,6 +1408,7 @@ mod tests {
             font_size: 16,
             surface_font_size: 16,
             external_file_auto_save: true,
+            snap_enabled: true,
         };
 
         assert_eq!(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,7 +3,7 @@ pub mod services;
 
 use services::notes::{default_store, AppConfig, AppError, Note, NoteMetadata, SaveNoteRequest};
 use std::path::PathBuf;
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, Manager};
 
 #[tauri::command]
 fn app_name() -> &'static str {
@@ -181,6 +181,17 @@ async fn open_note_in_editor(app: AppHandle, note_id: String) -> Result<(), AppE
     Ok(())
 }
 
+#[tauri::command]
+fn snap_window_to_edge(app: AppHandle, label: String) -> Result<(), AppError> {
+    let window = app
+        .get_webview_window(&label)
+        .ok_or_else(|| AppError {
+            code: "notFound".into(),
+            message: format!("Window {label} was not found"),
+        })?;
+    desktop::snap_window_to_edge(&window)
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -219,7 +230,8 @@ pub fn run() {
             open_notepad_window,
             recycle_notepad_window,
             open_tile_window,
-            open_note_in_editor
+            open_note_in_editor,
+            snap_window_to_edge
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/services/notes.rs
+++ b/src-tauri/src/services/notes.rs
@@ -30,6 +30,8 @@ pub struct AppConfig {
     pub surface_font_size: u32,
     #[serde(default = "default_external_file_auto_save")]
     pub external_file_auto_save: bool,
+    #[serde(default = "default_snap_enabled")]
+    pub snap_enabled: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -491,6 +493,7 @@ impl NoteStore {
             font_size: default_font_size(),
             surface_font_size: default_surface_font_size(),
             external_file_auto_save: default_external_file_auto_save(),
+            snap_enabled: default_snap_enabled(),
         }
     }
 
@@ -767,6 +770,10 @@ fn default_external_file_auto_save() -> bool {
     true
 }
 
+fn default_snap_enabled() -> bool {
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -898,6 +905,7 @@ mod tests {
             font_size: 16,
             surface_font_size: 16,
             external_file_auto_save: true,
+            snap_enabled: false,
         };
 
         store.save_config(saved.clone()).expect("save config");

--- a/src/components/MainWindow.test.tsx
+++ b/src/components/MainWindow.test.tsx
@@ -21,6 +21,7 @@ describe("MainWindow settings", () => {
           fontSize: 14,
           surfaceFontSize: 14,
           externalFileAutoSave: true,
+          snapEnabled: false,
         }}
       />,
     );

--- a/src/components/NotePad.tsx
+++ b/src/components/NotePad.tsx
@@ -129,6 +129,7 @@ export function NotePad({
   );
   const [tileColorMode, setTileColorMode] = useState<TileColorMode>("system");
   const [surfaceFontSize, setSurfaceFontSize] = useState(14);
+  const [snapEnabled, setSnapEnabled] = useState(false);
   const [tileColor, setTileColor] = useState(() =>
     resolveTileColor("system", normalizeTileColor(initialTileColor)),
   );
@@ -163,6 +164,7 @@ export function NotePad({
         if (!cancelled) {
           setNoteSurfaceAutoSave(loadedConfig.noteSurfaceAutoSave);
           setSurfaceFontSize(loadedConfig.surfaceFontSize ?? 14);
+          setSnapEnabled(loadedConfig.snapEnabled);
           setTileColorRaw(normalizeTileColor(loadedConfig.tileColor));
           setTileColorMode(loadedConfig.tileColorMode ?? "system");
           setTileColor(
@@ -219,6 +221,7 @@ export function NotePad({
       tileColor?: string;
       tileColorMode?: TileColorMode;
       surfaceFontSize?: number;
+      snapEnabled?: boolean;
     }>("config-changed", (event) => {
       const mode = event.payload.tileColorMode ?? tileColorMode;
       const raw = event.payload.tileColor ?? tileColorRaw;
@@ -226,6 +229,7 @@ export function NotePad({
       setTileColorRaw(normalizeTileColor(raw));
       setTileColor(resolveTileColor(mode, raw));
       if (event.payload.surfaceFontSize != null) setSurfaceFontSize(event.payload.surfaceFontSize);
+      if (event.payload.snapEnabled != null) setSnapEnabled(event.payload.snapEnabled);
     });
     return () => {
       void unlisten.then((fn) => fn());
@@ -408,6 +412,8 @@ export function NotePad({
   }, [content]);
 
   useEffect(() => {
+    if (!snapEnabled) return;
+
     let snapDebounce = 0;
 
     const handleSnap = () => {
@@ -426,7 +432,7 @@ export function NotePad({
       window.clearTimeout(snapDebounce);
       void unlisten?.then((fn) => fn?.());
     };
-  }, []);
+  }, [snapEnabled]);
 
   useEffect(() => {
     function handleSurfaceActionRequest(event: Event) {

--- a/src/components/NotePad.tsx
+++ b/src/components/NotePad.tsx
@@ -26,6 +26,7 @@ import {
   startCurrentWindowResize,
 } from "../features/windows/controls";
 import { openNoteInEditor } from "../features/windows/api";
+import { snapWindowToEdge } from "../features/windows/snap";
 import type { ResizeDirection } from "../features/windows/controls";
 import { getConfig } from "../features/settings/api";
 import {
@@ -405,6 +406,27 @@ export function NotePad({
       setErrorMessage(getErrorMessage(error));
     }
   }, [content]);
+
+  useEffect(() => {
+    let snapDebounce = 0;
+
+    const handleSnap = () => {
+      const label = getCurrentWindow().label;
+      void snapWindowToEdge(label).catch(() => undefined);
+    };
+
+    const unlisten = getCurrentWindow()
+      .onMoved(() => {
+        window.clearTimeout(snapDebounce);
+        snapDebounce = window.setTimeout(handleSnap, 250);
+      })
+      .catch(() => undefined);
+
+    return () => {
+      window.clearTimeout(snapDebounce);
+      void unlisten?.then((fn) => fn?.());
+    };
+  }, []);
 
   useEffect(() => {
     function handleSurfaceActionRequest(event: Event) {

--- a/src/components/SettingsPanel.test.tsx
+++ b/src/components/SettingsPanel.test.tsx
@@ -16,6 +16,7 @@ const config = {
   fontSize: 14,
   surfaceFontSize: 14,
   externalFileAutoSave: true,
+  snapEnabled: false,
 };
 
 describe("SettingsPanel", () => {

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -153,6 +153,11 @@ export function SettingsPanel({
               setConfigValue("externalFileAutoSave", checked)
             }
           />
+          <ToggleRow
+            label="边缘吸附"
+            checked={config.snapEnabled}
+            onChange={(checked) => setConfigValue("snapEnabled", checked)}
+          />
         </section>
 
         <section className="space-y-2">

--- a/src/features/settings/api.test.ts
+++ b/src/features/settings/api.test.ts
@@ -41,6 +41,7 @@ describe("settings api", () => {
       fontSize: 14,
       surfaceFontSize: 14,
       externalFileAutoSave: true,
+      snapEnabled: false,
     };
     mockedInvoke.mockResolvedValue(config);
 
@@ -64,6 +65,7 @@ describe("settings api", () => {
       fontSize: 16,
       surfaceFontSize: 16,
       externalFileAutoSave: true,
+      snapEnabled: false,
     };
     mockedInvoke.mockResolvedValue(config);
 

--- a/src/features/settings/types.ts
+++ b/src/features/settings/types.ts
@@ -18,4 +18,5 @@ export interface AppConfig {
   fontSize: number;
   surfaceFontSize: number;
   externalFileAutoSave: boolean;
+  snapEnabled: boolean;
 }

--- a/src/features/windows/snap.test.ts
+++ b/src/features/windows/snap.test.ts
@@ -1,0 +1,25 @@
+import { invoke } from "@tauri-apps/api/core";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { snapWindowToEdge } from "./snap";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+const mockedInvoke = vi.mocked(invoke);
+
+describe("window snap", () => {
+  beforeEach(() => {
+    mockedInvoke.mockReset();
+  });
+
+  test("invokes snap with window label", async () => {
+    mockedInvoke.mockResolvedValue(undefined);
+
+    await snapWindowToEdge("notepad-test-id");
+
+    expect(invoke).toHaveBeenCalledWith("snap_window_to_edge", {
+      label: "notepad-test-id",
+    });
+  });
+});

--- a/src/features/windows/snap.ts
+++ b/src/features/windows/snap.ts
@@ -1,0 +1,5 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export function snapWindowToEdge(label: string): Promise<void> {
+  return invoke("snap_window_to_edge", { label });
+}


### PR DESCRIPTION
**拖拽便签窗口 如果窗口边缘距离屏幕边界或者其他窗口边界不足20px会自动吸附并对齐**

- 后端: `desktop.rs`添加`snap_window_to_edge`来收集屏幕四边的候选。windows系统通过`EnumWindows`枚举可见窗口 排除最小化/自身进程/过小的窗口后作为额外候选 取距离最小的边吸附
- 前端: 修改了`NotePad.tsx`监听窗口移动事件 为了防止反复调用设置了250ms防抖后吸附