### PR TITLE
fix: 修复在linux代理环境下，由于系统代理导致的WebKitGTK 502白屏错误

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -181,8 +181,26 @@ async fn open_note_in_editor(app: AppHandle, note_id: String) -> Result<(), AppE
     Ok(())
 }
 
+// 屏蔽代理导致的应用白屏
+#[cfg(target_os = "linux")]
+fn fix_linux_proxy_issue() {
+    let existing = std::env::var("no_proxy").unwrap_or_default();
+    let append = if existing.is_empty() {
+        "localhost,127.0.0.1,::1".to_string()
+    } else if existing.contains("localhost") {
+        existing
+    } else {
+        format!("{},localhost,127.0.0.1,::1", existing)
+    };
+    std::env::set_var("no_proxy", append);
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // 框架初始化前修复代理环境问题
+    #[cfg(target_os = "linux")]
+    fix_linux_proxy_issue();
+
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())


### PR DESCRIPTION
Linux dev：Tauri webview 通过 libsoup 遵循 http_proxy，代理拦截 localhost:1420 导致白屏；lib.rs 环境初始化时追加 localhost 到 no_proxy（仅 Linux 环境下）
让所有流量走代理的时候会触发白屏，一个小补丁