### PR TITLE
feat: 显示/隐藏窗口

### DIFF
--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -297,6 +297,15 @@ pub fn runtime_config_changes(previous: &AppConfig, next: &AppConfig) -> Runtime
     }
 }
 
+fn clear_hidden_window_state(app: &AppHandle) {
+    if let Some(state) = app.try_state::<RuntimeState>() {
+        state.windows_hidden.store(false, Ordering::SeqCst);
+        if let Ok(mut guard) = state.hidden_window_labels.lock() {
+            guard.clear();
+        }
+    }
+}
+
 fn toggle_app_visibility(app: &AppHandle) {
     let Some(state) = app.try_state::<RuntimeState>() else {
         return;
@@ -340,12 +349,8 @@ pub fn apply_runtime_config(
 ) -> Result<(), Box<dyn Error>> {
     let changes = runtime_config_changes(previous, next);
 
-    if changes.global_shortcut_changed {
-        apply_global_shortcut_config(app, &next.global_shortcut)?;
-    }
-
-    if changes.toggle_visibility_shortcut_changed {
-        apply_visibility_toggle_shortcut_config(app, &next.toggle_visibility_shortcut)?;
+    if changes.global_shortcut_changed || changes.toggle_visibility_shortcut_changed {
+        apply_global_shortcut_config(app, next)?;
     }
 
     if changes.autostart_changed {
@@ -535,6 +540,8 @@ fn handle_tray_menu_event(app: &AppHandle, id: &str) -> Result<(), Box<dyn Error
 }
 
 pub fn show_main_window(app: &AppHandle) -> Result<(), AppError> {
+    clear_hidden_window_state(app);
+
     if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
         window.unminimize()?;
         window.show()?;
@@ -571,6 +578,7 @@ fn open_notepad_window_now(
 ) -> Result<String, AppError> {
     if note_id.is_none() {
         if let Some(reused) = activate_pooled_notepad(app, bounds) {
+            clear_hidden_window_state(app);
             return Ok(reused);
         }
     }
@@ -811,6 +819,8 @@ fn open_or_focus_window(
     label: &str,
     opts: WindowOpenOptions,
 ) -> Result<String, AppError> {
+    clear_hidden_window_state(app);
+
     let visual_options = dynamic_window_visual_options(label);
 
     if let Some(window) = app.get_webview_window(label) {
@@ -1028,59 +1038,49 @@ fn register_global_shortcut(
 }
 
 #[cfg(desktop)]
-fn apply_global_shortcut_config(
-    app: &AppHandle,
-    shortcut_config: &str,
-) -> Result<(), Box<dyn Error>> {
-    let Some(shortcut) = shortcut_from_config(shortcut_config).and_then(to_tauri_shortcut) else {
+fn apply_global_shortcut_config(app: &AppHandle, config: &AppConfig) -> Result<(), Box<dyn Error>> {
+    let Some(shortcut) = shortcut_from_config(&config.global_shortcut).and_then(to_tauri_shortcut)
+    else {
         return Err(Box::new(AppError {
             code: "unsupportedShortcut".into(),
-            message: format!("unsupported global shortcut config: {shortcut_config}"),
+            message: format!(
+                "unsupported global shortcut config: {}",
+                config.global_shortcut
+            ),
         }));
     };
 
+    let visibility_shortcut = if config.toggle_visibility_shortcut.is_empty() {
+        None
+    } else {
+        Some(
+            shortcut_from_config(&config.toggle_visibility_shortcut)
+                .and_then(to_tauri_shortcut)
+                .ok_or_else(|| {
+                    Box::new(AppError {
+                        code: "unsupportedShortcut".into(),
+                        message: format!(
+                            "unsupported visibility shortcut config: {}",
+                            config.toggle_visibility_shortcut
+                        ),
+                    }) as Box<dyn Error>
+                })?,
+        )
+    };
+
+    app.global_shortcut().unregister_all()?;
     app.global_shortcut().register(shortcut)?;
+    if let Some(visibility_shortcut) = visibility_shortcut {
+        app.global_shortcut().register(visibility_shortcut)?;
+    }
     Ok(())
 }
 
 #[cfg(not(desktop))]
 fn apply_global_shortcut_config(
     _app: &AppHandle,
-    _shortcut_config: &str,
+    _config: &AppConfig,
 ) -> Result<(), Box<dyn Error>> {
-    Ok(())
-}
-
-#[cfg(desktop)]
-fn apply_visibility_toggle_shortcut_config(
-    app: &AppHandle,
-    shortcut_config: &str,
-) -> Result<(), Box<dyn Error>> {
-    let config = load_config()?;
-    app.global_shortcut().unregister_all()?;
-
-    let Some(shortcut) =
-        shortcut_from_config(&config.global_shortcut).and_then(to_tauri_shortcut)
-    else {
-        return Err(Box::new(AppError {
-            code: "unsupportedShortcut".into(),
-            message: format!("unsupported global shortcut config: {}", config.global_shortcut),
-        }));
-    };
-    app.global_shortcut().register(shortcut)?;
-
-    if !shortcut_config.is_empty() {
-        let Some(vis_shortcut) =
-            shortcut_from_config(shortcut_config).and_then(to_tauri_shortcut)
-        else {
-            return Err(Box::new(AppError {
-                code: "unsupportedShortcut".into(),
-                message: format!("unsupported visibility shortcut config: {shortcut_config}"),
-            }));
-        };
-        app.global_shortcut().register(vis_shortcut)?;
-    }
-
     Ok(())
 }
 

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -125,7 +125,23 @@ struct WindowOpenOptions {
 struct RuntimeState {
     is_exiting: AtomicBool,
     windows_hidden: AtomicBool,
-    hidden_window_labels: std::sync::Mutex<Vec<String>>,
+    hidden_window_labels: Mutex<Vec<String>>,
+    #[cfg(desktop)]
+    shortcut_bindings: Mutex<ShortcutBindings>,
+}
+
+#[cfg(desktop)]
+#[derive(Clone, Default)]
+struct ShortcutBindings {
+    open_notepad: Option<Shortcut>,
+    toggle_visibility: Option<Shortcut>,
+}
+
+#[cfg(desktop)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ShortcutAction {
+    OpenNotepad,
+    ToggleVisibility,
 }
 
 #[derive(Default)]
@@ -163,6 +179,72 @@ impl RuntimeState {
 
     fn is_exiting(&self) -> bool {
         self.is_exiting.load(Ordering::SeqCst)
+    }
+
+    fn clear_hidden_windows(&self) {
+        if !self.windows_hidden.swap(false, Ordering::SeqCst) {
+            return;
+        }
+
+        if let Ok(mut guard) = self.hidden_window_labels.lock() {
+            guard.clear();
+        }
+    }
+
+    fn take_hidden_window_labels(&self) -> Option<Vec<String>> {
+        if !self.windows_hidden.swap(false, Ordering::SeqCst) {
+            return None;
+        }
+
+        self.hidden_window_labels
+            .lock()
+            .map(|mut guard| guard.drain(..).collect())
+            .ok()
+    }
+
+    fn hide_windows(&self, labels: Vec<String>) {
+        if labels.is_empty() {
+            self.clear_hidden_windows();
+            return;
+        }
+
+        if let Ok(mut guard) = self.hidden_window_labels.lock() {
+            *guard = labels;
+            self.windows_hidden.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[cfg(desktop)]
+    fn set_shortcut_bindings(&self, bindings: ShortcutBindings) {
+        if let Ok(mut guard) = self.shortcut_bindings.lock() {
+            *guard = bindings;
+        }
+    }
+
+    #[cfg(desktop)]
+    fn shortcut_action(&self, shortcut: &Shortcut) -> ShortcutAction {
+        self.shortcut_bindings
+            .lock()
+            .ok()
+            .and_then(|bindings| bindings.action_for(shortcut))
+            .unwrap_or(ShortcutAction::OpenNotepad)
+    }
+}
+
+#[cfg(desktop)]
+impl ShortcutBindings {
+    fn action_for(&self, shortcut: &Shortcut) -> Option<ShortcutAction> {
+        if self
+            .toggle_visibility
+            .as_ref()
+            .is_some_and(|s| s == shortcut)
+        {
+            Some(ShortcutAction::ToggleVisibility)
+        } else if self.open_notepad.as_ref().is_some_and(|s| s == shortcut) {
+            Some(ShortcutAction::OpenNotepad)
+        } else {
+            None
+        }
     }
 }
 
@@ -299,10 +381,7 @@ pub fn runtime_config_changes(previous: &AppConfig, next: &AppConfig) -> Runtime
 
 fn clear_hidden_window_state(app: &AppHandle) {
     if let Some(state) = app.try_state::<RuntimeState>() {
-        state.windows_hidden.store(false, Ordering::SeqCst);
-        if let Ok(mut guard) = state.hidden_window_labels.lock() {
-            guard.clear();
-        }
+        state.clear_hidden_windows();
     }
 }
 
@@ -311,35 +390,34 @@ fn toggle_app_visibility(app: &AppHandle) {
         return;
     };
 
-    let was_hidden = state.windows_hidden.load(Ordering::SeqCst);
-
-    if was_hidden {
-        let labels: Vec<String> = state
-            .hidden_window_labels
-            .lock()
-            .map(|mut guard| guard.drain(..).collect())
-            .unwrap_or_default();
-
+    if let Some(labels) = state.take_hidden_window_labels() {
+        let mut focus_target = None;
         for label in &labels {
             if let Some(window) = app.get_webview_window(label) {
+                let _ = window.unminimize();
                 let _ = window.show();
+                if focus_target.is_none() || label == MAIN_WINDOW_LABEL {
+                    focus_target = Some(label.clone());
+                }
+            }
+        }
+
+        if let Some(label) = focus_target {
+            if let Some(window) = app.get_webview_window(&label) {
                 let _ = window.set_focus();
             }
         }
-        state.windows_hidden.store(false, Ordering::SeqCst);
-    } else {
-        let mut labels = Vec::new();
-        for (label, window) in app.webview_windows() {
-            if window.is_visible().unwrap_or(false) {
-                labels.push(label.clone());
-                let _ = window.hide();
-            }
-        }
-        if let Ok(mut guard) = state.hidden_window_labels.lock() {
-            *guard = labels;
-        }
-        state.windows_hidden.store(true, Ordering::SeqCst);
+        return;
     }
+
+    let mut labels = Vec::new();
+    for (label, window) in app.webview_windows() {
+        if window.is_visible().unwrap_or(false) {
+            labels.push(label.clone());
+            let _ = window.hide();
+        }
+    }
+    state.hide_windows(labels);
 }
 
 pub fn apply_runtime_config(
@@ -945,31 +1023,30 @@ fn setup_global_shortcut_plugin(app: &AppHandle) -> tauri::Result<()> {
                     return;
                 }
 
-                let is_visibility_toggle = load_config()
-                    .ok()
-                    .and_then(|c| {
-                        if c.toggle_visibility_shortcut.is_empty() {
-                            return None;
-                        }
-                        shortcut_from_config(&c.toggle_visibility_shortcut)
-                            .and_then(to_tauri_shortcut)
-                    })
-                    .is_some_and(|vis| vis == *shortcut);
+                let action = app
+                    .try_state::<RuntimeState>()
+                    .map(|state| state.shortcut_action(shortcut))
+                    .unwrap_or(ShortcutAction::OpenNotepad);
 
                 let app_for_closure = app.clone();
-                if is_visibility_toggle {
-                    if let Err(error) = app.run_on_main_thread(move || {
-                        toggle_app_visibility(&app_for_closure);
-                    }) {
-                        eprintln!("failed to dispatch visibility toggle action: {error}");
-                    }
-                } else {
-                    if let Err(error) = app.run_on_main_thread(move || {
-                        if let Err(error) = open_notepad_window_now(&app_for_closure, None, None) {
-                            eprintln!("failed to open notepad from global shortcut: {error}");
+                match action {
+                    ShortcutAction::ToggleVisibility => {
+                        if let Err(error) = app.run_on_main_thread(move || {
+                            toggle_app_visibility(&app_for_closure);
+                        }) {
+                            eprintln!("failed to dispatch visibility toggle action: {error}");
                         }
-                    }) {
-                        eprintln!("failed to dispatch global shortcut action: {error}");
+                    }
+                    ShortcutAction::OpenNotepad => {
+                        if let Err(error) = app.run_on_main_thread(move || {
+                            if let Err(error) =
+                                open_notepad_window_now(&app_for_closure, None, None)
+                            {
+                                eprintln!("failed to open notepad from global shortcut: {error}");
+                            }
+                        }) {
+                            eprintln!("failed to dispatch global shortcut action: {error}");
+                        }
                     }
                 }
             })
@@ -988,92 +1065,85 @@ fn register_configured_global_shortcut(app: &AppHandle) {
         return;
     };
 
-    if let Err(error) = register_global_shortcut(app, &config.global_shortcut) {
-        let msg = format!(
-            "failed to register global shortcut {}: {error}",
-            config.global_shortcut
-        );
+    if let Err(error) = install_global_shortcut_bindings(app, &config, false) {
+        let msg = format!("failed to register global shortcuts: {error}");
         eprintln!("{msg}");
         let _ = app.emit("shortcut-register-failed", &msg);
     }
-
-    register_configured_visibility_toggle_shortcut(app, &config);
 }
 
 #[cfg(not(desktop))]
 fn register_configured_global_shortcut(_app: &AppHandle) {}
 
 #[cfg(desktop)]
-fn register_configured_visibility_toggle_shortcut(app: &AppHandle, config: &AppConfig) {
-    if config.toggle_visibility_shortcut.is_empty() {
-        return;
-    }
-    if let Err(error) = register_global_shortcut(app, &config.toggle_visibility_shortcut) {
-        eprintln!(
-            "failed to register visibility toggle shortcut {}: {error}",
-            config.toggle_visibility_shortcut
-        );
-    }
+fn parse_configured_shortcut(field: &str, value: &str) -> Result<Shortcut, Box<dyn Error>> {
+    shortcut_from_config(value)
+        .and_then(to_tauri_shortcut)
+        .ok_or_else(|| {
+            Box::new(AppError {
+                code: "unsupportedShortcut".into(),
+                message: format!("unsupported {field} shortcut config: {value}"),
+            }) as Box<dyn Error>
+        })
 }
 
 #[cfg(desktop)]
-fn register_global_shortcut(app: &AppHandle, shortcut_config: &str) -> Result<(), Box<dyn Error>> {
-    let Some(shortcut) = shortcut_from_config(shortcut_config).and_then(to_tauri_shortcut) else {
-        return Err(Box::new(AppError {
-            code: "unsupportedShortcut".into(),
-            message: format!("unsupported global shortcut config: {shortcut_config}"),
-        }));
+fn shortcut_bindings_from_config(config: &AppConfig) -> Result<ShortcutBindings, Box<dyn Error>> {
+    let open_notepad = parse_configured_shortcut("global", &config.global_shortcut)?;
+    let toggle_visibility = if config.toggle_visibility_shortcut.is_empty() {
+        None
+    } else {
+        Some(parse_configured_shortcut(
+            "visibility toggle",
+            &config.toggle_visibility_shortcut,
+        )?)
     };
 
-    app.global_shortcut().register(shortcut)?;
-    Ok(())
+    if toggle_visibility
+        .as_ref()
+        .is_some_and(|shortcut| shortcut == &open_notepad)
+    {
+        return Err(Box::new(AppError {
+            code: "duplicateShortcut".into(),
+            message: "visibility toggle shortcut must differ from global shortcut".into(),
+        }));
+    }
+
+    Ok(ShortcutBindings {
+        open_notepad: Some(open_notepad),
+        toggle_visibility,
+    })
 }
 
-#[cfg(not(desktop))]
-fn register_global_shortcut(
-    _app: &AppHandle,
-    _shortcut_config: &str,
+#[cfg(desktop)]
+fn install_global_shortcut_bindings(
+    app: &AppHandle,
+    config: &AppConfig,
+    replace_existing: bool,
 ) -> Result<(), Box<dyn Error>> {
+    let bindings = shortcut_bindings_from_config(config)?;
+
+    if replace_existing {
+        app.global_shortcut().unregister_all()?;
+    }
+
+    if let Some(shortcut) = &bindings.open_notepad {
+        app.global_shortcut().register(shortcut.clone())?;
+    }
+    if let Some(shortcut) = &bindings.toggle_visibility {
+        app.global_shortcut().register(shortcut.clone())?;
+    }
+
+    if let Some(state) = app.try_state::<RuntimeState>() {
+        state.set_shortcut_bindings(bindings);
+    }
+
     Ok(())
 }
 
 #[cfg(desktop)]
 fn apply_global_shortcut_config(app: &AppHandle, config: &AppConfig) -> Result<(), Box<dyn Error>> {
-    let Some(shortcut) = shortcut_from_config(&config.global_shortcut).and_then(to_tauri_shortcut)
-    else {
-        return Err(Box::new(AppError {
-            code: "unsupportedShortcut".into(),
-            message: format!(
-                "unsupported global shortcut config: {}",
-                config.global_shortcut
-            ),
-        }));
-    };
-
-    let visibility_shortcut = if config.toggle_visibility_shortcut.is_empty() {
-        None
-    } else {
-        Some(
-            shortcut_from_config(&config.toggle_visibility_shortcut)
-                .and_then(to_tauri_shortcut)
-                .ok_or_else(|| {
-                    Box::new(AppError {
-                        code: "unsupportedShortcut".into(),
-                        message: format!(
-                            "unsupported visibility shortcut config: {}",
-                            config.toggle_visibility_shortcut
-                        ),
-                    }) as Box<dyn Error>
-                })?,
-        )
-    };
-
-    app.global_shortcut().unregister_all()?;
-    app.global_shortcut().register(shortcut)?;
-    if let Some(visibility_shortcut) = visibility_shortcut {
-        app.global_shortcut().register(visibility_shortcut)?;
-    }
-    Ok(())
+    install_global_shortcut_bindings(app, config, true)
 }
 
 #[cfg(not(desktop))]
@@ -1371,6 +1441,34 @@ mod tests {
         assert_eq!(shortcut_from_config("Space"), None);
         assert_eq!(shortcut_from_config("Shift+K"), None);
         assert_eq!(shortcut_from_config("Ctrl+Unknown"), None);
+    }
+
+    #[cfg(desktop)]
+    #[test]
+    fn rejects_duplicate_shortcut_bindings() {
+        let config = AppConfig {
+            notes_dir: "D:\\notes".into(),
+            global_shortcut: "Ctrl+Space".into(),
+            close_to_tray: true,
+            autostart: false,
+            default_view_mode: "split".into(),
+            note_auto_save: true,
+            note_surface_auto_save: true,
+            tile_color: "#f6f3ec".into(),
+            tile_color_mode: "system".into(),
+            theme: "light".into(),
+            font_size: 14,
+            surface_font_size: 14,
+            external_file_auto_save: true,
+            toggle_visibility_shortcut: "Ctrl+Space".into(),
+        };
+
+        let error = match shortcut_bindings_from_config(&config) {
+            Ok(_) => panic!("expected duplicate shortcut error"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("must differ"));
     }
 
     #[test]

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -69,6 +69,7 @@ pub enum ShortcutKey {
 pub struct RuntimeConfigChanges {
     pub autostart_changed: bool,
     pub global_shortcut_changed: bool,
+    pub toggle_visibility_shortcut_changed: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -123,6 +124,8 @@ struct WindowOpenOptions {
 #[derive(Default)]
 struct RuntimeState {
     is_exiting: AtomicBool,
+    windows_hidden: AtomicBool,
+    hidden_window_labels: std::sync::Mutex<Vec<String>>,
 }
 
 #[derive(Default)]
@@ -289,6 +292,44 @@ pub fn runtime_config_changes(previous: &AppConfig, next: &AppConfig) -> Runtime
     RuntimeConfigChanges {
         autostart_changed: previous.autostart != next.autostart,
         global_shortcut_changed: previous.global_shortcut != next.global_shortcut,
+        toggle_visibility_shortcut_changed: previous.toggle_visibility_shortcut
+            != next.toggle_visibility_shortcut,
+    }
+}
+
+fn toggle_app_visibility(app: &AppHandle) {
+    let Some(state) = app.try_state::<RuntimeState>() else {
+        return;
+    };
+
+    let was_hidden = state.windows_hidden.load(Ordering::SeqCst);
+
+    if was_hidden {
+        let labels: Vec<String> = state
+            .hidden_window_labels
+            .lock()
+            .map(|mut guard| guard.drain(..).collect())
+            .unwrap_or_default();
+
+        for label in &labels {
+            if let Some(window) = app.get_webview_window(label) {
+                let _ = window.show();
+                let _ = window.set_focus();
+            }
+        }
+        state.windows_hidden.store(false, Ordering::SeqCst);
+    } else {
+        let mut labels = Vec::new();
+        for (label, window) in app.webview_windows() {
+            if window.is_visible().unwrap_or(false) {
+                labels.push(label.clone());
+                let _ = window.hide();
+            }
+        }
+        if let Ok(mut guard) = state.hidden_window_labels.lock() {
+            *guard = labels;
+        }
+        state.windows_hidden.store(true, Ordering::SeqCst);
     }
 }
 
@@ -301,6 +342,10 @@ pub fn apply_runtime_config(
 
     if changes.global_shortcut_changed {
         apply_global_shortcut_config(app, &next.global_shortcut)?;
+    }
+
+    if changes.toggle_visibility_shortcut_changed {
+        apply_visibility_toggle_shortcut_config(app, &next.toggle_visibility_shortcut)?;
     }
 
     if changes.autostart_changed {
@@ -885,9 +930,30 @@ fn setup_autostart_plugin(_app: &AppHandle) -> tauri::Result<()> {
 fn setup_global_shortcut_plugin(app: &AppHandle) -> tauri::Result<()> {
     app.plugin(
         tauri_plugin_global_shortcut::Builder::new()
-            .with_handler(|app, _shortcut, event| {
-                if event.state() == ShortcutState::Pressed {
-                    let app_for_closure = app.clone();
+            .with_handler(|app, shortcut, event| {
+                if event.state() != ShortcutState::Pressed {
+                    return;
+                }
+
+                let is_visibility_toggle = load_config()
+                    .ok()
+                    .and_then(|c| {
+                        if c.toggle_visibility_shortcut.is_empty() {
+                            return None;
+                        }
+                        shortcut_from_config(&c.toggle_visibility_shortcut)
+                            .and_then(to_tauri_shortcut)
+                    })
+                    .is_some_and(|vis| vis == *shortcut);
+
+                let app_for_closure = app.clone();
+                if is_visibility_toggle {
+                    if let Err(error) = app.run_on_main_thread(move || {
+                        toggle_app_visibility(&app_for_closure);
+                    }) {
+                        eprintln!("failed to dispatch visibility toggle action: {error}");
+                    }
+                } else {
                     if let Err(error) = app.run_on_main_thread(move || {
                         if let Err(error) = open_notepad_window_now(&app_for_closure, None, None) {
                             eprintln!("failed to open notepad from global shortcut: {error}");
@@ -920,10 +986,25 @@ fn register_configured_global_shortcut(app: &AppHandle) {
         eprintln!("{msg}");
         let _ = app.emit("shortcut-register-failed", &msg);
     }
+
+    register_configured_visibility_toggle_shortcut(app, &config);
 }
 
 #[cfg(not(desktop))]
 fn register_configured_global_shortcut(_app: &AppHandle) {}
+
+#[cfg(desktop)]
+fn register_configured_visibility_toggle_shortcut(app: &AppHandle, config: &AppConfig) {
+    if config.toggle_visibility_shortcut.is_empty() {
+        return;
+    }
+    if let Err(error) = register_global_shortcut(app, &config.toggle_visibility_shortcut) {
+        eprintln!(
+            "failed to register visibility toggle shortcut {}: {error}",
+            config.toggle_visibility_shortcut
+        );
+    }
+}
 
 #[cfg(desktop)]
 fn register_global_shortcut(app: &AppHandle, shortcut_config: &str) -> Result<(), Box<dyn Error>> {
@@ -958,7 +1039,6 @@ fn apply_global_shortcut_config(
         }));
     };
 
-    app.global_shortcut().unregister_all()?;
     app.global_shortcut().register(shortcut)?;
     Ok(())
 }
@@ -968,6 +1048,39 @@ fn apply_global_shortcut_config(
     _app: &AppHandle,
     _shortcut_config: &str,
 ) -> Result<(), Box<dyn Error>> {
+    Ok(())
+}
+
+#[cfg(desktop)]
+fn apply_visibility_toggle_shortcut_config(
+    app: &AppHandle,
+    shortcut_config: &str,
+) -> Result<(), Box<dyn Error>> {
+    let config = load_config()?;
+    app.global_shortcut().unregister_all()?;
+
+    let Some(shortcut) =
+        shortcut_from_config(&config.global_shortcut).and_then(to_tauri_shortcut)
+    else {
+        return Err(Box::new(AppError {
+            code: "unsupportedShortcut".into(),
+            message: format!("unsupported global shortcut config: {}", config.global_shortcut),
+        }));
+    };
+    app.global_shortcut().register(shortcut)?;
+
+    if !shortcut_config.is_empty() {
+        let Some(vis_shortcut) =
+            shortcut_from_config(shortcut_config).and_then(to_tauri_shortcut)
+        else {
+            return Err(Box::new(AppError {
+                code: "unsupportedShortcut".into(),
+                message: format!("unsupported visibility shortcut config: {shortcut_config}"),
+            }));
+        };
+        app.global_shortcut().register(vis_shortcut)?;
+    }
+
     Ok(())
 }
 
@@ -1285,8 +1398,10 @@ mod tests {
             surface_font_size: 14,
             external_file_auto_save: true,
             remember_surface_size: true,
+            tile_ctrl_close: true,
             surface_width: None,
             surface_height: None,
+            toggle_visibility_shortcut: String::new(),
         };
         let next = AppConfig {
             notes_dir: "D:\\other-notes".into(),
@@ -1303,8 +1418,10 @@ mod tests {
             surface_font_size: 16,
             external_file_auto_save: true,
             remember_surface_size: true,
+            tile_ctrl_close: true,
             surface_width: None,
             surface_height: None,
+            toggle_visibility_shortcut: "Ctrl+Shift+H".into(),
         };
 
         assert_eq!(
@@ -1312,6 +1429,7 @@ mod tests {
             RuntimeConfigChanges {
                 autostart_changed: true,
                 global_shortcut_changed: true,
+                toggle_visibility_shortcut_changed: true,
             }
         );
         assert_eq!(
@@ -1319,6 +1437,7 @@ mod tests {
             RuntimeConfigChanges {
                 autostart_changed: false,
                 global_shortcut_changed: false,
+                toggle_visibility_shortcut_changed: false,
             }
         );
     }

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -380,8 +380,20 @@ pub fn runtime_config_changes(previous: &AppConfig, next: &AppConfig) -> Runtime
 }
 
 fn clear_hidden_window_state(app: &AppHandle) {
-    if let Some(state) = app.try_state::<RuntimeState>() {
-        state.clear_hidden_windows();
+    let labels = app
+        .try_state::<RuntimeState>()
+        .and_then(|state| state.take_hidden_window_labels());
+
+    let Some(labels) = labels else {
+        return;
+    };
+
+    for label in &labels {
+        if label.starts_with("notepad-") || label.starts_with("tile-") {
+            if let Some(window) = app.get_webview_window(label) {
+                let _ = window.close();
+            }
+        }
     }
 }
 

--- a/src-tauri/src/services/notes.rs
+++ b/src-tauri/src/services/notes.rs
@@ -38,6 +38,8 @@ pub struct AppConfig {
     pub surface_width: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub surface_height: Option<u32>,
+    #[serde(default = "default_toggle_visibility_shortcut")]
+    pub toggle_visibility_shortcut: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -503,6 +505,7 @@ impl NoteStore {
             tile_ctrl_close: default_tile_ctrl_close(),
             surface_width: None,
             surface_height: None,
+            toggle_visibility_shortcut: default_toggle_visibility_shortcut(),
         }
     }
 
@@ -787,6 +790,10 @@ fn default_tile_ctrl_close() -> bool {
     true
 }
 
+fn default_toggle_visibility_shortcut() -> String {
+    String::new()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -919,8 +926,10 @@ mod tests {
             surface_font_size: 16,
             external_file_auto_save: true,
             remember_surface_size: true,
+            tile_ctrl_close: true,
             surface_width: None,
             surface_height: None,
+            toggle_visibility_shortcut: String::new(),
         };
 
         store.save_config(saved.clone()).expect("save config");

--- a/src/components/MainWindow.test.tsx
+++ b/src/components/MainWindow.test.tsx
@@ -23,6 +23,7 @@ describe("MainWindow settings", () => {
           externalFileAutoSave: true,
           rememberSurfaceSize: true,
           tileCtrlClose: true,
+          toggleVisibilityShortcut: "",
         }}
       />,
     );

--- a/src/components/SettingsPanel.test.tsx
+++ b/src/components/SettingsPanel.test.tsx
@@ -18,6 +18,7 @@ const config = {
   externalFileAutoSave: true,
   rememberSurfaceSize: true,
   tileCtrlClose: true,
+  toggleVisibilityShortcut: "",
 };
 
 describe("SettingsPanel", () => {

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -169,6 +169,15 @@ export function SettingsPanel({
               onChange={(v) => setConfigValue("globalShortcut", v)}
             />
           </div>
+          <div className="space-y-1.5">
+            <label className="block text-[11px] font-body text-ink-faint/70 px-0.5">
+              显示/隐藏窗口快捷键
+            </label>
+            <ShortcutRecorder
+              value={config.toggleVisibilityShortcut}
+              onChange={(v) => setConfigValue("toggleVisibilityShortcut", v)}
+            />
+          </div>
         </section>
 
         <section className="space-y-2">

--- a/src/features/settings/api.test.ts
+++ b/src/features/settings/api.test.ts
@@ -43,6 +43,7 @@ describe("settings api", () => {
       externalFileAutoSave: true,
       rememberSurfaceSize: true,
       tileCtrlClose: true,
+      toggleVisibilityShortcut: "",
     };
     mockedInvoke.mockResolvedValue(config);
 
@@ -68,6 +69,7 @@ describe("settings api", () => {
       externalFileAutoSave: true,
       rememberSurfaceSize: true,
       tileCtrlClose: true,
+      toggleVisibilityShortcut: "",
     };
     mockedInvoke.mockResolvedValue(config);
 

--- a/src/features/settings/types.ts
+++ b/src/features/settings/types.ts
@@ -22,4 +22,5 @@ export interface AppConfig {
   tileCtrlClose: boolean;
   surfaceWidth?: number;
   surfaceHeight?: number;
+  toggleVisibilityShortcut: string;
 }


### PR DESCRIPTION
**新增显示/隐藏窗口的功能+可录制快捷键，按下快捷键可以隐藏所有花笺的窗口，再次按下可以恢复显示**
> 快捷键默认为空，需在设置中录制生效

## 更改
- `desktop.rs`新增`toggle_app_visibility` 通过`RuntimeState`追踪隐藏状态
- `AppConfig`新增`toggleVisibilityShortcut`字段`""` 来实现默认关闭功能

通过Tauri的WebviewWindow API直接控制系统窗口的可见性
获取所有窗口
```
  fn toggle_app_visibility(app: &AppHandle) {
      // ...
      for (label, window) in app.webview_windows() {  // 获取所有 webview 窗口
          if window.is_visible().unwrap_or(false) {    // 只隐藏当前可见的
              labels.push(label.clone());
              let _ = window.hide(); // 隐藏窗口
          }
      }
  }
```
通过`window.hide()`，`window.show()`，`window.set_focus()`调用`ShowWindow(hwnd, SW_HIDE)`，`ShowWindow(hwnd, SW_SHOW)`，`SetForegroundWindow(hwnd)`

**状态管理**
```
struct RuntimeState {
      windows_hidden: AtomicBool, // 当前是否隐藏
      hidden_window_labels: Mutex<Vec<String>>, // 记录被隐藏的窗口标签
  }
```