### PR TITLE
修复 JSON 存储并发与安全写入问题

### DIFF
--- a/src-tauri/src/services/json_file.rs
+++ b/src-tauri/src/services/json_file.rs
@@ -1,0 +1,199 @@
+use serde::Serialize;
+use std::{
+    error::Error,
+    fmt, fs, io,
+    io::Write,
+    path::{Path, PathBuf},
+    sync::{Mutex, MutexGuard, OnceLock},
+};
+use uuid::Uuid;
+
+static METADATA_JSON_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+static CONFIG_JSON_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+#[derive(Debug)]
+pub enum JsonFileError {
+    Io(io::Error),
+    Json(serde_json::Error),
+    LockPoisoned(&'static str),
+}
+
+impl fmt::Display for JsonFileError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(error) => write!(f, "{error}"),
+            Self::Json(error) => write!(f, "{error}"),
+            Self::LockPoisoned(name) => write!(f, "{name} lock was poisoned"),
+        }
+    }
+}
+
+impl Error for JsonFileError {}
+
+impl From<io::Error> for JsonFileError {
+    fn from(error: io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+impl From<serde_json::Error> for JsonFileError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
+    }
+}
+
+pub fn metadata_json_guard() -> Result<MutexGuard<'static, ()>, JsonFileError> {
+    METADATA_JSON_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .map_err(|_| JsonFileError::LockPoisoned("metadata json"))
+}
+
+pub fn config_json_guard() -> Result<MutexGuard<'static, ()>, JsonFileError> {
+    CONFIG_JSON_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .map_err(|_| JsonFileError::LockPoisoned("config json"))
+}
+
+pub fn recover_json_after_interrupted_write(path: &Path) -> Result<(), JsonFileError> {
+    if path.exists() {
+        return Ok(());
+    }
+
+    let backup_path = backup_path(path);
+    if backup_path.exists() {
+        fs::copy(&backup_path, path)?;
+    }
+
+    Ok(())
+}
+
+pub fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> Result<(), JsonFileError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let temp_path = unique_temp_path(path);
+    let backup_path = backup_path(path);
+    let json = serde_json::to_string_pretty(value)?;
+
+    write_all_and_sync(&temp_path, json.as_bytes())?;
+
+    if path.exists() {
+        let _ = fs::remove_file(&backup_path);
+        fs::copy(path, &backup_path)?;
+        fs::remove_file(path)?;
+    }
+
+    if let Err(error) = fs::rename(&temp_path, path) {
+        let _ = fs::remove_file(&temp_path);
+        restore_backup_if_missing(path, &backup_path);
+        return Err(JsonFileError::Io(error));
+    }
+
+    let _ = fs::remove_file(&backup_path);
+    Ok(())
+}
+
+fn write_all_and_sync(path: &Path, bytes: &[u8]) -> Result<(), JsonFileError> {
+    let mut file = fs::File::create(path)?;
+    file.write_all(bytes)?;
+    file.sync_all()?;
+    Ok(())
+}
+
+fn restore_backup_if_missing(path: &Path, backup_path: &Path) {
+    if !path.exists() && backup_path.exists() {
+        let _ = fs::copy(backup_path, path);
+    }
+}
+
+fn unique_temp_path(path: &Path) -> PathBuf {
+    let file_name = path
+        .file_name()
+        .map(|name| name.to_string_lossy())
+        .unwrap_or_else(|| "json".into());
+    path.with_file_name(format!("{file_name}.{}.tmp", Uuid::new_v4()))
+}
+
+fn backup_path(path: &Path) -> PathBuf {
+    let file_name = path
+        .file_name()
+        .map(|name| name.to_string_lossy())
+        .unwrap_or_else(|| "json".into());
+    path.with_file_name(format!("{file_name}.bak"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[derive(Debug, Deserialize, PartialEq, Serialize)]
+    struct TestJson {
+        value: String,
+    }
+
+    fn test_root(name: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time")
+            .as_nanos();
+        let root = std::env::temp_dir()
+            .join("floral-notepaper-json-file-tests")
+            .join(format!("{name}-{nonce}"));
+        fs::create_dir_all(&root).expect("create test root");
+        root
+    }
+
+    #[test]
+    fn writes_json_and_removes_backup_after_success() {
+        let root = test_root("write");
+        let path = root.join("metadata.json");
+
+        write_json_atomic(
+            &path,
+            &TestJson {
+                value: "first".into(),
+            },
+        )
+        .expect("write first");
+        write_json_atomic(
+            &path,
+            &TestJson {
+                value: "second".into(),
+            },
+        )
+        .expect("write second");
+
+        let loaded: TestJson =
+            serde_json::from_str(&fs::read_to_string(&path).expect("read written json"))
+                .expect("parse written json");
+        assert_eq!(loaded.value, "second");
+        assert!(!backup_path(&path).exists());
+        assert!(!fs::read_dir(&root)
+            .expect("read test root")
+            .any(|entry| entry
+                .expect("entry")
+                .file_name()
+                .to_string_lossy()
+                .ends_with(".tmp")));
+    }
+
+    #[test]
+    fn restores_backup_when_json_is_missing() {
+        let root = test_root("recover");
+        let path = root.join("metadata.json");
+        let backup = backup_path(&path);
+        fs::write(&backup, r#"{"value":"backup"}"#).expect("write backup");
+
+        recover_json_after_interrupted_write(&path).expect("recover missing json");
+
+        let loaded: TestJson =
+            serde_json::from_str(&fs::read_to_string(&path).expect("read recovered json"))
+                .expect("parse recovered json");
+        assert_eq!(loaded.value, "backup");
+    }
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -1,1 +1,5 @@
+pub mod json_file;
 pub mod notes;
+
+#[cfg(test)]
+mod notes_safety_tests;

--- a/src-tauri/src/services/notes.rs
+++ b/src-tauri/src/services/notes.rs
@@ -1,3 +1,7 @@
+use crate::services::json_file::{
+    config_json_guard, metadata_json_guard, recover_json_after_interrupted_write,
+    write_json_atomic, JsonFileError,
+};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -115,6 +119,12 @@ impl From<tauri::Error> for AppError {
     }
 }
 
+impl From<JsonFileError> for AppError {
+    fn from(error: JsonFileError) -> Self {
+        Self::new("jsonFile", error.to_string())
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct MetadataFile {
@@ -171,11 +181,17 @@ impl NoteStore {
     }
 
     pub fn load_config(&self) -> Result<AppConfig, AppError> {
+        let _guard = config_json_guard()?;
+        self.load_config_unlocked()
+    }
+
+    fn load_config_unlocked(&self) -> Result<AppConfig, AppError> {
         self.ensure_base_dir()?;
         let path = self.config_path();
+        recover_json_after_interrupted_write(&path)?;
         if !path.exists() {
             let config = self.default_config();
-            self.save_config(config.clone())?;
+            self.save_config_unlocked(config.clone())?;
             return Ok(config);
         }
 
@@ -185,12 +201,19 @@ impl NoteStore {
     }
 
     pub fn save_config(&self, config: AppConfig) -> Result<(), AppError> {
+        let _guard = config_json_guard()?;
+        self.save_config_unlocked(config)
+    }
+
+    fn save_config_unlocked(&self, config: AppConfig) -> Result<(), AppError> {
         self.ensure_base_dir()?;
         fs::create_dir_all(&config.notes_dir)?;
-        write_json_atomic(&self.config_path(), &config)
+        write_json_atomic(&self.config_path(), &config)?;
+        Ok(())
     }
 
     pub fn list_notes(&self) -> Result<Vec<NoteMetadata>, AppError> {
+        let _guard = metadata_json_guard()?;
         self.ensure_storage()?;
         let mut metadata = self.load_metadata()?.notes;
         metadata.retain(|note| {
@@ -202,6 +225,7 @@ impl NoteStore {
     }
 
     pub fn read_note(&self, id: &str) -> Result<Note, AppError> {
+        let _guard = metadata_json_guard()?;
         self.ensure_storage()?;
         let metadata = self.find_metadata(id)?;
         let content = fs::read_to_string(
@@ -220,6 +244,7 @@ impl NoteStore {
     }
 
     pub fn create_note(&self, request: SaveNoteRequest) -> Result<Note, AppError> {
+        let _guard = metadata_json_guard()?;
         self.ensure_storage()?;
         let id = Uuid::new_v4().to_string();
         let now = Utc::now();
@@ -259,6 +284,7 @@ impl NoteStore {
     }
 
     pub fn update_note(&self, id: &str, request: SaveNoteRequest) -> Result<Note, AppError> {
+        let _guard = metadata_json_guard()?;
         self.ensure_storage()?;
         let mut metadata_file = self.load_metadata()?;
         let note = metadata_file
@@ -310,6 +336,7 @@ impl NoteStore {
     }
 
     pub fn delete_note(&self, id: &str) -> Result<(), AppError> {
+        let _guard = metadata_json_guard()?;
         self.ensure_storage()?;
         let mut metadata_file = self.load_metadata()?;
         let index = metadata_file
@@ -349,6 +376,7 @@ impl NoteStore {
     }
 
     pub fn list_categories(&self) -> Result<Vec<String>, AppError> {
+        let _guard = metadata_json_guard()?;
         let notes_dir = self.notes_dir()?;
         fs::create_dir_all(&notes_dir)?;
         let mut categories = Vec::new();
@@ -363,6 +391,7 @@ impl NoteStore {
     }
 
     pub fn create_category(&self, name: &str) -> Result<(), AppError> {
+        let _guard = metadata_json_guard()?;
         let name = name.trim();
         if name.is_empty() {
             return Err(AppError::new("invalidCategory", "分类名不能为空"));
@@ -377,6 +406,7 @@ impl NoteStore {
     }
 
     pub fn rename_category(&self, old_name: &str, new_name: &str) -> Result<(), AppError> {
+        let _guard = metadata_json_guard()?;
         let new_name = new_name.trim();
         if new_name.is_empty() {
             return Err(AppError::new("invalidCategory", "分类名不能为空"));
@@ -413,6 +443,7 @@ impl NoteStore {
     }
 
     pub fn delete_category(&self, name: &str) -> Result<(), AppError> {
+        let _guard = metadata_json_guard()?;
         let notes_dir = self.notes_dir()?;
         let category_path = notes_dir.join(name);
         if !category_path.exists() {
@@ -445,6 +476,7 @@ impl NoteStore {
         id: &str,
         new_category: &str,
     ) -> Result<NoteMetadata, AppError> {
+        let _guard = metadata_json_guard()?;
         self.ensure_storage()?;
         let mut metadata_file = self.load_metadata()?;
         let note = metadata_file
@@ -503,6 +535,7 @@ impl NoteStore {
         self.ensure_base_dir()?;
         let config = self.load_config()?;
         fs::create_dir_all(&config.notes_dir)?;
+        recover_json_after_interrupted_write(&self.metadata_path())?;
         if !self.metadata_path().exists() {
             self.save_metadata(&MetadataFile::default())?;
         }
@@ -544,6 +577,7 @@ impl NoteStore {
     fn load_metadata(&self) -> Result<MetadataFile, AppError> {
         self.ensure_base_dir()?;
         let path = self.metadata_path();
+        recover_json_after_interrupted_write(&path)?;
         if !path.exists() {
             let rebuilt = self.rebuild_metadata()?;
             self.save_metadata(&rebuilt)?;
@@ -568,7 +602,8 @@ impl NoteStore {
 
     fn save_metadata(&self, metadata: &MetadataFile) -> Result<(), AppError> {
         self.ensure_base_dir()?;
-        write_json_atomic(&self.metadata_path(), metadata)
+        write_json_atomic(&self.metadata_path(), metadata)?;
+        Ok(())
     }
 
     fn rebuild_metadata(&self) -> Result<MetadataFile, AppError> {
@@ -628,19 +663,6 @@ impl NoteStore {
         }
         Ok(())
     }
-}
-
-fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> Result<(), AppError> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    let temp_path = path.with_extension("json.tmp");
-    fs::write(&temp_path, serde_json::to_string_pretty(value)?)?;
-    if path.exists() {
-        fs::remove_file(path)?;
-    }
-    fs::rename(temp_path, path)?;
-    Ok(())
 }
 
 fn safe_file_stem(title: &str) -> String {
@@ -848,6 +870,7 @@ mod tests {
             })
             .expect("create second");
 
+        let _ = fs::remove_file(store.base_dir().join("metadata.json.bak"));
         fs::write(store.metadata_path(), "{ broken json").expect("corrupt metadata");
 
         let repaired = store.list_notes().expect("repair metadata");

--- a/src-tauri/src/services/notes_safety_tests.rs
+++ b/src-tauri/src/services/notes_safety_tests.rs
@@ -1,0 +1,74 @@
+use super::notes::{NoteStore, SaveNoteRequest};
+use std::{fs, path::PathBuf, thread};
+
+fn test_root(name: &str) -> PathBuf {
+    let base = std::env::var_os("FLORAL_NOTEPAPER_TEST_TEMP_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| std::env::temp_dir().join("floral-notepaper-rust-tests"));
+    let root = base.join(name);
+    if root.exists() {
+        fs::remove_dir_all(&root).expect("remove stale test root");
+    }
+    fs::create_dir_all(&root).expect("create test root");
+    root
+}
+
+#[test]
+fn restores_metadata_from_backup_when_current_json_is_missing() {
+    let store = NoteStore::new(test_root("metadata-backup-repair"));
+    let created = store
+        .create_note(SaveNoteRequest {
+            title: "第一条".into(),
+            content: "第一条正文".into(),
+            category: String::new(),
+        })
+        .expect("create note");
+
+    fs::copy(
+        store.metadata_path(),
+        store.base_dir().join("metadata.json.bak"),
+    )
+    .expect("create metadata backup");
+    fs::remove_file(store.metadata_path()).expect("remove current metadata");
+
+    let repaired = store.list_notes().expect("recover missing metadata");
+    let ids: Vec<_> = repaired.iter().map(|note| note.id.as_str()).collect();
+
+    assert_eq!(repaired.len(), 1);
+    assert!(ids.contains(&created.id.as_str()));
+    assert!(store.metadata_path().exists());
+}
+
+#[test]
+fn serializes_concurrent_metadata_writes() {
+    let store = NoteStore::new(test_root("concurrent-create"));
+
+    let handles: Vec<_> = (0..16)
+        .map(|index| {
+            let store = store.clone();
+            thread::spawn(move || {
+                store
+                    .create_note(SaveNoteRequest {
+                        title: format!("并发笔记 {index}"),
+                        content: format!("第 {index} 条正文"),
+                        category: String::new(),
+                    })
+                    .expect("create note concurrently");
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        handle.join().expect("join create thread");
+    }
+
+    let listed = store.list_notes().expect("list concurrent notes");
+    assert_eq!(listed.len(), 16);
+    assert!(!fs::read_dir(store.base_dir())
+        .expect("read store dir")
+        .any(|entry| entry
+            .expect("entry")
+            .file_name()
+            .to_string_lossy()
+            .ends_with(".tmp")));
+}


### PR DESCRIPTION

## 变更摘要

本 PR 修复当前 JSON 存储层在多窗口、多入口写入场景下可能出现的并发写入和文件恢复问题。

本次没有引入 SQLite，也没有改变现有 Markdown 正文存储方式。核心目标是：在尽量少侵入现有业务代码的前提下，为 `metadata.json` 和 `config.json` 增加更安全的写入与恢复能力。

## 背景问题

项目当前使用：

- `.md` 文件保存笔记正文。
- `metadata.json` 保存笔记元数据。
- `config.json` 保存应用配置。

原实现中，`metadata.json` 的写入是典型的读改写流程：

```text
读取 metadata.json
修改内存中的 metadata
重写 metadata.json
```

在主窗口自动保存、小窗保存、磁贴保存、分类移动/删除等操作交错发生时，存在以下风险：

1. 多个写入入口同时读取旧 metadata，后写入者可能覆盖先写入者的 metadata 更新。
2. 原 JSON 写入使用固定临时文件名，例如 `metadata.json.tmp`，并发写入时可能互相踩踏。
3. 原写入流程是先删除旧 JSON 再 rename 临时文件，如果中间失败或进程中断，可能导致 JSON 文件缺失。
4. `config.json` 也使用同类写入方式，虽然风险较低，但底层问题一致。

## 本次改动范围

本次代码变更集中在服务层，共涉及 4 个 Rust 文件：

| 文件 | 类型 | 说明 |
|---|---|---|
| `src-tauri/src/services/json_file.rs` | 新增 | 新增 JSON 锁、安全写入、`.bak` 中断恢复和工具层测试。 |
| `src-tauri/src/services/notes_safety_tests.rs` | 新增 | 新增 JSON 存储安全验证测试，避免把大块测试放进 `notes.rs`。 |
| `src-tauri/src/services/mod.rs` | 修改 | 注册 `json_file` 模块，并在测试环境挂载 `notes_safety_tests`。 |
| `src-tauri/src/services/notes.rs` | 修改 | 接入 JSON 锁和安全写入函数，删除旧的内联 JSON 写入实现。 |

### 行数变化

按当前 Git diff 统计，两个老文件的侵入控制在较小范围：

| 文件 | 新增行 | 删除行 | 说明 |
|---|---:|---:|---|
| `src-tauri/src/services/mod.rs` | 4 | 0 | 模块注册和测试模块挂载。 |
| `src-tauri/src/services/notes.rs` | 39 | 16 | 只保留必要接线，测试已外移。 |

为了减少对 `notes.rs` 的侵入，新增安全测试已移动到 `notes_safety_tests.rs`。

## 主要实现

### 1. 新增 JSON 安全工具模块

新增 `src-tauri/src/services/json_file.rs`，集中处理 JSON 文件安全相关逻辑。

该模块提供：

- `metadata_json_guard()`：保护 `metadata.json` 的全局进程内锁。
- `config_json_guard()`：保护 `config.json` 的全局进程内锁。
- `write_json_atomic()`：更安全的 JSON 写入函数。
- `recover_json_after_interrupted_write()`：中断写入后的 `.bak` 恢复函数。

### 2. metadata/config 写入串行化

`metadata.json` 相关操作现在会先获取同一把 metadata 锁，覆盖完整读改写流程：

```text
lock
ensure_storage / load_metadata
写入、移动或删除 .md 文件
修改 metadata
save_metadata
unlock
```

这比只锁 `save_metadata()` 更可靠，因为 lost update 通常发生在多个调用都先读取旧 metadata 之后。

`config.json` 读写也接入了独立的 config 锁。

### 3. 替换旧的固定 tmp 写法

旧逻辑使用固定临时文件：

```text
metadata.json.tmp
```

新逻辑使用唯一临时文件：

```text
metadata.json.<uuid>.tmp
```

写入流程变为：

```text
1. 写入唯一 tmp 文件
2. 如果目标 JSON 存在，先复制成 .bak
3. 删除旧目标文件
4. rename tmp -> 目标 JSON
5. 如果 rename 失败，尽量从 .bak 恢复
6. 成功后删除 .bak，避免长期保留过旧 metadata
```

### 4. 中断恢复

如果上一次写入在删除旧 JSON 后中断，可能只剩 `.bak`。

现在在加载 `config.json` 和初始化/加载 `metadata.json` 时，会先尝试：

```text
recover_json_after_interrupted_write(...)
```

如果目标 JSON 缺失但 `.bak` 存在，会先恢复 `.bak`，避免直接创建空 metadata。

### 5. 保留原有损坏恢复策略

如果 `metadata.json` 文件存在但内容已经损坏，仍沿用原策略：

1. 将损坏文件重命名为 `metadata.corrupt-*.json`。
2. 从现有 Markdown 文件扫描重建 metadata。

这样避免用过旧 `.bak` 覆盖当前真实的 Markdown 文件状态。

## 为什么不引入 SQLite

本 PR 的目标是修复 JSON 当前的安全写入问题，而不是改变存储架构。

当前项目继续保留：

- Markdown 作为正文源文件。
- JSON 作为轻量元数据和配置存储。

SQLite 可以作为未来全文搜索、索引、历史版本等能力的演进方向，但不是本 PR 的范围。

## 为什么新增 `notes_safety_tests.rs`


为了降低对老文件的侵入，本 PR 将新增的安全测试外移到：

```text
src-tauri/src/services/notes_safety_tests.rs
```

这样 `notes.rs` 只保留必要业务接线，测试逻辑单独维护。

## 测试覆盖

本 PR 新增/调整的测试覆盖：

1. JSON 安全写入后不会残留 `.tmp` 文件。
2. JSON 成功写入后会删除 `.bak`。
3. JSON 缺失但 `.bak` 存在时可以恢复。
4. `metadata.json` 损坏时仍可从 Markdown 文件重建。
5. 16 个线程并发创建笔记后，metadata 不丢记录。
6. 并发写入后存储目录不残留 `.tmp` 文件。

## 验证结果

已本地验证：

```text
cargo test
```

结果：

```text
21 passed
```

此前也验证过前端测试与构建：

```text
npm test
npm run build
```

结果：

- 前端测试：18 个测试文件、44 个测试通过。
- 前端构建：成功。
- 构建仍有既有 Vite chunk size warning，不是本次变更引入。

## 兼容性影响

本 PR 不改变：

- 前端 API。
- Tauri command 名称。
- Tauri command 参数。
- Markdown 文件格式。
- 笔记目录结构。
- 用户可见交互。

属于后端存储安全增强。

## 风险与注意事项

1. 当前锁是进程内锁，主要解决本 Tauri 应用多窗口、多入口之间的并发写问题。
2. 它不阻止外部进程直接修改 JSON 或 Markdown 文件。
3. 同一篇笔记多窗口同时编辑的内容级冲突检测，本 PR 暂未处理；后续可通过 revision 机制继续增强。



## PR 结论

本 PR 通过新增独立 JSON 安全模块和安全测试文件，在尽量少修改现有业务代码的前提下，修复了 JSON 存储层的主要并发写入和中断恢复隐患。

核心收益：

- 降低 metadata 丢更新风险。
- 避免固定 `.tmp` 文件并发踩踏。
- 增加 `.bak` 中断恢复能力。
- 保持现有 Markdown + JSON 存储架构不变。
- 老文件 `notes.rs` 当前只新增 39 行，侵入较小。
