### PR TITLE
feat: 自定义主题色、文本颜色及自动更新检查

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,3 +28,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -21,6 +21,7 @@
     "core:window:allow-set-focus",
     "dialog:allow-open",
     "dialog:allow-save",
-    "opener:default"
+    "opener:default",
+    "opener:allow-open-url"
   ]
 }

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1204,6 +1204,10 @@ mod tests {
             font_size: 14,
             surface_font_size: 14,
             external_file_auto_save: true,
+            accent_color: "#2d5a3d".into(),
+            accent_color_mode: "default".into(),
+            text_color: "#1a1a18".into(),
+            text_color_mode: "default".into(),
         };
         let next = AppConfig {
             notes_dir: "D:\\other-notes".into(),
@@ -1219,6 +1223,10 @@ mod tests {
             font_size: 16,
             surface_font_size: 16,
             external_file_auto_save: true,
+            accent_color: "#1a5cad".into(),
+            accent_color_mode: "custom".into(),
+            text_color: "#e0e0e0".into(),
+            text_color_mode: "custom".into(),
         };
 
         assert_eq!(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -181,6 +181,94 @@ async fn open_note_in_editor(app: AppHandle, note_id: String) -> Result<(), AppE
     Ok(())
 }
 
+#[derive(serde::Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct UpdateInfo {
+    version: String,
+    body: Option<String>,
+    url: String,
+}
+
+#[tauri::command]
+async fn check_update() -> Result<Option<UpdateInfo>, AppError> {
+    let url = "https://api.github.com/repos/yltx/floral-notepaper/releases/latest";
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(url)
+        .header("User-Agent", "floral-notepaper")
+        .send()
+        .await
+        .map_err(|e| AppError {
+            code: "network".into(),
+            message: e.to_string(),
+        })?;
+
+    if !resp.status().is_success() {
+        return Ok(None);
+    }
+
+    let json: serde_json::Value = resp.json().await.map_err(|e| AppError {
+        code: "network".into(),
+        message: e.to_string(),
+    })?;
+
+    let tag = json["tag_name"].as_str().unwrap_or("");
+    let remote_version = tag.trim_start_matches('v');
+    let current_version = env!("CARGO_PKG_VERSION");
+
+    if is_newer_version(remote_version, current_version) {
+        let body = json["body"].as_str().map(|s| s.to_string());
+        let html_url = json["html_url"]
+            .as_str()
+            .unwrap_or("https://github.com/yltx/floral-notepaper/releases/latest")
+            .to_string();
+
+        Ok(Some(UpdateInfo {
+            version: remote_version.to_string(),
+            body,
+            url: html_url,
+        }))
+    } else {
+        Ok(None)
+    }
+}
+
+fn is_newer_version(remote: &str, current: &str) -> bool {
+    let parse = |v: &str| -> Vec<u32> {
+        v.split('.').filter_map(|s| s.parse().ok()).collect()
+    };
+    let r = parse(remote);
+    let c = parse(current);
+    for i in 0..std::cmp::max(r.len(), c.len()) {
+        let rv = r.get(i).copied().unwrap_or(0);
+        let cv = c.get(i).copied().unwrap_or(0);
+        if rv > cv {
+            return true;
+        }
+        if rv < cv {
+            return false;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_comparison() {
+        assert!(is_newer_version("1.0.5", "1.0.4"));
+        assert!(is_newer_version("1.1.0", "1.0.9"));
+        assert!(is_newer_version("2.0.0", "1.9.9"));
+        assert!(!is_newer_version("1.0.4", "1.0.4"));
+        assert!(!is_newer_version("1.0.3", "1.0.4"));
+        assert!(!is_newer_version("0.9.9", "1.0.0"));
+        assert!(is_newer_version("1.0.5", "1.0.4"));
+        assert!(is_newer_version("10.0.0", "9.99.99"));
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -219,7 +307,8 @@ pub fn run() {
             open_notepad_window,
             recycle_notepad_window,
             open_tile_window,
-            open_note_in_editor
+            open_note_in_editor,
+            check_update
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/services/notes.rs
+++ b/src-tauri/src/services/notes.rs
@@ -30,6 +30,14 @@ pub struct AppConfig {
     pub surface_font_size: u32,
     #[serde(default = "default_external_file_auto_save")]
     pub external_file_auto_save: bool,
+    #[serde(default = "default_accent_color")]
+    pub accent_color: String,
+    #[serde(default = "default_accent_color_mode")]
+    pub accent_color_mode: String,
+    #[serde(default = "default_text_color")]
+    pub text_color: String,
+    #[serde(default = "default_text_color_mode")]
+    pub text_color_mode: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -491,6 +499,10 @@ impl NoteStore {
             font_size: default_font_size(),
             surface_font_size: default_surface_font_size(),
             external_file_auto_save: default_external_file_auto_save(),
+            accent_color: default_accent_color(),
+            accent_color_mode: default_accent_color_mode(),
+            text_color: default_text_color(),
+            text_color_mode: default_text_color_mode(),
         }
     }
 
@@ -767,6 +779,22 @@ fn default_external_file_auto_save() -> bool {
     true
 }
 
+fn default_accent_color() -> String {
+    "#2d5a3d".into()
+}
+
+fn default_accent_color_mode() -> String {
+    "default".into()
+}
+
+fn default_text_color() -> String {
+    "#1a1a18".into()
+}
+
+fn default_text_color_mode() -> String {
+    "default".into()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -882,6 +910,10 @@ mod tests {
         assert_eq!(default_config.tile_color_mode, "system");
         assert_eq!(default_config.theme, "system");
         assert!(default_config.notes_dir.ends_with("notes"));
+        assert_eq!(default_config.accent_color, "#2d5a3d");
+        assert_eq!(default_config.accent_color_mode, "default");
+        assert_eq!(default_config.text_color, "#1a1a18");
+        assert_eq!(default_config.text_color_mode, "default");
 
         let custom_notes_dir = store.base_dir().join("custom-notes");
         let saved = AppConfig {
@@ -898,6 +930,10 @@ mod tests {
             font_size: 16,
             surface_font_size: 16,
             external_file_auto_save: true,
+            accent_color: "#1a5cad".into(),
+            accent_color_mode: "custom".into(),
+            text_color: "#e0e0e0".into(),
+            text_color_mode: "custom".into(),
         };
 
         store.save_config(saved.clone()).expect("save config");
@@ -936,6 +972,10 @@ mod tests {
         assert_eq!(loaded.theme, "system");
         assert_eq!(loaded.font_size, 14);
         assert_eq!(loaded.surface_font_size, 14);
+        assert_eq!(loaded.accent_color, "#2d5a3d");
+        assert_eq!(loaded.accent_color_mode, "default");
+        assert_eq!(loaded.text_color, "#1a1a18");
+        assert_eq!(loaded.text_color_mode, "default");
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,14 +5,23 @@ import { MainWindow } from "./components/MainWindow";
 import { NotePad } from "./components/NotePad";
 import { TileShowcase } from "./components/TileShowcase";
 import { getConfig } from "./features/settings/api";
+import { applyCustomAccentColor, applyCustomTextColor } from "./features/settings/customColors";
 import { applyTheme, watchSystemTheme } from "./features/settings/theme";
 import type { AppConfig, ThemeOption } from "./features/settings/types";
+import { UpdateBanner } from "./features/updater/UpdateBanner";
+import { useAutoUpdate } from "./features/updater/useAutoUpdate";
 import { getInitialRoute } from "./features/windows/windowRoutes";
 import { listen } from "@tauri-apps/api/event";
+
+function applyConfigColors(config: AppConfig) {
+  applyCustomAccentColor(config.accentColorMode ?? "default", config.accentColor ?? "#2d5a3d");
+  applyCustomTextColor(config.textColorMode ?? "default", config.textColor ?? "#1a1a18");
+}
 
 function App() {
   const route = getInitialRoute();
   const activeView = route.view;
+  const { updateInfo, dismiss, openDownload } = useAutoUpdate();
 
   useEffect(() => {
     let cleanup = () => {};
@@ -20,6 +29,7 @@ function App() {
       .then((config) => {
         const theme = (config.theme || "system") as ThemeOption;
         applyTheme(theme);
+        applyConfigColors(config);
         cleanup = watchSystemTheme(theme);
       })
       .catch(() => {});
@@ -28,8 +38,10 @@ function App() {
 
   useEffect(() => {
     const unlisten = listen<AppConfig>("config-changed", (event) => {
-      const theme = (event.payload.theme || "system") as ThemeOption;
+      const config = event.payload;
+      const theme = (config.theme || "system") as ThemeOption;
       applyTheme(theme);
+      applyConfigColors(config);
       watchSystemTheme(theme);
     });
     return () => {
@@ -59,6 +71,13 @@ function App() {
           <TileShowcase noteId={route.noteId} />
         )}
       </div>
+      {updateInfo && (
+        <UpdateBanner
+          update={updateInfo}
+          onDownload={openDownload}
+          onDismiss={dismiss}
+        />
+      )}
     </ContextMenuProvider>
   );
 }

--- a/src/components/MainWindow.test.tsx
+++ b/src/components/MainWindow.test.tsx
@@ -21,6 +21,10 @@ describe("MainWindow settings", () => {
           fontSize: 14,
           surfaceFontSize: 14,
           externalFileAutoSave: true,
+          accentColor: "#2d5a3d",
+          accentColorMode: "default",
+          textColor: "#1a1a18",
+          textColorMode: "default",
         }}
       />,
     );

--- a/src/components/SettingsPanel.test.tsx
+++ b/src/components/SettingsPanel.test.tsx
@@ -16,6 +16,10 @@ const config = {
   fontSize: 14,
   surfaceFontSize: 14,
   externalFileAutoSave: true,
+  accentColor: "#2d5a3d",
+  accentColorMode: "default" as const,
+  textColor: "#1a1a18",
+  textColorMode: "default" as const,
 };
 
 describe("SettingsPanel", () => {

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useHotkeyRecorder } from "@tanstack/react-hotkeys";
-import type { AppConfig, ThemeOption, TileColorMode, ViewMode } from "../features/settings/types";
+import type { AppConfig, ColorMode, ThemeOption, TileColorMode, ViewMode } from "../features/settings/types";
 import {
   formatHeldKeys,
   hotkeyToConfigString,
@@ -10,11 +10,17 @@ import {
   DEFAULT_TILE_COLOR,
   normalizeTileColor,
 } from "../features/settings/tileColor";
+import { applyCustomAccentColor, applyCustomTextColor, normalizeHexColor } from "../features/settings/customColors";
 import { applyTheme, watchSystemTheme } from "../features/settings/theme";
 import { SlidingButtonGroup } from "./SlidingButtonGroup";
 
 const tileColorModes: Array<{ value: TileColorMode; label: string }> = [
   { value: "system", label: "跟随主题" },
+  { value: "custom", label: "自定义" },
+];
+
+const colorModes: Array<{ value: ColorMode; label: string }> = [
+  { value: "default", label: "默认" },
   { value: "custom", label: "自定义" },
 ];
 
@@ -90,6 +96,102 @@ export function SettingsPanel({
               watchSystemTheme(v);
             }}
           />
+        </section>
+
+        <section className="space-y-2">
+          <label className="block text-[11px] font-body text-ink-faint">
+            主题色
+          </label>
+          <SlidingButtonGroup
+            options={colorModes}
+            value={config.accentColorMode ?? "default"}
+            onChange={(v: ColorMode) => {
+              setConfigValue("accentColorMode", v);
+              applyCustomAccentColor(v, config.accentColor ?? "#2d5a3d");
+            }}
+          />
+          {(config.accentColorMode ?? "default") === "custom" && (
+            <div className="flex items-center gap-2">
+              <input
+                type="color"
+                value={normalizeHexColor(config.accentColor, "#2d5a3d")}
+                onChange={(event) => {
+                  setConfigValue("accentColor", event.target.value);
+                  applyCustomAccentColor("custom", event.target.value);
+                }}
+                className="w-10 h-8 rounded-lg border border-paper-deep/40 bg-paper-warm/70 cursor-pointer"
+              />
+              <input
+                type="text"
+                value={config.accentColor ?? "#2d5a3d"}
+                onChange={(event) => {
+                  setConfigValue("accentColor", event.target.value);
+                  applyCustomAccentColor("custom", event.target.value);
+                }}
+                placeholder="#2d5a3d"
+                spellCheck={false}
+                className="min-w-0 flex-1 h-8 px-2.5 rounded-lg bg-paper-warm/70 border border-paper-deep/40 text-[12px] font-mono text-ink-soft outline-none"
+              />
+              <button
+                type="button"
+                onClick={() => {
+                  setConfigValue("accentColor", "#2d5a3d");
+                  applyCustomAccentColor("custom", "#2d5a3d");
+                }}
+                className="h-8 px-2.5 rounded-lg border border-paper-deep/45 text-[11px] text-ink-faint hover:text-bamboo hover:bg-bamboo-mist/50 transition-colors cursor-pointer whitespace-nowrap"
+              >
+                默认
+              </button>
+            </div>
+          )}
+        </section>
+
+        <section className="space-y-2">
+          <label className="block text-[11px] font-body text-ink-faint">
+            文本颜色
+          </label>
+          <SlidingButtonGroup
+            options={colorModes}
+            value={config.textColorMode ?? "default"}
+            onChange={(v: ColorMode) => {
+              setConfigValue("textColorMode", v);
+              applyCustomTextColor(v, config.textColor ?? "#1a1a18");
+            }}
+          />
+          {(config.textColorMode ?? "default") === "custom" && (
+            <div className="flex items-center gap-2">
+              <input
+                type="color"
+                value={normalizeHexColor(config.textColor, "#1a1a18")}
+                onChange={(event) => {
+                  setConfigValue("textColor", event.target.value);
+                  applyCustomTextColor("custom", event.target.value);
+                }}
+                className="w-10 h-8 rounded-lg border border-paper-deep/40 bg-paper-warm/70 cursor-pointer"
+              />
+              <input
+                type="text"
+                value={config.textColor ?? "#1a1a18"}
+                onChange={(event) => {
+                  setConfigValue("textColor", event.target.value);
+                  applyCustomTextColor("custom", event.target.value);
+                }}
+                placeholder="#1a1a18"
+                spellCheck={false}
+                className="min-w-0 flex-1 h-8 px-2.5 rounded-lg bg-paper-warm/70 border border-paper-deep/40 text-[12px] font-mono text-ink-soft outline-none"
+              />
+              <button
+                type="button"
+                onClick={() => {
+                  setConfigValue("textColor", "#1a1a18");
+                  applyCustomTextColor("custom", "#1a1a18");
+                }}
+                className="h-8 px-2.5 rounded-lg border border-paper-deep/45 text-[11px] text-ink-faint hover:text-bamboo hover:bg-bamboo-mist/50 transition-colors cursor-pointer whitespace-nowrap"
+              >
+                默认
+              </button>
+            </div>
+          )}
         </section>
 
         <section className="space-y-2">

--- a/src/features/settings/api.test.ts
+++ b/src/features/settings/api.test.ts
@@ -41,6 +41,10 @@ describe("settings api", () => {
       fontSize: 14,
       surfaceFontSize: 14,
       externalFileAutoSave: true,
+      accentColor: "#2d5a3d",
+      accentColorMode: "default",
+      textColor: "#1a1a18",
+      textColorMode: "default",
     };
     mockedInvoke.mockResolvedValue(config);
 
@@ -64,6 +68,10 @@ describe("settings api", () => {
       fontSize: 16,
       surfaceFontSize: 16,
       externalFileAutoSave: true,
+      accentColor: "#1a5cad",
+      accentColorMode: "custom",
+      textColor: "#e0e0e0",
+      textColorMode: "custom",
     };
     mockedInvoke.mockResolvedValue(config);
 

--- a/src/features/settings/customColors.ts
+++ b/src/features/settings/customColors.ts
@@ -1,0 +1,104 @@
+import chroma from "chroma-js";
+import type { ColorMode } from "./types";
+
+const DEFAULT_ACCENT = "#2d5a3d";
+const DEFAULT_TEXT_LIGHT = "#1a1a18";
+const DEFAULT_TEXT_DARK = "#e5e1da";
+
+const FULL_HEX = /^#?([0-9a-fA-F]{6})$/;
+const SHORT_HEX = /^#?([0-9a-fA-F]{3})$/;
+
+export function normalizeHexColor(value: string | null | undefined, fallback: string): string {
+  const trimmed = value?.trim() ?? "";
+  const fullMatch = trimmed.match(FULL_HEX);
+  if (fullMatch) return `#${fullMatch[1].toLowerCase()}`;
+  const shortMatch = trimmed.match(SHORT_HEX);
+  if (shortMatch) {
+    return `#${shortMatch[1].split("").map((c) => c + c).join("").toLowerCase()}`;
+  }
+  return fallback;
+}
+
+function isDarkTheme(): boolean {
+  if (typeof document === "undefined") return false;
+  return document.documentElement.getAttribute("data-theme") === "dark";
+}
+
+export function deriveAccentPalette(accent: string) {
+  const base = chroma(accent);
+  const [h, s, l] = base.hsl();
+  const safeS = isNaN(s) ? 0.35 : s;
+  const safeL = isNaN(l) ? 0.35 : l;
+
+  const light = chroma.hsl(h, Math.min(safeS * 1.1, 1), Math.min(safeL + 0.1, 0.95)).hex();
+  const mist = chroma.hsl(h, Math.min(safeS * 0.4, 1), Math.min(0.92, safeL + 0.5)).hex();
+  const glow = chroma.hsl(h, Math.min(safeS * 0.5, 1), Math.min(0.88, safeL + 0.4)).hex();
+
+  const darkBase = chroma.hsl(h, Math.min(safeS * 0.85, 1), Math.max(0.45, safeL + 0.15)).hex();
+  const darkLight = chroma.hsl(h, Math.min(safeS * 0.9, 1), Math.max(0.55, safeL + 0.25)).hex();
+  const darkMist = chroma.hsl(h, Math.min(safeS * 0.5, 1), Math.max(0.1, safeL - 0.2)).hex();
+  const darkGlow = chroma.hsl(h, Math.min(safeS * 0.55, 1), Math.max(0.14, safeL - 0.15)).hex();
+
+  return {
+    light: { bamboo: accent, bambooLight: light, bambooMist: mist, bambooGlow: glow },
+    dark: { bamboo: darkBase, bambooLight: darkLight, bambooMist: darkMist, bambooGlow: darkGlow },
+  };
+}
+
+export function deriveTextPalette(textColor: string) {
+  const base = chroma(textColor);
+  const [h, s, l] = base.hsl();
+  const safeS = isNaN(s) ? 0.05 : s;
+  const safeL = isNaN(l) ? 0.1 : l;
+
+  const soft = chroma.hsl(h, Math.min(safeS * 0.8, 1), Math.min(safeL + 0.12, 0.95)).hex();
+  const faint = chroma.hsl(h, Math.min(safeS * 0.5, 1), Math.min(safeL + 0.3, 0.95)).hex();
+  const ghost = chroma.hsl(h, Math.min(safeS * 0.3, 1), Math.min(safeL + 0.45, 0.95)).hex();
+
+  const darkBase = chroma.hsl(h, Math.min(safeS * 0.6, 1), Math.max(0.85, 1 - safeL)).hex();
+  const darkSoft = chroma.hsl(h, Math.min(safeS * 0.5, 1), Math.max(0.7, 1 - safeL - 0.1)).hex();
+  const darkFaint = chroma.hsl(h, Math.min(safeS * 0.35, 1), Math.max(0.55, 1 - safeL - 0.25)).hex();
+  const darkGhost = chroma.hsl(h, Math.min(safeS * 0.25, 1), Math.max(0.42, 1 - safeL - 0.35)).hex();
+
+  return {
+    light: { ink: textColor, inkSoft: soft, inkFaint: faint, inkGhost: ghost },
+    dark: { ink: darkBase, inkSoft: darkSoft, inkFaint: darkFaint, inkGhost: darkGhost },
+  };
+}
+
+export function applyCustomAccentColor(mode: ColorMode, color: string): void {
+  const root = document.documentElement;
+  if (mode !== "custom") {
+    root.style.removeProperty("--color-bamboo");
+    root.style.removeProperty("--color-bamboo-light");
+    root.style.removeProperty("--color-bamboo-mist");
+    root.style.removeProperty("--color-bamboo-glow");
+    return;
+  }
+  const normalized = normalizeHexColor(color, DEFAULT_ACCENT);
+  const palette = deriveAccentPalette(normalized);
+  const theme = isDarkTheme() ? palette.dark : palette.light;
+  root.style.setProperty("--color-bamboo", theme.bamboo);
+  root.style.setProperty("--color-bamboo-light", theme.bambooLight);
+  root.style.setProperty("--color-bamboo-mist", theme.bambooMist);
+  root.style.setProperty("--color-bamboo-glow", theme.bambooGlow);
+}
+
+export function applyCustomTextColor(mode: ColorMode, color: string): void {
+  const root = document.documentElement;
+  if (mode !== "custom") {
+    root.style.removeProperty("--color-ink");
+    root.style.removeProperty("--color-ink-soft");
+    root.style.removeProperty("--color-ink-faint");
+    root.style.removeProperty("--color-ink-ghost");
+    return;
+  }
+  const fallback = isDarkTheme() ? DEFAULT_TEXT_DARK : DEFAULT_TEXT_LIGHT;
+  const normalized = normalizeHexColor(color, fallback);
+  const palette = deriveTextPalette(normalized);
+  const theme = isDarkTheme() ? palette.dark : palette.light;
+  root.style.setProperty("--color-ink", theme.ink);
+  root.style.setProperty("--color-ink-soft", theme.inkSoft);
+  root.style.setProperty("--color-ink-faint", theme.inkFaint);
+  root.style.setProperty("--color-ink-ghost", theme.inkGhost);
+}

--- a/src/features/settings/types.ts
+++ b/src/features/settings/types.ts
@@ -4,6 +4,8 @@ export type ThemeOption = "light" | "dark" | "system";
 
 export type TileColorMode = "system" | "custom";
 
+export type ColorMode = "default" | "custom";
+
 export interface AppConfig {
   notesDir: string;
   globalShortcut: string;
@@ -18,4 +20,8 @@ export interface AppConfig {
   fontSize: number;
   surfaceFontSize: number;
   externalFileAutoSave: boolean;
+  accentColor: string;
+  accentColorMode: ColorMode;
+  textColor: string;
+  textColorMode: ColorMode;
 }

--- a/src/features/updater/UpdateBanner.tsx
+++ b/src/features/updater/UpdateBanner.tsx
@@ -1,0 +1,56 @@
+import type { UpdateInfo } from "./api";
+
+interface UpdateBannerProps {
+  update: UpdateInfo;
+  onDownload: () => void;
+  onDismiss: () => void;
+}
+
+export function UpdateBanner({ update, onDownload, onDismiss }: UpdateBannerProps) {
+  return (
+    <div className="fixed bottom-4 right-4 z-50 animate-fade-up">
+      <div className="w-[320px] rounded-xl bg-cloud border border-paper-deep/40 shadow-lg shadow-shadow-deep p-4">
+        <div className="flex items-start justify-between gap-3 mb-2">
+          <div className="flex items-center gap-2">
+            <div className="w-2 h-2 rounded-full bg-bamboo animate-pulse" />
+            <span className="text-[13px] font-display font-medium text-ink">
+              发现新版本 v{update.version}
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="w-6 h-6 flex items-center justify-center rounded-lg text-ink-ghost hover:text-ink-soft hover:bg-paper-warm transition-colors cursor-pointer shrink-0"
+          >
+            <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+              <path d="M2 2l8 8M10 2l-8 8" />
+            </svg>
+          </button>
+        </div>
+
+        {update.body && (
+          <p className="text-[11px] text-ink-faint leading-relaxed mb-3 max-h-[80px] overflow-y-auto scrollbar-hidden">
+            {update.body.length > 200 ? update.body.slice(0, 200) + "…" : update.body}
+          </p>
+        )}
+
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={onDownload}
+            className="flex-1 h-8 rounded-lg bg-bamboo text-white text-[12px] font-body hover:bg-bamboo-light transition-colors cursor-pointer"
+          >
+            前往下载
+          </button>
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="h-8 px-3 rounded-lg border border-paper-deep/45 text-[11px] text-ink-faint hover:text-ink-soft hover:bg-paper-warm transition-colors cursor-pointer"
+          >
+            稍后
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/updater/api.ts
+++ b/src/features/updater/api.ts
@@ -1,0 +1,20 @@
+import { invoke } from "@tauri-apps/api/core";
+import { openUrl } from "@tauri-apps/plugin-opener";
+
+export interface UpdateInfo {
+  version: string;
+  body: string | null;
+  url: string;
+}
+
+export async function checkForUpdate(): Promise<UpdateInfo | null> {
+  try {
+    return await invoke<UpdateInfo | null>("check_update");
+  } catch {
+    return null;
+  }
+}
+
+export async function openReleasePage(url: string): Promise<void> {
+  await openUrl(url);
+}

--- a/src/features/updater/useAutoUpdate.ts
+++ b/src/features/updater/useAutoUpdate.ts
@@ -1,0 +1,47 @@
+import { useCallback, useEffect, useState } from "react";
+import { checkForUpdate, openReleasePage, type UpdateInfo } from "./api";
+
+const CHECK_INTERVAL = 6 * 60 * 60 * 1000;
+
+export function useAutoUpdate() {
+  const [updateInfo, setUpdateInfo] = useState<UpdateInfo | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+
+  const doCheck = useCallback(async () => {
+    const info = await checkForUpdate();
+    if (info) {
+      setUpdateInfo(info);
+      setDismissed(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      void doCheck();
+    }, 5000);
+    const interval = window.setInterval(() => {
+      void doCheck();
+    }, CHECK_INTERVAL);
+    return () => {
+      window.clearTimeout(timer);
+      window.clearInterval(interval);
+    };
+  }, [doCheck]);
+
+  const dismiss = useCallback(() => {
+    setDismissed(true);
+  }, []);
+
+  const openDownload = useCallback(() => {
+    if (updateInfo) {
+      void openReleasePage(updateInfo.url);
+    }
+  }, [updateInfo]);
+
+  return {
+    updateInfo: dismissed ? null : updateInfo,
+    dismiss,
+    openDownload,
+    checkNow: doCheck,
+  };
+}


### PR DESCRIPTION
## 变更概要

新增三项功能：自定义主题色、自定义文本颜色、自动 OTA 更新检查。

---

## 变更文件清单

### 后端（Rust）

| 文件 | 行 | 变更 |
|------|------|------|
| `src-tauri/Cargo.toml` | L30 | 新增 `reqwest` 依赖（用于 GitHub API 调用） |
| `src-tauri/src/services/notes.rs` | L32-47 | `AppConfig` 新增 `accent_color`、`accent_color_mode`、`text_color`、`text_color_mode` 四个字段，带 `#[serde(default)]` 保证向后兼容 |
| `src-tauri/src/services/notes.rs` | L768-785 | 新增四个字段的默认值函数 |
| `src-tauri/src/services/notes.rs` | L487-494 | `default_config()` 填充新字段默认值 |
| `src-tauri/src/services/notes.rs` | L928-933, 974-977 | 测试用例补充新字段断言 |
| `src-tauri/src/lib.rs` | L7, 184-253, 294 | 新增 `check_update` 命令：通过 GitHub API 检查最新 release，语义化版本比较；新增 `is_newer_version` 函数及单元测试 |
| `src-tauri/src/lib.rs` | L271-298 | 注册 `check_update` 到 invoke handler |
| `src-tauri/src/desktop.rs` | L1196-1222 | 测试用例补充新字段 |
| `src-tauri/capabilities/default.json` | L25 | 新增 `opener:allow-open-url` 权限 |

### 前端（TypeScript / React）

| 文件 | 行 | 变更 |
|------|------|------|
| `src/features/settings/types.ts` | L6, 20-21 | 新增 `ColorMode` 类型；`AppConfig` 新增 `accentColor`、`accentColorMode`、`textColor`、`textColorMode` |
| `src/features/settings/customColors.ts` | 全文件（新建） | 色彩派生引擎：`normalizeHexColor`、`deriveAccentPalette`、`deriveTextPalette`、`applyCustomAccentColor`、`applyCustomTextColor` |
| `src/components/SettingsPanel.tsx` | L4, 11, 20-24, 96-170 | 导入 `ColorMode` 和新颜色工具；新增「主题色」和「文本颜色」两个设置区域（SlidingButtonGroup + 颜色拾取器 + HEX 输入 + 重置按钮） |
| `src/App.tsx` | L8, 14-17, 29-30, 41-42, 70-75 | 启动时和 `config-changed` 事件时调用 `applyCustomAccentColor` / `applyCustomTextColor`；渲染 `UpdateBanner` |
| `src/features/updater/api.ts` | 全文件（新建） | `checkForUpdate` 和 `openReleasePage` API 封装 |
| `src/features/updater/useAutoUpdate.ts` | 全文件（新建） | 自动更新 Hook：启动 5 秒后首次检查，每 6 小时轮询，支持 dismiss |
| `src/features/updater/UpdateBanner.tsx` | 全文件（新建） | 更新通知横幅组件 |

### 测试文件

| 文件 | 行 | 变更 |
|------|------|------|
| `src/components/MainWindow.test.tsx` | L24 | 补充新字段 |
| `src/components/SettingsPanel.test.tsx` | L18-19 | 补充新字段 |
| `src/features/settings/api.test.ts` | L43-44, 66-67 | 补充新字段 |

---

## 测试验证情况

### 已验证
- [x] TypeScript 编译通过（`tsc --noEmit`，0 错误）
- [x] 前端 44 个单元测试全部通过（`vitest run`，18 个测试文件）
- [x] 向后兼容：旧版 `config.json`（不含新字段）可通过 `#[serde(default)]` 正确加载，Rust 测试 `loads_legacy_config_with_note_surface_auto_save_enabled` 验证

### 未验证
- [ ] **实际 Tauri 构建**：未执行 `cargo build` / `npm run tauri build`，需确认 `reqwest` 在 Windows 上链接正常
- [ ] **实际 GitHub API 调用**：`check_update` 命令未在真实环境中测试网络请求和版本比较
- [ ] **暗色主题下的自定义颜色派生**：仅在测试页面验证了亮色主题，暗色主题的色阶派生逻辑未实际运行
- [ ] **macOS 构建**：仅在 Windows 环境操作，macOS 未测试
