### PR TITLE
feat:添加自定义字体功能

### DIFF
--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       run_build:
-        description: 'Run heavy Tauri build jobs'
+        description: "Run heavy Tauri build jobs"
         required: false
         default: false
         type: boolean
@@ -275,7 +275,7 @@ jobs:
         if: ${{ needs.detect-changes.outputs.frontend == 'true' }}
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
-          node-version: '24'
+          node-version: "24"
           cache: npm
 
       - name: Install dependencies
@@ -308,7 +308,7 @@ jobs:
         if: ${{ needs.detect-changes.outputs.frontend == 'true' }}
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
-          node-version: '24'
+          node-version: "24"
           cache: npm
 
       - name: Install dependencies
@@ -341,7 +341,7 @@ jobs:
         if: ${{ needs.detect-changes.outputs.frontend == 'true' }}
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
-          node-version: '24'
+          node-version: "24"
           cache: npm
 
       - name: Install dependencies
@@ -454,7 +454,7 @@ jobs:
         if: ${{ github.event_name != 'issue_comment' || needs.detect-changes.outputs.build == 'true' }}
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
-          node-version: '24'
+          node-version: "24"
           cache: npm
 
       - name: Setup Rust
@@ -545,7 +545,7 @@ jobs:
         if: ${{ github.event_name != 'issue_comment' || needs.detect-changes.outputs.build == 'true' }}
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
-          node-version: '24'
+          node-version: "24"
           cache: npm
 
       - name: Setup Rust

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: '版本号（例如 v1.0.3）'
+        description: "版本号（例如 v1.0.3）"
         required: true
         type: string
 
@@ -76,7 +76,7 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: '24'
+          node-version: "24"
           cache: npm
 
       - uses: dtolnay/rust-toolchain@stable
@@ -253,7 +253,7 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: '24'
+          node-version: "24"
           cache: npm
 
       - uses: dtolnay/rust-toolchain@stable
@@ -309,7 +309,7 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: '24'
+          node-version: "24"
           cache: npm
 
       - uses: dtolnay/rust-toolchain@stable

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "floral-notepaper",
-  "private": true,
   "version": "1.0.4",
+  "private": true,
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1283,8 +1283,13 @@ mod tests {
             theme: "light".into(),
             font_size: 14,
             surface_font_size: 14,
+            ui_font_family: r#""Noto Sans SC", "Source Han Sans SC", system-ui, sans-serif"#.into(),
+            font_family: r#""Noto Sans SC", "Source Han Sans SC", system-ui, sans-serif"#.into(),
+            surface_font_family: r#""Noto Sans SC", "Source Han Sans SC", system-ui, sans-serif"#
+                .into(),
             external_file_auto_save: true,
             remember_surface_size: true,
+            tile_ctrl_close: true,
             surface_width: None,
             surface_height: None,
         };
@@ -1301,8 +1306,12 @@ mod tests {
             theme: "dark".into(),
             font_size: 16,
             surface_font_size: 16,
+            ui_font_family: r#""LXGW WenKai", serif"#.into(),
+            font_family: r#""LXGW WenKai", serif"#.into(),
+            surface_font_family: r#""Maple Mono NF CN", monospace"#.into(),
             external_file_auto_save: true,
             remember_surface_size: true,
+            tile_ctrl_close: false,
             surface_width: None,
             surface_height: None,
         };

--- a/src-tauri/src/services/notes.rs
+++ b/src-tauri/src/services/notes.rs
@@ -28,6 +28,12 @@ pub struct AppConfig {
     pub font_size: u32,
     #[serde(default = "default_surface_font_size")]
     pub surface_font_size: u32,
+    #[serde(default = "default_ui_font_family")]
+    pub ui_font_family: String,
+    #[serde(default = "default_font_family")]
+    pub font_family: String,
+    #[serde(default = "default_surface_font_family")]
+    pub surface_font_family: String,
     #[serde(default = "default_external_file_auto_save")]
     pub external_file_auto_save: bool,
     #[serde(default = "default_remember_surface_size")]
@@ -498,6 +504,9 @@ impl NoteStore {
             theme: default_theme(),
             font_size: default_font_size(),
             surface_font_size: default_surface_font_size(),
+            ui_font_family: default_ui_font_family(),
+            font_family: default_font_family(),
+            surface_font_family: default_surface_font_family(),
             external_file_auto_save: default_external_file_auto_save(),
             remember_surface_size: default_remember_surface_size(),
             tile_ctrl_close: default_tile_ctrl_close(),
@@ -775,6 +784,18 @@ fn default_surface_font_size() -> u32 {
     14
 }
 
+fn default_ui_font_family() -> String {
+    r#""Noto Sans SC", "Source Han Sans SC", system-ui, sans-serif"#.into()
+}
+
+fn default_font_family() -> String {
+    r#""Noto Sans SC", "Source Han Sans SC", system-ui, sans-serif"#.into()
+}
+
+fn default_surface_font_family() -> String {
+    r#""Noto Sans SC", "Source Han Sans SC", system-ui, sans-serif"#.into()
+}
+
 fn default_external_file_auto_save() -> bool {
     true
 }
@@ -901,6 +922,18 @@ mod tests {
         assert_eq!(default_config.tile_color, "#f6f3ec");
         assert_eq!(default_config.tile_color_mode, "system");
         assert_eq!(default_config.theme, "system");
+        assert_eq!(
+            default_config.ui_font_family,
+            r#""Noto Sans SC", "Source Han Sans SC", system-ui, sans-serif"#
+        );
+        assert_eq!(
+            default_config.font_family,
+            r#""Noto Sans SC", "Source Han Sans SC", system-ui, sans-serif"#
+        );
+        assert_eq!(
+            default_config.surface_font_family,
+            r#""Noto Sans SC", "Source Han Sans SC", system-ui, sans-serif"#
+        );
         assert!(default_config.notes_dir.ends_with("notes"));
 
         let custom_notes_dir = store.base_dir().join("custom-notes");
@@ -917,8 +950,12 @@ mod tests {
             theme: "dark".into(),
             font_size: 16,
             surface_font_size: 16,
+            ui_font_family: r#""LXGW WenKai", serif"#.into(),
+            font_family: r#""LXGW WenKai", serif"#.into(),
+            surface_font_family: r#""Maple Mono NF CN", monospace"#.into(),
             external_file_auto_save: true,
             remember_surface_size: true,
+            tile_ctrl_close: false,
             surface_width: None,
             surface_height: None,
         };
@@ -959,6 +996,18 @@ mod tests {
         assert_eq!(loaded.theme, "system");
         assert_eq!(loaded.font_size, 14);
         assert_eq!(loaded.surface_font_size, 14);
+        assert_eq!(
+            loaded.ui_font_family,
+            r#""Noto Sans SC", "Source Han Sans SC", system-ui, sans-serif"#
+        );
+        assert_eq!(
+            loaded.font_family,
+            r#""Noto Sans SC", "Source Han Sans SC", system-ui, sans-serif"#
+        );
+        assert_eq!(
+            loaded.surface_font_family,
+            r#""Noto Sans SC", "Source Han Sans SC", system-ui, sans-serif"#
+        );
     }
 
     #[test]

--- a/src/App.css
+++ b/src/App.css
@@ -47,15 +47,29 @@ html.theme-transition,
 html.theme-transition *,
 html.theme-transition *::before,
 html.theme-transition *::after {
-  transition: color 0.35s ease, background-color 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease, fill 0.35s ease, stroke 0.35s ease !important;
+  transition:
+    color 0.35s ease,
+    background-color 0.35s ease,
+    border-color 0.35s ease,
+    box-shadow 0.35s ease,
+    fill 0.35s ease,
+    stroke 0.35s ease !important;
   transition-delay: 0s !important;
 }
 html.theme-transition .sliding-highlight {
-  transition: left 0.25s cubic-bezier(0.22,1,0.36,1), top 0.25s cubic-bezier(0.22,1,0.36,1), width 0.25s cubic-bezier(0.22,1,0.36,1), height 0.25s cubic-bezier(0.22,1,0.36,1), background-color 0.35s ease, box-shadow 0.35s ease !important;
+  transition:
+    left 0.25s cubic-bezier(0.22, 1, 0.36, 1),
+    top 0.25s cubic-bezier(0.22, 1, 0.36, 1),
+    width 0.25s cubic-bezier(0.22, 1, 0.36, 1),
+    height 0.25s cubic-bezier(0.22, 1, 0.36, 1),
+    background-color 0.35s ease,
+    box-shadow 0.35s ease !important;
 }
 
 /* Global resets */
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
 }
 
@@ -64,21 +78,37 @@ html {
   -moz-osx-font-smoothing: grayscale;
 }
 
-::-webkit-scrollbar { width: 4px; }
-::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: var(--color-ink-ghost); border-radius: 2px; }
-::-webkit-scrollbar-thumb:hover { background: var(--color-ink-faint); }
+::-webkit-scrollbar {
+  width: 4px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: var(--color-ink-ghost);
+  border-radius: 2px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: var(--color-ink-faint);
+}
 
-.scrollbar-hidden::-webkit-scrollbar { display: none; }
-.scrollbar-hidden { -ms-overflow-style: none; scrollbar-width: none; }
+.scrollbar-hidden::-webkit-scrollbar {
+  display: none;
+}
+.scrollbar-hidden {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
 
-textarea, input {
+textarea,
+input {
   resize: none;
   outline: none;
   border: none;
   background: transparent;
 }
-textarea::placeholder, input::placeholder {
+textarea::placeholder,
+input::placeholder {
   color: var(--color-ink-ghost);
 }
 
@@ -101,39 +131,87 @@ textarea::placeholder, input::placeholder {
 
 /* Animations */
 @keyframes fade-up {
-  from { opacity: 0; transform: translateY(14px); }
-  to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 @keyframes scale-in {
-  from { opacity: 0; transform: scale(0.95); }
-  to { opacity: 1; transform: scale(1); }
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 @keyframes shimmer {
-  0%, 100% { opacity: 0.4; }
-  50% { opacity: 0.7; }
+  0%,
+  100% {
+    opacity: 0.4;
+  }
+  50% {
+    opacity: 0.7;
+  }
 }
 @keyframes float-gentle {
-  0%, 100% { transform: translateY(0) rotate(0deg); }
-  50% { transform: translateY(-6px) rotate(0.3deg); }
+  0%,
+  100% {
+    transform: translateY(0) rotate(0deg);
+  }
+  50% {
+    transform: translateY(-6px) rotate(0.3deg);
+  }
 }
 @keyframes dash-draw {
-  to { stroke-dashoffset: 0; }
+  to {
+    stroke-dashoffset: 0;
+  }
 }
 @keyframes window-enter {
-  from { opacity: 0; transform: scale(0.96); }
-  to { opacity: 1; transform: scale(1); }
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 @keyframes window-exit {
-  from { opacity: 1; transform: scale(1); }
-  to { opacity: 0; transform: scale(0.96); }
+  from {
+    opacity: 1;
+    transform: scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: scale(0.96);
+  }
 }
 @keyframes menu-enter {
-  from { opacity: 0; transform: translateY(4px) scale(0.97); }
-  to { opacity: 1; transform: translateY(0) scale(1); }
+  from {
+    opacity: 0;
+    transform: translateY(4px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
 }
 @keyframes menu-exit {
-  from { opacity: 1; transform: translateY(0) scale(1); }
-  to { opacity: 0; transform: translateY(4px) scale(0.97); }
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(4px) scale(0.97);
+  }
 }
 
 .animate-fade-up {
@@ -160,12 +238,24 @@ textarea::placeholder, input::placeholder {
   pointer-events: none;
 }
 @keyframes menu-slide-left {
-  from { opacity: 0; transform: translateX(8px); }
-  to { opacity: 1; transform: translateX(0); }
+  from {
+    opacity: 0;
+    transform: translateX(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
 }
 @keyframes menu-slide-right {
-  from { opacity: 0; transform: translateX(-8px); }
-  to { opacity: 1; transform: translateX(0); }
+  from {
+    opacity: 0;
+    transform: translateX(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
 }
 .animate-menu-slide-left {
   animation: menu-slide-left 0.15s cubic-bezier(0.22, 1, 0.36, 1) forwards;
@@ -174,22 +264,36 @@ textarea::placeholder, input::placeholder {
   animation: menu-slide-right 0.15s cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }
 @keyframes fade-in {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 .animate-fade-in {
   animation: fade-in 0.25s ease-out forwards;
 }
 @keyframes note-enter {
-  from { opacity: 0; transform: translateY(6px); }
-  to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 .animate-note-enter {
   animation: note-enter 0.6s cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }
 @keyframes view-fade {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 .animate-view-fade {
   animation: view-fade 0.72s ease-out forwards;
@@ -200,7 +304,9 @@ textarea::placeholder, input::placeholder {
   display: grid;
   grid-template-rows: 0fr;
   opacity: 0;
-  transition: grid-template-rows 0.25s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.2s ease;
+  transition:
+    grid-template-rows 0.25s cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 0.2s ease;
 }
 .category-body.expanded {
   grid-template-rows: 1fr;
@@ -212,12 +318,24 @@ textarea::placeholder, input::placeholder {
 
 /* Delete confirm inline pop */
 @keyframes delete-confirm-enter {
-  from { opacity: 0; transform: scale(0.9); }
-  to { opacity: 1; transform: scale(1); }
+  from {
+    opacity: 0;
+    transform: scale(0.9);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 @keyframes delete-confirm-exit {
-  from { opacity: 1; transform: scale(1); }
-  to { opacity: 0; transform: scale(0.9); }
+  from {
+    opacity: 1;
+    transform: scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: scale(0.9);
+  }
 }
 .animate-delete-confirm {
   animation: delete-confirm-enter 0.18s cubic-bezier(0.22, 1, 0.36, 1) forwards;
@@ -229,8 +347,12 @@ textarea::placeholder, input::placeholder {
 
 /* Save status crossfade */
 @keyframes status-fade {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 .animate-status-fade {
   animation: status-fade 0.25s ease-out forwards;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,11 +5,7 @@ import { MainWindow } from "./components/MainWindow";
 import { NotePad } from "./components/NotePad";
 import { TileShowcase } from "./components/TileShowcase";
 import { getConfig } from "./features/settings/api";
-import {
-  applyTheme,
-  applyUiFontFamily,
-  watchSystemTheme,
-} from "./features/settings/theme";
+import { applyTheme, applyUiFontFamily, watchSystemTheme } from "./features/settings/theme";
 import type { AppConfig, ThemeOption } from "./features/settings/types";
 import { getInitialRoute } from "./features/windows/windowRoutes";
 import { listen } from "@tauri-apps/api/event";
@@ -50,8 +46,7 @@ function App() {
       }
     };
     document.addEventListener("keydown", preventSystemMenu, true);
-    return () =>
-      document.removeEventListener("keydown", preventSystemMenu, true);
+    return () => document.removeEventListener("keydown", preventSystemMenu, true);
   }, []);
 
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,11 @@ import { MainWindow } from "./components/MainWindow";
 import { NotePad } from "./components/NotePad";
 import { TileShowcase } from "./components/TileShowcase";
 import { getConfig } from "./features/settings/api";
-import { applyTheme, watchSystemTheme } from "./features/settings/theme";
+import {
+  applyTheme,
+  applyUiFontFamily,
+  watchSystemTheme,
+} from "./features/settings/theme";
 import type { AppConfig, ThemeOption } from "./features/settings/types";
 import { getInitialRoute } from "./features/windows/windowRoutes";
 import { listen } from "@tauri-apps/api/event";
@@ -20,6 +24,7 @@ function App() {
       .then((config) => {
         const theme = (config.theme || "system") as ThemeOption;
         applyTheme(theme);
+        applyUiFontFamily(config.uiFontFamily);
         cleanup = watchSystemTheme(theme);
       })
       .catch(() => {});
@@ -30,6 +35,7 @@ function App() {
     const unlisten = listen<AppConfig>("config-changed", (event) => {
       const theme = (event.payload.theme || "system") as ThemeOption;
       applyTheme(theme);
+      applyUiFontFamily(event.payload.uiFontFamily);
       watchSystemTheme(theme);
     });
     return () => {

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -20,21 +20,23 @@ export function ContextMenuProvider({ children }: { children: React.ReactNode })
 
   useEffect(() => {
     getConfig()
-      .then((c) => { tileCtrlCloseRef.current = c.tileCtrlClose ?? true; })
+      .then((c) => {
+        tileCtrlCloseRef.current = c.tileCtrlClose ?? true;
+      })
       .catch(() => {});
     const unlisten = listen<AppConfig>("config-changed", (event) => {
       tileCtrlCloseRef.current = event.payload.tileCtrlClose ?? true;
     });
-    return () => { void unlisten.then((fn) => fn()); };
+    return () => {
+      void unlisten.then((fn) => fn());
+    };
   }, []);
 
   useEffect(() => {
     function handleContextMenu(event: MouseEvent) {
       const target = event.target as HTMLElement;
       const isEditable =
-        target.tagName === "TEXTAREA" ||
-        target.tagName === "INPUT" ||
-        target.isContentEditable;
+        target.tagName === "TEXTAREA" || target.tagName === "INPUT" || target.isContentEditable;
       const tileTarget = target.closest<HTMLElement>('[data-context-menu="tile"]');
 
       if (!isEditable && !tileTarget) {
@@ -108,9 +110,7 @@ export function ContextMenuProvider({ children }: { children: React.ReactNode })
     dismissMenu();
   };
 
-  const runSurfaceAction = (
-    action: (typeof tileContextMenuItems)[number]["action"],
-  ) => {
+  const runSurfaceAction = (action: (typeof tileContextMenuItems)[number]["action"]) => {
     requestSurfaceAction(action);
     dismissMenu();
   };

--- a/src/components/MainWindow.test.tsx
+++ b/src/components/MainWindow.test.tsx
@@ -20,6 +20,9 @@ describe("MainWindow settings", () => {
           theme: "light",
           fontSize: 14,
           surfaceFontSize: 14,
+          uiFontFamily: '"LXGW WenKai", serif',
+          fontFamily: '"LXGW WenKai", serif',
+          surfaceFontFamily: '"Maple Mono NF CN", monospace',
           externalFileAutoSave: true,
           rememberSurfaceSize: true,
           tileCtrlClose: true,
@@ -42,9 +45,9 @@ describe("MainWindow settings", () => {
   test("renders the import Markdown icon as a down arrow", () => {
     const markup = renderToStaticMarkup(<MainWindow />);
 
-    expect(markup).toContain('d="M12 21V9"');
-    expect(markup).toContain('d="m7 16 5 5 5-5"');
-    expect(markup).toContain('d="M5 3h14"');
+    expect(markup).toContain('d="M12 3v12"');
+    expect(markup).toContain('d="m7 10 5 5 5-5"');
+    expect(markup).toContain('d="M5 21h14"');
     expect(markup).not.toContain('d="m7 8 5-5 5 5"');
   });
 });

--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -75,7 +75,17 @@ const saveStateLabel: Record<SaveState, string> = {
   error: "保存失败",
 };
 
-type FormatAction = "bold" | "italic" | "heading" | "hr" | "ul" | "ol" | "code" | "quote" | "inlineMath" | "blockMath";
+type FormatAction =
+  | "bold"
+  | "italic"
+  | "heading"
+  | "hr"
+  | "ul"
+  | "ol"
+  | "code"
+  | "quote"
+  | "inlineMath"
+  | "blockMath";
 
 const toolbarButtons: { label: string; title: string; style: string; action: FormatAction }[] = [
   { label: "B", title: "粗体", style: "font-bold", action: "bold" },
@@ -157,7 +167,10 @@ function applyFormat(
     }
     case "ul": {
       if (selected.includes("\n")) {
-        const lines = selected.split("\n").map((l) => `- ${l}`).join("\n");
+        const lines = selected
+          .split("\n")
+          .map((l) => `- ${l}`)
+          .join("\n");
         result = before + lines + after;
         cursorStart = start;
         cursorEnd = start + lines.length;
@@ -171,7 +184,10 @@ function applyFormat(
     }
     case "ol": {
       if (selected.includes("\n")) {
-        const lines = selected.split("\n").map((l, i) => `${i + 1}. ${l}`).join("\n");
+        const lines = selected
+          .split("\n")
+          .map((l, i) => `${i + 1}. ${l}`)
+          .join("\n");
         result = before + lines + after;
         cursorStart = start;
         cursorEnd = start + lines.length;
@@ -199,7 +215,10 @@ function applyFormat(
     }
     case "quote": {
       if (selected.includes("\n")) {
-        const lines = selected.split("\n").map((l) => `> ${l}`).join("\n");
+        const lines = selected
+          .split("\n")
+          .map((l) => `> ${l}`)
+          .join("\n");
         result = before + lines + after;
         cursorStart = start;
         cursorEnd = start + lines.length;
@@ -272,9 +291,7 @@ export function MainWindow({
   const [noteMenu, setNoteMenu] = useState<NoteMenuState | null>(null);
   const [noteMenuClosing, setNoteMenuClosing] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(initialSettingsOpen);
-  const [settingsConfig, setSettingsConfig] = useState<AppConfig | null>(
-    initialConfig ?? null,
-  );
+  const [settingsConfig, setSettingsConfig] = useState<AppConfig | null>(initialConfig ?? null);
   const [savedNotesDir, setSavedNotesDir] = useState<string | null>(
     initialConfig?.notesDir ?? null,
   );
@@ -319,10 +336,7 @@ export function MainWindow({
     [noteMenu?.noteId, notes],
   );
 
-  const filteredNotes = useMemo(
-    () => filterNotes(notes, searchQuery),
-    [notes, searchQuery],
-  );
+  const filteredNotes = useMemo(() => filterNotes(notes, searchQuery), [notes, searchQuery]);
 
   const categoryGroups = useMemo(
     () => groupNotesByCategory(filteredNotes, categories),
@@ -352,9 +366,7 @@ export function MainWindow({
       const next = exists
         ? current.map((item) => (item.id === metadata.id ? metadata : item))
         : [metadata, ...current];
-      return [...next].sort((left, right) =>
-        right.updatedAt.localeCompare(left.updatedAt),
-      );
+      return [...next].sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
     });
   }, []);
 
@@ -369,10 +381,7 @@ export function MainWindow({
   );
 
   const refreshNotes = useCallback(async () => {
-    const [loadedNotes, loadedCategories] = await Promise.all([
-      listNotes(),
-      listCategories(),
-    ]);
+    const [loadedNotes, loadedCategories] = await Promise.all([listNotes(), listCategories()]);
     setNotes(loadedNotes);
     setCategories(loadedCategories);
     return loadedNotes;
@@ -584,7 +593,15 @@ export function MainWindow({
       setErrorMessage(getErrorMessage(error));
       return null;
     }
-  }, [content, isExternal, replaceNoteMetadata, selectedExternalFile, selectedId, selectedNote, title]);
+  }, [
+    content,
+    isExternal,
+    replaceNoteMetadata,
+    selectedExternalFile,
+    selectedId,
+    selectedNote,
+    title,
+  ]);
 
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
@@ -611,7 +628,14 @@ export function MainWindow({
     }, 900);
 
     return () => window.clearTimeout(timer);
-  }, [isExternal, saveCurrentNote, saveState, selectedId, settingsConfig?.noteAutoSave, settingsConfig?.externalFileAutoSave]);
+  }, [
+    isExternal,
+    saveCurrentNote,
+    saveState,
+    selectedId,
+    settingsConfig?.noteAutoSave,
+    settingsConfig?.externalFileAutoSave,
+  ]);
 
   const handleNewNote = async () => {
     setErrorMessage(null);
@@ -804,10 +828,7 @@ export function MainWindow({
     }
   };
 
-  const handleOpenNoteMenu = (
-    event: MouseEvent<HTMLElement>,
-    noteId: string,
-  ) => {
+  const handleOpenNoteMenu = (event: MouseEvent<HTMLElement>, noteId: string) => {
     event.preventDefault();
     event.stopPropagation();
 
@@ -1026,9 +1047,7 @@ export function MainWindow({
   };
 
   const toggleMaximize = () => {
-    void toggleMaximizeCurrentWindow().then(() =>
-      isCurrentWindowMaximized().then(setIsMaximized),
-    );
+    void toggleMaximizeCurrentWindow().then(() => isCurrentWindowMaximized().then(setIsMaximized));
   };
 
   const handleTitleBarDoubleClick = (event: MouseEvent<HTMLDivElement>) => {
@@ -1127,12 +1146,26 @@ export function MainWindow({
               title={isMaximized ? "还原" : "最大化"}
             >
               {isMaximized ? (
-                <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.2">
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 12 12"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.2"
+                >
                   <rect x="3" y="3" width="7" height="7" rx="1" />
                   <path d="M3 5H2V2a1 1 0 0 1 1-1h5v1" />
                 </svg>
               ) : (
-                <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.2">
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 12 12"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.2"
+                >
                   <rect x="1.5" y="1.5" width="9" height="9" rx="1.5" />
                 </svg>
               )}
@@ -1142,7 +1175,15 @@ export function MainWindow({
               className="w-11 h-11 flex items-center justify-center text-ink-ghost hover:text-red-500 hover:bg-danger-bg transition-all cursor-pointer"
               title="关闭"
             >
-              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+              <svg
+                width="12"
+                height="12"
+                viewBox="0 0 12 12"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              >
                 <path d="M2 2l8 8M10 2l-8 8" />
               </svg>
             </button>
@@ -1243,14 +1284,23 @@ export function MainWindow({
 
             <div className="flex items-center justify-between px-5 pb-1.5 shrink-0">
               <span className="text-[10px] text-ink-ghost font-mono tracking-wider uppercase">
-                {filteredNotes.length} 篇笔记{externalFiles.length > 0 ? ` · ${externalFiles.length} 个外部文件` : ""}
+                {filteredNotes.length} 篇笔记
+                {externalFiles.length > 0 ? ` · ${externalFiles.length} 个外部文件` : ""}
               </span>
               <button
                 onClick={() => setShowCategoryInput(true)}
                 className="text-[10px] text-ink-ghost hover:text-bamboo transition-colors cursor-pointer"
                 title="新建分类"
               >
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                >
                   <path d="M12 5v14M5 12h14" />
                 </svg>
               </button>
@@ -1302,9 +1352,11 @@ export function MainWindow({
                                 : "bg-transparent"
                           }`}
                         >
-                          <div className={`absolute left-0 top-1/2 -translate-y-1/2 w-[3px] rounded-r-full bg-bamboo/60 transition-all duration-[600ms] ${
-                            isSelected ? "h-5 opacity-100" : "h-0 opacity-0"
-                          }`} />
+                          <div
+                            className={`absolute left-0 top-1/2 -translate-y-1/2 w-[3px] rounded-r-full bg-bamboo/60 transition-all duration-[600ms] ${
+                              isSelected ? "h-5 opacity-100" : "h-0 opacity-0"
+                            }`}
+                          />
 
                           <div className="flex items-baseline justify-between mb-0.5">
                             <span
@@ -1312,7 +1364,17 @@ export function MainWindow({
                                 isSelected ? "text-bamboo" : "text-ink-soft"
                               }`}
                             >
-                              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="shrink-0 opacity-60">
+                              <svg
+                                width="12"
+                                height="12"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                className="shrink-0 opacity-60"
+                              >
                                 <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
                                 <polyline points="14 2 14 8 20 8" />
                               </svg>
@@ -1326,7 +1388,15 @@ export function MainWindow({
                               className="opacity-0 group-hover:opacity-100 text-ink-ghost hover:text-red-400 transition-all p-0.5"
                               title="从列表移除"
                             >
-                              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                              <svg
+                                width="12"
+                                height="12"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                                strokeLinecap="round"
+                              >
                                 <line x1="18" y1="6" x2="6" y2="18" />
                                 <line x1="6" y1="6" x2="18" y2="18" />
                               </svg>
@@ -1348,9 +1418,7 @@ export function MainWindow({
                       <div
                         key="__uncategorized__"
                         className={`rounded-lg transition-all duration-200 ${
-                          dragOverCategory === ""
-                            ? "bg-bamboo/10 ring-1 ring-bamboo/20"
-                            : ""
+                          dragOverCategory === "" ? "bg-bamboo/10 ring-1 ring-bamboo/20" : ""
                         }`}
                         onDragOver={(e) => {
                           e.preventDefault();
@@ -1392,13 +1460,17 @@ export function MainWindow({
                                     : "bg-transparent"
                               }`}
                             >
-                              <div className={`absolute left-0 top-1/2 -translate-y-1/2 w-[3px] rounded-r-full bg-bamboo/60 transition-all duration-[600ms] ${
-                                isSelected ? "h-5 opacity-100" : "h-0 opacity-0"
-                              }`} />
+                              <div
+                                className={`absolute left-0 top-1/2 -translate-y-1/2 w-[3px] rounded-r-full bg-bamboo/60 transition-all duration-[600ms] ${
+                                  isSelected ? "h-5 opacity-100" : "h-0 opacity-0"
+                                }`}
+                              />
                               <div className="flex items-baseline justify-between mb-0.5">
-                                <span className={`text-[13px] font-display font-medium truncate pr-2 transition-colors ${
-                                  isSelected ? "text-bamboo" : "text-ink-soft"
-                                }`}>
+                                <span
+                                  className={`text-[13px] font-display font-medium truncate pr-2 transition-colors ${
+                                    isSelected ? "text-bamboo" : "text-ink-soft"
+                                  }`}
+                                >
                                   {getDisplayTitle(note)}
                                 </span>
                                 <span className="text-[10px] text-ink-ghost font-mono tabular-nums shrink-0">
@@ -1532,64 +1604,68 @@ export function MainWindow({
                             <div className="px-3 py-3 text-center text-[11px] text-ink-ghost/50">
                               空文件夹
                             </div>
-                          ) : group.notes.map((note) => {
-                            const isSelected = note.id === selectedId;
-                            const isHovered = note.id === hoveredId;
+                          ) : (
+                            group.notes.map((note) => {
+                              const isSelected = note.id === selectedId;
+                              const isHovered = note.id === hoveredId;
 
-                            return (
-                              <div
-                                key={note.id}
-                                draggable
-                                onDragStart={(e) => {
-                                  e.dataTransfer.setData("text/plain", note.id);
-                                  e.dataTransfer.effectAllowed = "move";
-                                }}
-                                onClick={() => void handleSelectNote(note.id)}
-                                onContextMenu={(event) => handleOpenNoteMenu(event, note.id)}
-                                onMouseEnter={() => setHoveredId(note.id)}
-                                onMouseLeave={() => setHoveredId(null)}
-                                className={`w-full text-left rounded-lg mx-1 px-2.5 py-2 transition-all duration-[600ms] cursor-pointer group relative ${
-                                  isSelected
-                                    ? "bg-bamboo-mist/70"
-                                    : isHovered
-                                      ? "bg-paper-warm/70"
-                                      : "bg-transparent"
-                                }`}
-                                style={{ width: "calc(100% - 8px)" }}
-                              >
-                                <div className={`absolute left-0 top-1/2 -translate-y-1/2 w-[3px] rounded-r-full bg-bamboo/60 transition-all duration-[600ms] ${
-                                  isSelected ? "h-5 opacity-100" : "h-0 opacity-0"
-                                }`} />
-
-                                <div className="flex items-baseline justify-between mb-0.5">
-                                  <span
-                                    className={`text-[13px] font-display font-medium truncate pr-2 transition-colors ${
-                                      isSelected ? "text-bamboo" : "text-ink-soft"
+                              return (
+                                <div
+                                  key={note.id}
+                                  draggable
+                                  onDragStart={(e) => {
+                                    e.dataTransfer.setData("text/plain", note.id);
+                                    e.dataTransfer.effectAllowed = "move";
+                                  }}
+                                  onClick={() => void handleSelectNote(note.id)}
+                                  onContextMenu={(event) => handleOpenNoteMenu(event, note.id)}
+                                  onMouseEnter={() => setHoveredId(note.id)}
+                                  onMouseLeave={() => setHoveredId(null)}
+                                  className={`w-full text-left rounded-lg mx-1 px-2.5 py-2 transition-all duration-[600ms] cursor-pointer group relative ${
+                                    isSelected
+                                      ? "bg-bamboo-mist/70"
+                                      : isHovered
+                                        ? "bg-paper-warm/70"
+                                        : "bg-transparent"
+                                  }`}
+                                  style={{ width: "calc(100% - 8px)" }}
+                                >
+                                  <div
+                                    className={`absolute left-0 top-1/2 -translate-y-1/2 w-[3px] rounded-r-full bg-bamboo/60 transition-all duration-[600ms] ${
+                                      isSelected ? "h-5 opacity-100" : "h-0 opacity-0"
                                     }`}
-                                  >
-                                    {getDisplayTitle(note)}
-                                  </span>
-                                  <span className="text-[10px] text-ink-ghost font-mono tabular-nums shrink-0">
-                                    {formatShortDate(note.updatedAt)}
-                                  </span>
-                                </div>
+                                  />
 
-                                <p className="text-[11px] text-ink-ghost leading-relaxed line-clamp-2 group-hover:text-ink-faint transition-colors">
-                                  {note.preview || "空白笔记"}
-                                </p>
+                                  <div className="flex items-baseline justify-between mb-0.5">
+                                    <span
+                                      className={`text-[13px] font-display font-medium truncate pr-2 transition-colors ${
+                                        isSelected ? "text-bamboo" : "text-ink-soft"
+                                      }`}
+                                    >
+                                      {getDisplayTitle(note)}
+                                    </span>
+                                    <span className="text-[10px] text-ink-ghost font-mono tabular-nums shrink-0">
+                                      {formatShortDate(note.updatedAt)}
+                                    </span>
+                                  </div>
 
-                                <div className="flex items-center gap-2 mt-1">
-                                  <span className="text-[10px] text-ink-ghost/60 font-mono tabular-nums">
-                                    {formatTime(note.updatedAt)}
-                                  </span>
-                                  <span className="text-[10px] text-ink-ghost/40">·</span>
-                                  <span className="text-[10px] text-ink-ghost/60 font-mono tabular-nums">
-                                    {note.wordCount} 字
-                                  </span>
+                                  <p className="text-[11px] text-ink-ghost leading-relaxed line-clamp-2 group-hover:text-ink-faint transition-colors">
+                                    {note.preview || "空白笔记"}
+                                  </p>
+
+                                  <div className="flex items-center gap-2 mt-1">
+                                    <span className="text-[10px] text-ink-ghost/60 font-mono tabular-nums">
+                                      {formatTime(note.updatedAt)}
+                                    </span>
+                                    <span className="text-[10px] text-ink-ghost/40">·</span>
+                                    <span className="text-[10px] text-ink-ghost/60 font-mono tabular-nums">
+                                      {note.wordCount} 字
+                                    </span>
+                                  </div>
                                 </div>
-                              </div>
-                            );
-                          })}
+                              );
+                            })
+                          )}
                         </div>
                       </div>
                     </div>
@@ -1613,7 +1689,9 @@ export function MainWindow({
                 setIsResizingSidebar(true);
               }}
             >
-              <div className={`absolute inset-y-0 -left-1 -right-1 ${isResizingSidebar ? "" : "group-hover:bg-bamboo/5"}`} />
+              <div
+                className={`absolute inset-y-0 -left-1 -right-1 ${isResizingSidebar ? "" : "group-hover:bg-bamboo/5"}`}
+              />
             </div>
           )}
 
@@ -1698,7 +1776,9 @@ export function MainWindow({
                 </button>
 
                 {deleteConfirm ? (
-                  <div className={`flex items-center gap-1 ml-1 ${deleteExiting ? "animate-delete-confirm-exit" : "animate-delete-confirm"}`}>
+                  <div
+                    className={`flex items-center gap-1 ml-1 ${deleteExiting ? "animate-delete-confirm-exit" : "animate-delete-confirm"}`}
+                  >
                     <span className="text-[11px] text-red-400 whitespace-nowrap">确认删除？</span>
                     <button
                       onClick={() => {
@@ -1762,7 +1842,10 @@ export function MainWindow({
               />
             </div>
 
-            <div key={noteTransitionKey} className="animate-note-enter px-6 pt-4 pb-2 shrink-0 border-b border-paper-deep/15">
+            <div
+              key={noteTransitionKey}
+              className="animate-note-enter px-6 pt-4 pb-2 shrink-0 border-b border-paper-deep/15"
+            >
               <input
                 type="text"
                 value={title}
@@ -1808,7 +1891,11 @@ export function MainWindow({
               </div>
             </div>
 
-            <div key={viewMode} ref={splitContainerRef} className="flex-1 flex min-h-0 animate-view-fade">
+            <div
+              key={viewMode}
+              ref={splitContainerRef}
+              className="flex-1 flex min-h-0 animate-view-fade"
+            >
               {!selectedId && !isLoading ? (
                 <div className="flex-1 flex items-center justify-center text-[13px] text-ink-ghost">
                   选择或新建一篇笔记
@@ -1828,7 +1915,12 @@ export function MainWindow({
                             onMouseDown={(e) => e.preventDefault()}
                             onClick={() => {
                               if (contentRef.current) {
-                                applyFormat(contentRef.current, button.action, setContent, markDirty);
+                                applyFormat(
+                                  contentRef.current,
+                                  button.action,
+                                  setContent,
+                                  markDirty,
+                                );
                               }
                             }}
                             className={`w-6 h-6 flex items-center justify-center rounded text-[11px] text-ink-ghost hover:text-ink-faint hover:bg-paper-warm transition-all cursor-pointer ${button.style}`}
@@ -1847,7 +1939,10 @@ export function MainWindow({
                             markDirty();
                           }}
                           className="w-full h-full leading-[1.9] text-ink-soft font-mono placeholder:text-ink-ghost/40"
-                          style={{ fontSize: `${settingsConfig?.fontSize ?? 14}px` }}
+                          style={{
+                            fontSize: `${settingsConfig?.fontSize ?? 14}px`,
+                            fontFamily: settingsConfig?.fontFamily,
+                          }}
                           placeholder="开始写作……"
                           spellCheck={false}
                           disabled={!selectedId}
@@ -1864,14 +1959,14 @@ export function MainWindow({
                         setIsResizingSplit(true);
                       }}
                     >
-                      <div className={`absolute inset-y-0 -left-1 -right-1 ${isResizingSplit ? "" : "group-hover:bg-bamboo/5"}`} />
+                      <div
+                        className={`absolute inset-y-0 -left-1 -right-1 ${isResizingSplit ? "" : "group-hover:bg-bamboo/5"}`}
+                      />
                     </div>
                   )}
 
                   {(viewMode === "preview" || viewMode === "split") && (
-                    <div
-                      className="flex flex-col min-h-0 min-w-0 flex-1"
-                    >
+                    <div className="flex flex-col min-h-0 min-w-0 flex-1">
                       {viewMode === "split" && (
                         <div className="px-4 pt-2.5 pb-1 shrink-0">
                           <span className="text-[10px] text-ink-ghost/60 font-mono tracking-widest uppercase">
@@ -1884,7 +1979,11 @@ export function MainWindow({
                           viewMode === "preview" ? "pt-3" : "pt-1"
                         }`}
                       >
-                        <MarkdownPreview content={content} fontSize={settingsConfig?.fontSize ?? 14} />
+                        <MarkdownPreview
+                          content={content}
+                          fontSize={settingsConfig?.fontSize ?? 14}
+                          fontFamily={settingsConfig?.fontFamily}
+                        />
                       </div>
                     </div>
                   )}
@@ -1898,14 +1997,10 @@ export function MainWindow({
                   Ln {lineCount}
                 </span>
                 <span className="text-[10px] text-ink-ghost/40">|</span>
-                <span className="text-[10px] text-ink-ghost font-mono">
-                  Markdown + LaTeX
-                </span>
+                <span className="text-[10px] text-ink-ghost font-mono">Markdown + LaTeX</span>
               </div>
               <div className="flex items-center gap-3">
-                <span className="text-[10px] text-ink-ghost font-mono">
-                  UTF-8
-                </span>
+                <span className="text-[10px] text-ink-ghost font-mono">UTF-8</span>
                 <span className="text-[10px] text-ink-ghost/40">|</span>
                 <span className="text-[10px] text-ink-ghost font-mono tabular-nums">
                   {byteSize} KB
@@ -1914,9 +2009,11 @@ export function MainWindow({
             </div>
           </div>
           {settingsConfig && (
-            <div className={`relative shrink-0 transition-all duration-[600ms] overflow-hidden h-full ${
-              settingsOpen ? "w-[360px]" : "w-0"
-            }`}>
+            <div
+              className={`relative shrink-0 transition-all duration-[600ms] overflow-hidden h-full ${
+                settingsOpen ? "w-[360px]" : "w-0"
+              }`}
+            >
               <div className="w-[360px] h-full">
                 <SettingsPanel
                   config={settingsConfig}
@@ -1957,7 +2054,16 @@ export function MainWindow({
                 onClick={() => setNoteMenuMode("main")}
                 className="w-full flex items-center gap-1.5 px-3 py-1.5 text-[12px] font-body text-ink-ghost hover:bg-paper-warm transition-colors cursor-pointer border-b border-paper-deep/20"
               >
-                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <svg
+                  width="10"
+                  height="10"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
                   <polyline points="15 18 9 12 15 6" />
                 </svg>
                 <span>返回</span>

--- a/src/components/NotePad.tsx
+++ b/src/components/NotePad.tsx
@@ -1,12 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { MouseEvent } from "react";
-import {
-  createNote,
-  getErrorMessage,
-  getNote,
-  listNotes,
-  updateNote,
-} from "../features/notes/api";
+import { createNote, getErrorMessage, getNote, listNotes, updateNote } from "../features/notes/api";
 import type { Note, NoteMetadata } from "../features/notes/types";
 import {
   countNoteChars,
@@ -54,6 +48,7 @@ interface NotePadProps {
   initialSurfaceMode?: NoteSurfaceMode;
   initialAutoSave?: boolean;
   initialTileColor?: string;
+  initialSurfaceFontFamily?: string;
 }
 
 const surfaceResizeHandles: Array<{
@@ -94,9 +89,7 @@ function SurfaceResizeHandles() {
           data-resize-direction={handle.direction}
           onMouseDown={(event) => {
             event.stopPropagation();
-            void startCurrentWindowResize(handle.direction).catch(
-              () => undefined,
-            );
+            void startCurrentWindowResize(handle.direction).catch(() => undefined);
           }}
           className={`absolute ${handle.size} opacity-0 ${handle.className}`}
         />
@@ -110,9 +103,9 @@ export function NotePad({
   initialSurfaceMode = "pad",
   initialAutoSave = true,
   initialTileColor = DEFAULT_TILE_COLOR,
+  initialSurfaceFontFamily = undefined,
 }: NotePadProps) {
-  const [surfaceMode, setSurfaceMode] =
-    useState<NoteSurfaceMode>(initialSurfaceMode);
+  const [surfaceMode, setSurfaceMode] = useState<NoteSurfaceMode>(initialSurfaceMode);
   const [mode, setMode] = useState<OpenMode>("new");
   const [notes, setNotes] = useState<NoteMetadata[]>([]);
   const [editingNoteId, setEditingNoteId] = useState<string | null>(null);
@@ -121,13 +114,13 @@ export function NotePad({
   const [hoveredNote, setHoveredNote] = useState<string | null>(null);
   const [status, setStatus] = useState("空");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [noteSurfaceAutoSave, setNoteSurfaceAutoSave] =
-    useState(initialAutoSave);
-  const [tileColorRaw, setTileColorRaw] = useState(
-    normalizeTileColor(initialTileColor),
-  );
+  const [noteSurfaceAutoSave, setNoteSurfaceAutoSave] = useState(initialAutoSave);
+  const [tileColorRaw, setTileColorRaw] = useState(normalizeTileColor(initialTileColor));
   const [tileColorMode, setTileColorMode] = useState<TileColorMode>("system");
   const [surfaceFontSize, setSurfaceFontSize] = useState(14);
+  const [surfaceFontFamily, setSurfaceFontFamily] = useState<string | undefined>(
+    initialSurfaceFontFamily,
+  );
   const [tileColor, setTileColor] = useState(() =>
     resolveTileColor("system", normalizeTileColor(initialTileColor)),
   );
@@ -162,13 +155,11 @@ export function NotePad({
         if (!cancelled) {
           setNoteSurfaceAutoSave(loadedConfig.noteSurfaceAutoSave);
           setSurfaceFontSize(loadedConfig.surfaceFontSize ?? 14);
+          setSurfaceFontFamily(loadedConfig.surfaceFontFamily);
           setTileColorRaw(normalizeTileColor(loadedConfig.tileColor));
           setTileColorMode(loadedConfig.tileColorMode ?? "system");
           setTileColor(
-            resolveTileColor(
-              loadedConfig.tileColorMode ?? "system",
-              loadedConfig.tileColor,
-            ),
+            resolveTileColor(loadedConfig.tileColorMode ?? "system", loadedConfig.tileColor),
           );
         }
         if (initialNoteId) {
@@ -218,6 +209,7 @@ export function NotePad({
       tileColor?: string;
       tileColorMode?: TileColorMode;
       surfaceFontSize?: number;
+      surfaceFontFamily?: string;
     }>("config-changed", (event) => {
       const mode = event.payload.tileColorMode ?? tileColorMode;
       const raw = event.payload.tileColor ?? tileColorRaw;
@@ -225,6 +217,8 @@ export function NotePad({
       setTileColorRaw(normalizeTileColor(raw));
       setTileColor(resolveTileColor(mode, raw));
       if (event.payload.surfaceFontSize != null) setSurfaceFontSize(event.payload.surfaceFontSize);
+      if (event.payload.surfaceFontFamily != null)
+        setSurfaceFontFamily(event.payload.surfaceFontFamily);
     });
     return () => {
       void unlisten.then((fn) => fn());
@@ -288,9 +282,7 @@ export function NotePad({
       const next = exists
         ? current.map((item) => (item.id === note.id ? metadata : item))
         : [metadata, ...current];
-      return [...next].sort((left, right) =>
-        right.updatedAt.localeCompare(left.updatedAt),
-      );
+      return [...next].sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
     });
     setStatus("已保存");
     return note;
@@ -310,9 +302,7 @@ export function NotePad({
       }
 
       const currentBounds = await getCurrentWindowBounds();
-      await animateCurrentWindowBounds(
-        getSurfaceTargetBounds(nextMode, currentBounds),
-      );
+      await animateCurrentWindowBounds(getSurfaceTargetBounds(nextMode, currentBounds));
     } catch (error) {
       setErrorMessage(getErrorMessage(error));
     }
@@ -327,10 +317,7 @@ export function NotePad({
 
     window.addEventListener(NOTE_SURFACE_MODE_EVENT, handleSurfaceModeRequest);
     return () => {
-      window.removeEventListener(
-        NOTE_SURFACE_MODE_EVENT,
-        handleSurfaceModeRequest,
-      );
+      window.removeEventListener(NOTE_SURFACE_MODE_EVENT, handleSurfaceModeRequest);
     };
   }, [switchSurfaceMode]);
 
@@ -429,15 +416,9 @@ export function NotePad({
       void switchSurfaceMode("pad");
     }
 
-    window.addEventListener(
-      NOTE_SURFACE_ACTION_EVENT,
-      handleSurfaceActionRequest,
-    );
+    window.addEventListener(NOTE_SURFACE_ACTION_EVENT, handleSurfaceActionRequest);
     return () => {
-      window.removeEventListener(
-        NOTE_SURFACE_ACTION_EVENT,
-        handleSurfaceActionRequest,
-      );
+      window.removeEventListener(NOTE_SURFACE_ACTION_EVENT, handleSurfaceActionRequest);
     };
   }, [copyTileContent, handleClose, handleSave, switchSurfaceMode]);
 
@@ -485,6 +466,7 @@ export function NotePad({
           content={errorMessage || content}
           color={tileColor}
           fontSize={surfaceFontSize}
+          fontFamily={surfaceFontFamily}
           width="100%"
           className="h-full cursor-default"
           data-surface-mode={surfaceMode}
@@ -587,7 +569,10 @@ export function NotePad({
                   }}
                   placeholder="标题（可选）"
                   className="w-full font-display font-medium text-ink placeholder:text-ink-ghost/60 mb-2 tracking-wide shrink-0"
-                  style={{ fontSize: `${surfaceFontSize}px` }}
+                  style={{
+                    fontSize: `${surfaceFontSize}px`,
+                    fontFamily: surfaceFontFamily,
+                  }}
                 />
 
                 <textarea
@@ -599,7 +584,10 @@ export function NotePad({
                   }}
                   placeholder="写点什么……"
                   className="w-full flex-1 min-h-0 pb-2 leading-relaxed text-ink-soft font-body placeholder:text-ink-ghost/50"
-                  style={{ fontSize: `${surfaceFontSize}px` }}
+                  style={{
+                    fontSize: `${surfaceFontSize}px`,
+                    fontFamily: surfaceFontFamily,
+                  }}
                 />
 
                 <div className="flex items-center justify-between mt-auto pt-2 border-t border-paper-deep/30 shrink-0">

--- a/src/components/SettingsPanel.test.tsx
+++ b/src/components/SettingsPanel.test.tsx
@@ -15,6 +15,9 @@ const config = {
   theme: "light" as const,
   fontSize: 14,
   surfaceFontSize: 14,
+  uiFontFamily: '"LXGW WenKai", serif',
+  fontFamily: '"LXGW WenKai", serif',
+  surfaceFontFamily: '"Maple Mono NF CN", monospace',
   externalFileAutoSave: true,
   rememberSurfaceSize: true,
   tileCtrlClose: true,
@@ -40,6 +43,11 @@ describe("SettingsPanel", () => {
     expect(markup).toContain("自动保存笔记");
     expect(markup).toContain("小窗笔记自动保存");
     expect(markup).toContain("磁贴颜色");
+    expect(markup).toContain("界面字体");
+    expect(markup).toContain("编辑器字体");
+    expect(markup).toContain("小窗/磁贴字体");
+    expect(markup).toContain("&quot;LXGW WenKai&quot;, serif");
+    expect(markup).toContain("&quot;Maple Mono NF CN&quot;, monospace");
     expect(markup).toContain("跟随主题");
     expect(markup).toContain("自定义");
     expect(markup).toContain('type="color"');

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -6,10 +6,7 @@ import {
   hotkeyToConfigString,
   isValidGlobalShortcut,
 } from "../features/settings/shortcutRecorder";
-import {
-  DEFAULT_TILE_COLOR,
-  normalizeTileColor,
-} from "../features/settings/tileColor";
+import { DEFAULT_TILE_COLOR, normalizeTileColor } from "../features/settings/tileColor";
 import { applyTheme, watchSystemTheme } from "../features/settings/theme";
 import { SlidingButtonGroup } from "./SlidingButtonGroup";
 
@@ -37,25 +34,17 @@ const viewModes: Array<{ value: ViewMode; label: string }> = [
   { value: "preview", label: "预览" },
 ];
 
-export function SettingsPanel({
-  config,
-  onChange,
-  onChooseNotesDir,
-  onClose,
-}: SettingsPanelProps) {
-  const setConfigValue = <Key extends keyof AppConfig>(
-    key: Key,
-    value: AppConfig[Key],
-  ) => {
+const DEFAULT_FONT_FAMILY = '"Noto Sans SC", "Source Han Sans SC", system-ui, sans-serif';
+
+export function SettingsPanel({ config, onChange, onChooseNotesDir, onClose }: SettingsPanelProps) {
+  const setConfigValue = <Key extends keyof AppConfig>(key: Key, value: AppConfig[Key]) => {
     onChange({ ...config, [key]: value });
   };
 
   return (
     <aside className="w-[360px] h-full shrink-0 border-l border-paper-deep/30 bg-cloud/92 backdrop-blur-sm flex flex-col">
       <div className="flex items-center justify-between h-11 px-4 border-b border-paper-deep/25">
-        <h2 className="text-[13px] font-display font-medium text-ink-soft">
-          应用设置
-        </h2>
+        <h2 className="text-[13px] font-display font-medium text-ink-soft">应用设置</h2>
         <button
           type="button"
           onClick={onClose}
@@ -78,9 +67,7 @@ export function SettingsPanel({
 
       <div className="flex-1 overflow-y-auto scrollbar-hidden px-4 py-4 space-y-5">
         <section className="space-y-2">
-          <label className="block text-[11px] font-body text-ink-faint">
-            主题
-          </label>
+          <label className="block text-[11px] font-body text-ink-faint">主题</label>
           <SlidingButtonGroup
             options={themeOptions}
             value={config.theme}
@@ -93,9 +80,7 @@ export function SettingsPanel({
         </section>
 
         <section className="space-y-2">
-          <label className="block text-[11px] font-body text-ink-faint">
-            笔记目录
-          </label>
+          <label className="block text-[11px] font-body text-ink-faint">笔记目录</label>
           <div className="flex gap-2">
             <input
               type="text"
@@ -132,23 +117,17 @@ export function SettingsPanel({
           <ToggleRow
             label="小窗笔记自动保存"
             checked={config.noteSurfaceAutoSave}
-            onChange={(checked) =>
-              setConfigValue("noteSurfaceAutoSave", checked)
-            }
+            onChange={(checked) => setConfigValue("noteSurfaceAutoSave", checked)}
           />
           <ToggleRow
             label="外部文件自动保存"
             checked={config.externalFileAutoSave}
-            onChange={(checked) =>
-              setConfigValue("externalFileAutoSave", checked)
-            }
+            onChange={(checked) => setConfigValue("externalFileAutoSave", checked)}
           />
           <ToggleRow
             label="记住小窗尺寸"
             checked={config.rememberSurfaceSize}
-            onChange={(checked) =>
-              setConfigValue("rememberSurfaceSize", checked)
-            }
+            onChange={(checked) => setConfigValue("rememberSurfaceSize", checked)}
           />
         </section>
 
@@ -156,9 +135,7 @@ export function SettingsPanel({
           <ToggleRow
             label="Ctrl+右键快速关闭磁贴"
             checked={config.tileCtrlClose}
-            onChange={(checked) =>
-              setConfigValue("tileCtrlClose", checked)
-            }
+            onChange={(checked) => setConfigValue("tileCtrlClose", checked)}
           />
           <div className="space-y-1.5">
             <label className="block text-[11px] font-body text-ink-faint/70 px-0.5">
@@ -172,9 +149,7 @@ export function SettingsPanel({
         </section>
 
         <section className="space-y-2">
-          <label className="block text-[11px] font-body text-ink-faint">
-            编辑器字号
-          </label>
+          <label className="block text-[11px] font-body text-ink-faint">编辑器字号</label>
           <div className="flex items-center gap-3 h-9 rounded-lg px-2.5 bg-paper-warm/45 border border-paper-deep/25">
             <input
               type="range"
@@ -182,9 +157,7 @@ export function SettingsPanel({
               max={30}
               step={1}
               value={config.fontSize ?? 14}
-              onChange={(event) =>
-                setConfigValue("fontSize", Number(event.target.value))
-              }
+              onChange={(event) => setConfigValue("fontSize", Number(event.target.value))}
               className="flex-1 h-1 accent-bamboo cursor-pointer appearance-none bg-transparent [&::-webkit-slider-runnable-track]:h-[3px] [&::-webkit-slider-runnable-track]:rounded-full [&::-webkit-slider-runnable-track]:bg-paper-deep/50 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-bamboo [&::-webkit-slider-thumb]:-mt-[4.5px] [&::-webkit-slider-thumb]:shadow-[0_1px_3px_rgba(0,0,0,0.15)]"
             />
             <span className="text-[12px] font-mono text-ink-soft tabular-nums w-8 text-right">
@@ -193,10 +166,22 @@ export function SettingsPanel({
           </div>
         </section>
 
+        <FontFamilyField
+          label="界面字体"
+          value={config.uiFontFamily ?? DEFAULT_FONT_FAMILY}
+          onChange={(value) => setConfigValue("uiFontFamily", value)}
+          onReset={() => setConfigValue("uiFontFamily", DEFAULT_FONT_FAMILY)}
+        />
+
+        <FontFamilyField
+          label="编辑器字体"
+          value={config.fontFamily ?? DEFAULT_FONT_FAMILY}
+          onChange={(value) => setConfigValue("fontFamily", value)}
+          onReset={() => setConfigValue("fontFamily", DEFAULT_FONT_FAMILY)}
+        />
+
         <section className="space-y-2">
-          <label className="block text-[11px] font-body text-ink-faint">
-            小窗/磁贴字号
-          </label>
+          <label className="block text-[11px] font-body text-ink-faint">小窗/磁贴字号</label>
           <div className="flex items-center gap-3 h-9 rounded-lg px-2.5 bg-paper-warm/45 border border-paper-deep/25">
             <input
               type="range"
@@ -204,9 +189,7 @@ export function SettingsPanel({
               max={30}
               step={1}
               value={config.surfaceFontSize ?? 14}
-              onChange={(event) =>
-                setConfigValue("surfaceFontSize", Number(event.target.value))
-              }
+              onChange={(event) => setConfigValue("surfaceFontSize", Number(event.target.value))}
               className="flex-1 h-1 accent-bamboo cursor-pointer appearance-none bg-transparent [&::-webkit-slider-runnable-track]:h-[3px] [&::-webkit-slider-runnable-track]:rounded-full [&::-webkit-slider-runnable-track]:bg-paper-deep/50 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-bamboo [&::-webkit-slider-thumb]:-mt-[4.5px] [&::-webkit-slider-thumb]:shadow-[0_1px_3px_rgba(0,0,0,0.15)]"
             />
             <span className="text-[12px] font-mono text-ink-soft tabular-nums w-8 text-right">
@@ -215,10 +198,15 @@ export function SettingsPanel({
           </div>
         </section>
 
+        <FontFamilyField
+          label="小窗/磁贴字体"
+          value={config.surfaceFontFamily ?? DEFAULT_FONT_FAMILY}
+          onChange={(value) => setConfigValue("surfaceFontFamily", value)}
+          onReset={() => setConfigValue("surfaceFontFamily", DEFAULT_FONT_FAMILY)}
+        />
+
         <section className="space-y-2">
-          <label className="block text-[11px] font-body text-ink-faint">
-            磁贴颜色
-          </label>
+          <label className="block text-[11px] font-body text-ink-faint">磁贴颜色</label>
           <SlidingButtonGroup
             options={tileColorModes}
             value={config.tileColorMode}
@@ -229,17 +217,13 @@ export function SettingsPanel({
               <input
                 type="color"
                 value={normalizeTileColor(config.tileColor)}
-                onChange={(event) =>
-                  setConfigValue("tileColor", event.target.value)
-                }
+                onChange={(event) => setConfigValue("tileColor", event.target.value)}
                 className="w-10 h-8 rounded-lg border border-paper-deep/40 bg-paper-warm/70 cursor-pointer"
               />
               <input
                 type="text"
                 value={config.tileColor}
-                onChange={(event) =>
-                  setConfigValue("tileColor", event.target.value)
-                }
+                onChange={(event) => setConfigValue("tileColor", event.target.value)}
                 placeholder="#f6f3ec"
                 spellCheck={false}
                 className="min-w-0 flex-1 h-8 px-2.5 rounded-lg bg-paper-warm/70 border border-paper-deep/40 text-[12px] font-mono text-ink-soft outline-none"
@@ -256,9 +240,7 @@ export function SettingsPanel({
         </section>
 
         <section className="space-y-2">
-          <label className="block text-[11px] font-body text-ink-faint">
-            默认视图
-          </label>
+          <label className="block text-[11px] font-body text-ink-faint">默认视图</label>
           <SlidingButtonGroup
             options={viewModes}
             value={config.defaultViewMode}
@@ -266,8 +248,39 @@ export function SettingsPanel({
           />
         </section>
       </div>
-
     </aside>
+  );
+}
+
+interface FontFamilyFieldProps {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  onReset: () => void;
+}
+
+function FontFamilyField({ label, value, onChange, onReset }: FontFamilyFieldProps) {
+  return (
+    <section className="space-y-2">
+      <label className="block text-[11px] font-body text-ink-faint">{label}</label>
+      <div className="flex items-center gap-2 h-9 rounded-xl border border-paper-deep/45 bg-cloud/80 px-2.5 shadow-[0_1px_4px_rgba(26,26,24,0.04)] focus-within:border-bamboo/35 transition-colors">
+        <input
+          type="text"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          spellCheck={false}
+          className="min-w-0 flex-1 h-7 bg-transparent text-[13px] leading-none text-ink-soft placeholder:text-ink-ghost/60 outline-none"
+          style={{ fontFamily: value }}
+        />
+        <button
+          type="button"
+          onClick={onReset}
+          className="h-7 px-2 rounded-lg text-[11px] text-ink-ghost hover:text-bamboo hover:bg-bamboo-mist/50 transition-colors cursor-pointer whitespace-nowrap"
+        >
+          默认
+        </button>
+      </div>
+    </section>
   );
 }
 
@@ -360,10 +373,7 @@ function ShortcutRecorder({ value, onChange }: ShortcutRecorderProps) {
   useEffect(() => {
     if (!recorder.isRecording) return;
     const handleClick = (e: MouseEvent) => {
-      if (
-        containerRef.current &&
-        !containerRef.current.contains(e.target as Node)
-      ) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
         recorder.cancelRecording();
       }
     };
@@ -371,10 +381,7 @@ function ShortcutRecorder({ value, onChange }: ShortcutRecorderProps) {
     return () => document.removeEventListener("mousedown", handleClick);
   }, [recorder.isRecording, recorder.cancelRecording]);
 
-  const liveDisplay =
-    recorder.isRecording && heldKeys.length > 0
-      ? formatHeldKeys(heldKeys)
-      : null;
+  const liveDisplay = recorder.isRecording && heldKeys.length > 0 ? formatHeldKeys(heldKeys) : null;
 
   return (
     <div ref={containerRef} className="relative">
@@ -389,19 +396,13 @@ function ShortcutRecorder({ value, onChange }: ShortcutRecorderProps) {
       >
         {recorder.isRecording ? (
           <>
-            <span className="flex-1 text-left text-bamboo">
-              {liveDisplay || "按下快捷键..."}
-            </span>
-            <span className="text-[10px] text-ink-faint shrink-0">
-              Esc 取消
-            </span>
+            <span className="flex-1 text-left text-bamboo">{liveDisplay || "按下快捷键..."}</span>
+            <span className="text-[10px] text-ink-faint shrink-0">Esc 取消</span>
           </>
         ) : (
           <>
             <span className="flex-1 text-left text-ink-soft">{value}</span>
-            <span className="text-[10px] text-ink-ghost shrink-0">
-              点击录制
-            </span>
+            <span className="text-[10px] text-ink-ghost shrink-0">点击录制</span>
           </>
         )}
       </button>

--- a/src/components/Tile.test.tsx
+++ b/src/components/Tile.test.tsx
@@ -30,9 +30,7 @@ describe("Tile", () => {
   });
 
   test("uses a custom hex color instead of preset tile palettes", () => {
-    const markup = renderToStaticMarkup(
-      <Tile color="#efe8dc" content="磁贴内容" />,
-    );
+    const markup = renderToStaticMarkup(<Tile color="#efe8dc" content="磁贴内容" />);
 
     expect(markup).toContain("background-color:#efe8dc");
     expect(markup).not.toContain("bg-[#d8eee9]");

--- a/src/components/Tile.tsx
+++ b/src/components/Tile.tsx
@@ -1,18 +1,18 @@
 import chroma from "chroma-js";
 import type { CSSProperties, HTMLAttributes } from "react";
-import {
-  DEFAULT_TILE_COLOR,
-  normalizeTileColor,
-} from "../features/settings/tileColor";
+import { DEFAULT_TILE_COLOR, normalizeTileColor } from "../features/settings/tileColor";
 
-export interface TileProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, "color" | "content" | "title"> {
+export interface TileProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  "color" | "content" | "title"
+> {
   title?: string;
   content: string;
   color?: string;
   width?: number | string;
   rotation?: number;
   fontSize?: number;
+  fontFamily?: string;
 }
 
 const MARK_SIZE = 8;
@@ -71,6 +71,7 @@ export function Tile({
   width = 260,
   rotation = 0,
   fontSize = 14,
+  fontFamily,
   className = "",
   style,
   children,
@@ -101,16 +102,25 @@ export function Tile({
     >
       <div className="px-4 pt-4 pb-4 h-full overflow-y-auto scrollbar-hidden">
         {title && (
-          <div className="font-display tracking-wide mb-3 leading-snug" style={{ color: titleColor, fontSize: `${fontSize + 1}px` }}>
+          <div
+            className="font-display tracking-wide mb-3 leading-snug"
+            style={{ color: titleColor, fontSize: `${fontSize + 1}px` }}
+          >
             {title}
           </div>
         )}
         {content ? (
-          <div className="leading-[1.8] whitespace-pre-wrap font-body" style={{ color: contentColor, fontSize: `${fontSize}px` }}>
+          <div
+            className="leading-[1.8] whitespace-pre-wrap font-body"
+            style={{ color: contentColor, fontSize: `${fontSize}px`, fontFamily }}
+          >
             {content}
           </div>
         ) : (
-          <div className="font-body text-center py-6" style={{ color: emptyColor, fontSize: `${fontSize}px` }}>
+          <div
+            className="font-body text-center py-6"
+            style={{ color: emptyColor, fontSize: `${fontSize}px`, fontFamily }}
+          >
             空
           </div>
         )}
@@ -121,4 +131,3 @@ export function Tile({
     </div>
   );
 }
-

--- a/src/features/importExport/api.test.ts
+++ b/src/features/importExport/api.test.ts
@@ -60,9 +60,7 @@ describe("importExport api", () => {
     mockedSave.mockResolvedValue("D:\\exports\\读书笔记.md");
     mockedInvoke.mockResolvedValue(undefined);
 
-    await expect(
-      exportMarkdownNote({ id: "note-1", title: "读书笔记" }),
-    ).resolves.toBe(true);
+    await expect(exportMarkdownNote({ id: "note-1", title: "读书笔记" })).resolves.toBe(true);
 
     expect(save).toHaveBeenCalledWith({
       defaultPath: "读书笔记.md",

--- a/src/features/markdown/MarkdownPreview.tsx
+++ b/src/features/markdown/MarkdownPreview.tsx
@@ -46,6 +46,7 @@ function extractText(node: React.ReactNode): string {
 interface MarkdownPreviewProps {
   content: string;
   fontSize?: number;
+  fontFamily?: string;
 }
 
 const remarkPlugins = [remarkGfm, remarkMath];
@@ -72,15 +73,9 @@ const components: Components = {
       {children}
     </h4>
   ),
-  p: ({ children }) => (
-    <p className="text-ink-soft leading-[1.9]">{children}</p>
-  ),
-  strong: ({ children }) => (
-    <strong className="font-semibold text-ink">{children}</strong>
-  ),
-  em: ({ children }) => (
-    <em className="italic text-bamboo-light">{children}</em>
-  ),
+  p: ({ children }) => <p className="text-ink-soft leading-[1.9]">{children}</p>,
+  strong: ({ children }) => <strong className="font-semibold text-ink">{children}</strong>,
+  em: ({ children }) => <em className="italic text-bamboo-light">{children}</em>,
   blockquote: ({ children }) => (
     <blockquote className="border-l-2 border-bamboo/40 pl-4 my-3 text-ink-soft/80 italic leading-[1.9]">
       {children}
@@ -96,9 +91,7 @@ const components: Components = {
       {children}
     </ol>
   ),
-  li: ({ children }) => (
-    <li className="text-ink-soft leading-[1.9]">{children}</li>
-  ),
+  li: ({ children }) => <li className="text-ink-soft leading-[1.9]">{children}</li>,
   hr: () => (
     <hr className="my-6 border-none h-px bg-gradient-to-r from-transparent via-paper-deep to-transparent" />
   ),
@@ -141,25 +134,22 @@ const components: Components = {
     </th>
   ),
   td: ({ children }) => (
-    <td className="px-3 py-1.5 border-b border-paper-deep/15 text-ink-soft">
-      {children}
-    </td>
+    <td className="px-3 py-1.5 border-b border-paper-deep/15 text-ink-soft">{children}</td>
   ),
   input: ({ checked, ...props }) => (
-    <input
-      {...props}
-      checked={checked}
-      disabled
-      className="mr-1.5 accent-bamboo"
-    />
+    <input {...props} checked={checked} disabled className="mr-1.5 accent-bamboo" />
   ),
 };
 
-export function MarkdownPreview({ content, fontSize = 14 }: MarkdownPreviewProps) {
+export function MarkdownPreview({ content, fontSize = 14, fontFamily }: MarkdownPreviewProps) {
   return (
-    <div className="font-body" style={{ fontSize: `${fontSize}px` }}>
+    <div className="font-body" style={{ fontSize: `${fontSize}px`, fontFamily }}>
       {content.trim() ? (
-        <Markdown remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins} components={components}>
+        <Markdown
+          remarkPlugins={remarkPlugins}
+          rehypePlugins={rehypePlugins}
+          components={components}
+        >
           {content}
         </Markdown>
       ) : (

--- a/src/features/notes/noteUtils.ts
+++ b/src/features/notes/noteUtils.ts
@@ -88,12 +88,7 @@ export function filterNotes(notes: NoteMetadata[], query: string): NoteMetadata[
   if (!normalized) return notes;
 
   return notes.filter((note) => {
-    const haystack = [
-      note.title,
-      note.preview,
-      note.fileName,
-      getDisplayTitle(note),
-    ]
+    const haystack = [note.title, note.preview, note.fileName, getDisplayTitle(note)]
       .join(" ")
       .toLowerCase();
     return haystack.includes(normalized);

--- a/src/features/settings/api.test.ts
+++ b/src/features/settings/api.test.ts
@@ -1,12 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import {
-  chooseNotesDirectory,
-  getConfig,
-  normalizeViewMode,
-  saveConfig,
-} from "./api";
+import { chooseNotesDirectory, getConfig, normalizeViewMode, saveConfig } from "./api";
 import type { AppConfig } from "./types";
 
 vi.mock("@tauri-apps/api/core", () => ({
@@ -40,6 +35,9 @@ describe("settings api", () => {
       theme: "light",
       fontSize: 14,
       surfaceFontSize: 14,
+      uiFontFamily: '"Noto Sans SC", "Source Han Sans SC", system-ui, sans-serif',
+      fontFamily: '"Noto Sans SC", "Source Han Sans SC", system-ui, sans-serif',
+      surfaceFontFamily: '"Noto Sans SC", "Source Han Sans SC", system-ui, sans-serif',
       externalFileAutoSave: true,
       rememberSurfaceSize: true,
       tileCtrlClose: true,
@@ -65,6 +63,9 @@ describe("settings api", () => {
       theme: "dark",
       fontSize: 16,
       surfaceFontSize: 16,
+      uiFontFamily: '"LXGW WenKai", serif',
+      fontFamily: '"LXGW WenKai", serif',
+      surfaceFontFamily: '"Maple Mono NF CN", monospace',
       externalFileAutoSave: true,
       rememberSurfaceSize: true,
       tileCtrlClose: true,

--- a/src/features/settings/shortcutRecorder.test.ts
+++ b/src/features/settings/shortcutRecorder.test.ts
@@ -1,14 +1,9 @@
 import { describe, expect, test } from "vitest";
-import {
-  formatHeldKeys,
-  hotkeyToConfigString,
-  isValidGlobalShortcut,
-} from "./shortcutRecorder";
+import { formatHeldKeys, hotkeyToConfigString, isValidGlobalShortcut } from "./shortcutRecorder";
 
 describe("shortcutRecorder", () => {
   test("serializes meta shortcuts into config strings", () => {
-    const layeredMetaShortcut =
-      "Meta+Shift+P" as Parameters<typeof hotkeyToConfigString>[0];
+    const layeredMetaShortcut = "Meta+Shift+P" as Parameters<typeof hotkeyToConfigString>[0];
 
     expect(hotkeyToConfigString("Meta+K")).toBe("Meta+K");
     expect(hotkeyToConfigString(layeredMetaShortcut)).toBe("Shift+Meta+P");

--- a/src/features/settings/shortcutRecorder.ts
+++ b/src/features/settings/shortcutRecorder.ts
@@ -39,9 +39,7 @@ export function formatHeldKeys(keys: string[]): string {
     }
   }
 
-  modifiers.sort(
-    (a, b) => modifierOrder.indexOf(a) - modifierOrder.indexOf(b),
-  );
+  modifiers.sort((a, b) => modifierOrder.indexOf(a) - modifierOrder.indexOf(b));
 
   const all = [...modifiers, ...others];
   return all.map((k) => KEY_DISPLAY_NAMES[k] ?? k).join(" + ");

--- a/src/features/settings/theme.ts
+++ b/src/features/settings/theme.ts
@@ -1,13 +1,10 @@
 import type { ThemeOption } from "./types";
 
-const DEFAULT_UI_FONT_FAMILY =
-  '"Noto Sans SC", "Source Han Sans SC", system-ui, sans-serif';
+const DEFAULT_UI_FONT_FAMILY = '"Noto Sans SC", "Source Han Sans SC", system-ui, sans-serif';
 
 function resolveTheme(option: ThemeOption): "light" | "dark" {
   if (option === "system") {
-    return window.matchMedia("(prefers-color-scheme: dark)").matches
-      ? "dark"
-      : "light";
+    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
   }
   return option;
 }

--- a/src/features/settings/theme.ts
+++ b/src/features/settings/theme.ts
@@ -1,5 +1,8 @@
 import type { ThemeOption } from "./types";
 
+const DEFAULT_UI_FONT_FAMILY =
+  '"Noto Sans SC", "Source Han Sans SC", system-ui, sans-serif';
+
 function resolveTheme(option: ThemeOption): "light" | "dark" {
   if (option === "system") {
     return window.matchMedia("(prefers-color-scheme: dark)").matches
@@ -17,6 +20,13 @@ export function applyTheme(option: ThemeOption): void {
     root.setAttribute("data-theme", resolved);
     setTimeout(() => root.classList.remove("theme-transition"), 400);
   }
+}
+
+export function applyUiFontFamily(fontFamily?: string): void {
+  const nextFontFamily = fontFamily?.trim() || DEFAULT_UI_FONT_FAMILY;
+  document.documentElement.style.setProperty("--color-ui-font", nextFontFamily);
+  document.documentElement.style.setProperty("--font-body", nextFontFamily);
+  document.documentElement.style.setProperty("--font-display", nextFontFamily);
 }
 
 let systemListener: (() => void) | null = null;

--- a/src/features/settings/tileColor.ts
+++ b/src/features/settings/tileColor.ts
@@ -32,11 +32,6 @@ export function resolveSystemTileColor(): string {
   return theme === "dark" ? SYSTEM_TILE_COLOR_DARK : SYSTEM_TILE_COLOR_LIGHT;
 }
 
-export function resolveTileColor(
-  mode: TileColorMode,
-  customColor: string,
-): string {
-  return mode === "system"
-    ? resolveSystemTileColor()
-    : normalizeTileColor(customColor);
+export function resolveTileColor(mode: TileColorMode, customColor: string): string {
+  return mode === "system" ? resolveSystemTileColor() : normalizeTileColor(customColor);
 }

--- a/src/features/settings/types.ts
+++ b/src/features/settings/types.ts
@@ -17,6 +17,9 @@ export interface AppConfig {
   theme: ThemeOption;
   fontSize: number;
   surfaceFontSize: number;
+  uiFontFamily: string;
+  fontFamily: string;
+  surfaceFontFamily: string;
   externalFileAutoSave: boolean;
   rememberSurfaceSize: boolean;
   tileCtrlClose: boolean;

--- a/src/features/windows/api.ts
+++ b/src/features/windows/api.ts
@@ -7,20 +7,14 @@ export interface WindowBounds {
   height: number;
 }
 
-export function openNotepadWindow(
-  noteId?: string,
-  bounds?: WindowBounds,
-): Promise<string> {
+export function openNotepadWindow(noteId?: string, bounds?: WindowBounds): Promise<string> {
   return invoke("open_notepad_window", {
     noteId: noteId ?? null,
     bounds: bounds ?? null,
   });
 }
 
-export function openTileWindow(
-  noteId: string,
-  bounds?: WindowBounds,
-): Promise<string> {
+export function openTileWindow(noteId: string, bounds?: WindowBounds): Promise<string> {
   return invoke("open_tile_window", { noteId, bounds: bounds ?? null });
 }
 

--- a/src/features/windows/controls.test.ts
+++ b/src/features/windows/controls.test.ts
@@ -23,9 +23,6 @@ describe("window controls", () => {
 
     expect(show).toHaveBeenCalledTimes(1);
     expect(setFocus).toHaveBeenCalledTimes(1);
-    expect(show.mock.invocationCallOrder[0]).toBeLessThan(
-      setFocus.mock.invocationCallOrder[0],
-    );
+    expect(show.mock.invocationCallOrder[0]).toBeLessThan(setFocus.mock.invocationCallOrder[0]);
   });
-
 });

--- a/src/features/windows/controls.ts
+++ b/src/features/windows/controls.ts
@@ -3,11 +3,7 @@ import { PhysicalPosition, PhysicalSize } from "@tauri-apps/api/dpi";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import type { WindowBounds } from "./api";
 
-export type ResizeDirection =
-  | "NorthWest"
-  | "NorthEast"
-  | "SouthWest"
-  | "SouthEast";
+export type ResizeDirection = "NorthWest" | "NorthEast" | "SouthWest" | "SouthEast";
 
 export async function showCurrentWindow(): Promise<void> {
   const window = getCurrentWindow();
@@ -49,18 +45,13 @@ export function startCurrentWindowDrag(): Promise<void> {
   return getCurrentWindow().startDragging();
 }
 
-export function startCurrentWindowResize(
-  direction: ResizeDirection = "SouthEast",
-): Promise<void> {
+export function startCurrentWindowResize(direction: ResizeDirection = "SouthEast"): Promise<void> {
   return getCurrentWindow().startResizeDragging(direction);
 }
 
 export async function getCurrentWindowBounds(): Promise<WindowBounds> {
   const window = getCurrentWindow();
-  const [position, size] = await Promise.all([
-    window.outerPosition(),
-    window.innerSize(),
-  ]);
+  const [position, size] = await Promise.all([window.outerPosition(), window.innerSize()]);
 
   return {
     x: position.x,
@@ -70,9 +61,7 @@ export async function getCurrentWindowBounds(): Promise<WindowBounds> {
   };
 }
 
-export async function setCurrentWindowBounds(
-  bounds: WindowBounds,
-): Promise<void> {
+export async function setCurrentWindowBounds(bounds: WindowBounds): Promise<void> {
   const window = getCurrentWindow();
   await Promise.all([
     window.setPosition(new PhysicalPosition(bounds.x, bounds.y)),

--- a/src/features/windows/surfaceActions.ts
+++ b/src/features/windows/surfaceActions.ts
@@ -2,21 +2,12 @@ export type NoteSurfaceAction = "copy" | "save" | "switchToPad" | "close";
 
 export const NOTE_SURFACE_ACTION_EVENT = "floral-notepaper:surface-action";
 
-export function isNoteSurfaceAction(
-  value: unknown,
-): value is NoteSurfaceAction {
-  return (
-    value === "copy" ||
-    value === "save" ||
-    value === "switchToPad" ||
-    value === "close"
-  );
+export function isNoteSurfaceAction(value: unknown): value is NoteSurfaceAction {
+  return value === "copy" || value === "save" || value === "switchToPad" || value === "close";
 }
 
 export function requestSurfaceAction(action: NoteSurfaceAction): void {
-  window.dispatchEvent(
-    new CustomEvent(NOTE_SURFACE_ACTION_EVENT, { detail: { action } }),
-  );
+  window.dispatchEvent(new CustomEvent(NOTE_SURFACE_ACTION_EVENT, { detail: { action } }));
 }
 
 export function surfaceActionFromEvent(event: Event): NoteSurfaceAction | null {

--- a/src/features/windows/surfaceMode.ts
+++ b/src/features/windows/surfaceMode.ts
@@ -24,9 +24,7 @@ export function getSurfaceTargetBounds(
 }
 
 export function requestSurfaceMode(mode: NoteSurfaceMode): void {
-  window.dispatchEvent(
-    new CustomEvent(NOTE_SURFACE_MODE_EVENT, { detail: { mode } }),
-  );
+  window.dispatchEvent(new CustomEvent(NOTE_SURFACE_MODE_EVENT, { detail: { mode } }));
 }
 
 export function surfaceModeFromEvent(event: Event): NoteSurfaceMode | null {

--- a/src/features/windows/windowRoutes.test.ts
+++ b/src/features/windows/windowRoutes.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  buildNotepadUrl,
-  buildTileUrl,
-  getInitialRoute,
-  routeFromSearch,
-} from "./windowRoutes";
+import { buildNotepadUrl, buildTileUrl, getInitialRoute, routeFromSearch } from "./windowRoutes";
 
 describe("window routes", () => {
   it("parses supported routes and note ids", () => {
@@ -21,9 +16,7 @@ describe("window routes", () => {
 
   it("builds app urls for dynamic windows", () => {
     expect(buildNotepadUrl()).toBe("index.html?view=notepad");
-    expect(buildNotepadUrl("abc 123")).toBe(
-      "index.html?view=notepad&noteId=abc+123",
-    );
+    expect(buildNotepadUrl("abc 123")).toBe("index.html?view=notepad&noteId=abc+123");
     expect(buildTileUrl("note-1")).toBe("index.html?view=tile&noteId=note-1");
   });
 


### PR DESCRIPTION
## 做了什么

- 新增界面字体、编辑器字体、小窗/磁贴字体三项自定义配置
- 将界面字体应用到全局 UI 字体变量，编辑器和小窗/磁贴字体保持独立
- 为旧配置提供默认字体栈，升级后默认视觉保持不变
- 更新设置面板样式，使字体输入项贴合现有 UI
- 补齐相关前端和 Rust 测试配置

## 验证

- npm test
- npm run build
- cargo test
- cargo fmt --check
- 
<img width="2142" height="1400" alt="屏幕截图 2026-05-20 185457" src="https://github.com/user-attachments/assets/739c78d3-cfe0-4e9a-9467-82d1213f6fe1" />
<img width="694" height="638" alt="屏幕截图 2026-05-20 185512" src="https://github.com/user-attachments/assets/bb821f91-13a6-4322-b06f-f23808e2311c" />
