### PR TITLE
style(preview): 预览体验优化  分栏拖拽手柄/内容居中/表格框线

### DIFF
--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -2072,15 +2072,21 @@ export function MainWindow({
 
                   {viewMode === "split" && (
                     <div
-                      className={`w-1 shrink-0 cursor-col-resize group relative ${isResizingSplit ? "bg-bamboo/30" : "hover:bg-bamboo/20"} transition-colors`}
+                      className={`w-1.5 shrink-0 cursor-col-resize group relative flex items-center justify-center ${isResizingSplit ? "bg-bamboo/30" : "hover:bg-bamboo/20"} transition-colors`}
                       onMouseDown={(e) => {
                         e.preventDefault();
                         setIsResizingSplit(true);
                       }}
                     >
                       <div
-                        className={`absolute inset-y-0 -left-1 -right-1 ${isResizingSplit ? "" : "group-hover:bg-bamboo/5"}`}
+                        className={`absolute inset-y-0 -left-1.5 -right-1.5 ${isResizingSplit ? "" : "group-hover:bg-bamboo/5"}`}
                       />
+                      {/* 拖拽手柄指示器 */}
+                      <div className="relative z-10 flex flex-col gap-[3px] opacity-0 group-hover:opacity-100 transition-opacity">
+                        <div className="w-[3px] h-[3px] rounded-full bg-ink-ghost/60" />
+                        <div className="w-[3px] h-[3px] rounded-full bg-ink-ghost/60" />
+                        <div className="w-[3px] h-[3px] rounded-full bg-ink-ghost/60" />
+                      </div>
                     </div>
                   )}
 
@@ -2094,8 +2100,10 @@ export function MainWindow({
                         </div>
                       )}
                       <div
-                        className={`flex-1 overflow-y-auto px-6 pb-6 ${
-                          viewMode === "preview" ? "pt-3" : "pt-1"
+                        className={`flex-1 overflow-y-auto pb-6 ${
+                          viewMode === "preview"
+                            ? "pt-3 px-[max(2rem,calc((100%-720px)/2))]"
+                            : "pt-1 px-6"
                         }`}
                       >
                         <MarkdownPreview

--- a/src/features/markdown/MarkdownPreview.tsx
+++ b/src/features/markdown/MarkdownPreview.tsx
@@ -128,16 +128,18 @@ const components: Components = {
   ),
   table: ({ children }) => (
     <div className="my-3 overflow-x-auto">
-      <table className="w-full text-[0.93em] border-collapse">{children}</table>
+      <table className="w-full text-[0.93em] border-collapse border border-paper-deep/50">
+        {children}
+      </table>
     </div>
   ),
   th: ({ children }) => (
-    <th className="text-left px-3 py-1.5 border-b border-paper-deep/30 font-semibold text-ink text-[0.85em]">
+    <th className="text-left px-3 py-1.5 border border-paper-deep/40 font-semibold text-ink text-[0.85em] bg-paper-warm/50">
       {children}
     </th>
   ),
   td: ({ children }) => (
-    <td className="px-3 py-1.5 border-b border-paper-deep/15 text-ink-soft">{children}</td>
+    <td className="px-3 py-1.5 border border-paper-deep/35 text-ink-soft">{children}</td>
   ),
   input: ({ checked, ...props }) => (
     <input {...props} checked={checked} disabled className="mr-1.5 accent-bamboo" />


### PR DESCRIPTION
## 改动内容

解决三个 Markdown 预览的体验问题（对比 Typedown 后发现的差距）：

### 1. 分栏拖拽手柄可发现性
- 分割线加宽（w-1 → w-1.5）
- hover 热区扩大（-left-1.5 -right-1.5）
- 新增三圆点拖拽指示器，hover 时显示

### 2. 纯预览模式内容居中留白
- 内容区最大宽度 720px，两侧自动留白
- 窄窗口退化为最小 2rem 内边距
- 分栏模式不受影响（空间有限）

### 3. 表格框线增强
- 改为完整网格边框（四边 border）
- 透明度提升到 35%~50%（原来 15%~30% 几乎不可见）
- ⚠️ 表头额外加了浅色背景（bg-paper-warm/50）用于区分表头和数据行，如果觉得不需要可以去掉这一项
