### PR TITLE
fix: 修复若干小问题

### DIFF
--- a/src-tauri/src/services/notes.rs
+++ b/src-tauri/src/services/notes.rs
@@ -840,10 +840,7 @@ fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> Result<(), AppErro
     }
     let temp_path = path.with_extension("json.tmp");
     fs::write(&temp_path, serde_json::to_string_pretty(value)?)?;
-    if path.exists() {
-        fs::remove_file(path)?;
-    }
-    fs::rename(temp_path, path)?;
+    fs::rename(&temp_path, path)?;
     Ok(())
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,13 +29,16 @@ function App() {
   }, []);
 
   useEffect(() => {
+    let themeCleanup = () => {};
     const unlisten = listen<AppConfig>("config-changed", (event) => {
       const theme = (event.payload.theme || "system") as ThemeOption;
       applyTheme(theme);
-      watchSystemTheme(theme);
+      themeCleanup();
+      themeCleanup = watchSystemTheme(theme);
       void syncLanguage(event.payload.locale);
     });
     return () => {
+      themeCleanup();
       void unlisten.then((fn) => fn());
     };
   }, []);

--- a/src/components/Tile.tsx
+++ b/src/components/Tile.tsx
@@ -1,5 +1,6 @@
 import chroma from "chroma-js";
 import type { CSSProperties, HTMLAttributes } from "react";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { DEFAULT_TILE_COLOR, normalizeTileColor } from "../features/settings/tileColor";
 import { MarkdownPreview } from "../features/markdown/MarkdownPreview";
@@ -81,13 +82,17 @@ export function Tile({
 }: TileProps) {
   const { t } = useTranslation();
   const tileColor = normalizeTileColor(color);
-  const isLightBg = chroma(tileColor).luminance() > 0.18;
-  const mixTarget = isLightBg ? "#1a1a18" : "#ffffff";
-  const borderColor = chroma.mix(tileColor, mixTarget, 0.18).alpha(0.55).css();
-  const cornerColor = chroma.mix(tileColor, mixTarget, 0.3).alpha(0.26).css();
-  const titleColor = chroma.mix(tileColor, mixTarget, 0.4).alpha(0.5).css();
-  const contentColor = chroma.mix(tileColor, mixTarget, 0.65).alpha(0.85).css();
-  const emptyColor = chroma.mix(tileColor, mixTarget, 0.25).alpha(0.4).css();
+  const { borderColor, cornerColor, titleColor, contentColor, emptyColor } = useMemo(() => {
+    const isLightBg = chroma(tileColor).luminance() > 0.18;
+    const mixTarget = isLightBg ? "#1a1a18" : "#ffffff";
+    return {
+      borderColor: chroma.mix(tileColor, mixTarget, 0.18).alpha(0.55).css(),
+      cornerColor: chroma.mix(tileColor, mixTarget, 0.3).alpha(0.26).css(),
+      titleColor: chroma.mix(tileColor, mixTarget, 0.4).alpha(0.5).css(),
+      contentColor: chroma.mix(tileColor, mixTarget, 0.65).alpha(0.85).css(),
+      emptyColor: chroma.mix(tileColor, mixTarget, 0.25).alpha(0.4).css(),
+    };
+  }, [tileColor]);
   const mergedStyle: CSSProperties = {
     width,
     backgroundColor: tileColor,

--- a/src/features/markdown/MarkdownPreview.tsx
+++ b/src/features/markdown/MarkdownPreview.tsx
@@ -119,7 +119,7 @@ const components: Components = {
       href={href}
       onClick={(e) => {
         e.preventDefault();
-        if (href) openUrl(href);
+        if (href && /^https?:\/\//i.test(href)) openUrl(href);
       }}
       className="text-bamboo hover:text-bamboo-light underline underline-offset-2 cursor-pointer"
     >


### PR DESCRIPTION
## fix: 修复若干小问题

### 1. write_json_atomic 竞态条件（notes.rs）
去掉 `fs::remove_file` + `fs::rename` 的两步操作，改为直接 `fs::rename` 覆盖。
原实现在 remove 成功但 rename 失败时会丢失数据。

### 2. watchSystemTheme 监听器泄漏（App.tsx）
`config-changed` 事件每次触发都调用 `watchSystemTheme` 创建新的 MediaQueryList 监听器，但从不清理旧的。
现在在创建新监听器前先清理上一个。

### 3. Tile 颜色计算加 useMemo（Tile.tsx）
5 个 `chroma.mix` 计算在每次渲染时执行。加 `useMemo` 依赖 `tileColor`，仅在颜色变化时重新计算。

### 4. openUrl 协议白名单（MarkdownPreview.tsx）
Markdown 中的链接点击通过 `openUrl` 传递给系统浏览器。添加 `http/https` 协议检查，阻止 `javascript:`、`file:` 等潜在危险协议。
