### PR TITLE
fix: preserve focus and cursor position during auto-save

### DIFF
--- a/src/components/NotePad.tsx
+++ b/src/components/NotePad.tsx
@@ -300,6 +300,13 @@ export function NotePad({
       ? await updateNote(editingNoteId, request)
       : await createNote(request);
 
+    // Preserve focus state before updating state
+    const activeElement = document.activeElement;
+    const shouldRestoreFocus = activeElement === titleRef.current || activeElement === contentRef.current;
+    const cursorPosition = shouldRestoreFocus && activeElement instanceof HTMLInputElement || activeElement instanceof HTMLTextAreaElement
+      ? activeElement.selectionStart
+      : null;
+
     setEditingNoteId(note.id);
     setNotes((current) => {
       const metadata = metadataFromNote(note);
@@ -310,6 +317,26 @@ export function NotePad({
       return [...next].sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
     });
     setStatus("saved");
+
+    // Restore focus and cursor position after state update
+    if (shouldRestoreFocus) {
+      requestAnimationFrame(() => {
+        if (activeElement === titleRef.current) {
+          titleRef.current?.focus();
+          if (cursorPosition !== null && titleRef.current) {
+            titleRef.current.selectionStart = cursorPosition;
+            titleRef.current.selectionEnd = cursorPosition;
+          }
+        } else if (activeElement === contentRef.current) {
+          contentRef.current?.focus();
+          if (cursorPosition !== null && contentRef.current) {
+            contentRef.current.selectionStart = cursorPosition;
+            contentRef.current.selectionEnd = cursorPosition;
+          }
+        }
+      });
+    }
+
     return note;
   }, [content, editingNoteId, title]);
 


### PR DESCRIPTION
Fixes #123

## 问题描述

编辑标题时，自动保存会触发状态更新（`setEditingNoteId`），导致组件重新渲染，输入框失去焦点，用户必须重新点击才能继续编辑。

## 解决方案

在 `saveNote` 函数中：
1. 保存当前焦点元素和光标位置
2. 执行状态更新
3. 使用 `requestAnimationFrame` 在下一帧恢复焦点和光标位置

这样自动保存不会中断用户的编辑流程，体验与内容区域一致。

## 测试步骤

1. 新建笔记
2. 在标题输入框中输入文字
3. 停顿 900ms 触发自动保存
4. 验证光标保持在原位置，可以继续输入

## 技术细节

- 使用 `document.activeElement` 检测当前焦点
- 保存 `selectionStart` 记录光标位置
- 使用 `requestAnimationFrame` 确保在 DOM 更新后恢复焦点
- 同时支持标题输入框和内容文本框