### PR TITLE
fix: 全局快捷键添加 800ms 防抖，防止快速连按创建大量窗口导致卡死

### DIFF
--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -140,6 +140,8 @@ struct RuntimeState {
     hidden_window_labels: Mutex<Vec<String>>,
     #[cfg(desktop)]
     shortcut_bindings: Mutex<ShortcutBindings>,
+    #[cfg(desktop)]
+    last_notepad_open: Mutex<Option<std::time::Instant>>,
 }
 
 #[cfg(desktop)]
@@ -1188,14 +1190,34 @@ fn setup_global_shortcut_plugin(app: &AppHandle) -> tauri::Result<()> {
                         }
                     }
                     ShortcutAction::OpenNotepad => {
-                        if let Err(error) = app.run_on_main_thread(move || {
-                            if let Err(error) =
-                                open_notepad_window_now(&app_for_closure, None, None)
-                            {
-                                eprintln!("failed to open notepad from global shortcut: {error}");
+                        // 防抖：800ms 内忽略重复触发，防止快速连按创建大量窗口
+                        let should_open = app
+                            .try_state::<RuntimeState>()
+                            .map(|state| {
+                                let mut guard = state.last_notepad_open.lock().unwrap();
+                                let now = std::time::Instant::now();
+                                if let Some(last) = *guard {
+                                    if now.duration_since(last).as_millis() < 800 {
+                                        return false;
+                                    }
+                                }
+                                *guard = Some(now);
+                                true
+                            })
+                            .unwrap_or(true);
+
+                        if should_open {
+                            if let Err(error) = app.run_on_main_thread(move || {
+                                if let Err(error) =
+                                    open_notepad_window_now(&app_for_closure, None, None)
+                                {
+                                    eprintln!(
+                                        "failed to open notepad from global shortcut: {error}"
+                                    );
+                                }
+                            }) {
+                                eprintln!("failed to dispatch global shortcut action: {error}");
                             }
-                        }) {
-                            eprintln!("failed to dispatch global shortcut action: {error}");
                         }
                     }
                 }


### PR DESCRIPTION
## fix: 全局快捷键添加 800ms 防抖，防止快速连按导致应用无响应

### 问题

快速连续按全局快捷键呼出小窗时，每次按键都触发窗口创建，窗口池耗尽后
大量窗口创建会耗尽系统资源导致应用无响应。

### 修复

在快捷键 handler 中添加 800ms 防抖：
- `RuntimeState` 新增 `last_notepad_open` 时间戳
- 触发时检查距上次是否超过 800ms，未超过则忽略

### 简单测试

- 系统: Windows 11 24H2, 16GB 内存
- 对比测试: 上游 v1.0.4 发布版 vs 修复版
- 快速连按不再卡死，正常使用频率不受影响

### 说明

这是我在使用中遇到的问题。800ms 冷却时间可根据体验调整。
是否合并由作者自行决定。
