### PR TITLE
feat: 快捷便签小窗新增 Markdown 预览渲染按钮

### DIFF
--- a/src/components/NotePad.tsx
+++ b/src/components/NotePad.tsx
@@ -47,6 +47,7 @@ import {
   tileSurfaceModeUnpinNoteId,
 } from "../features/windows/tileWindowEvents";
 import { Tile } from "./Tile";
+import { MarkdownPreview } from "../features/markdown/MarkdownPreview";
 
 type OpenMode = "new" | "open";
 type NotePadStatus = "empty" | "opened" | "saved" | "dirty" | "saveFailed" | "copied";
@@ -126,6 +127,7 @@ export function NotePad({
   const [tileColorMode, setTileColorMode] = useState<TileColorMode>("system");
   const [surfaceFontSize, setSurfaceFontSize] = useState(14);
   const [tileRenderMarkdown, setTileRenderMarkdown] = useState(false);
+  const [showPreview, setShowPreview] = useState(false);
   const [tileColor, setTileColor] = useState(() =>
     resolveTileColor("system", normalizeTileColor(initialTileColor)),
   );
@@ -169,6 +171,7 @@ export function NotePad({
     setContent(note.content);
     setMode("new");
     setStatus("opened");
+    setShowPreview(false);
   }, []);
 
   useEffect(() => {
@@ -282,6 +285,7 @@ export function NotePad({
       setStatus("empty");
       setErrorMessage(null);
       setIsExiting(false);
+      setShowPreview(false);
       setSurfaceMode("pad");
       void refreshNotes().catch(() => undefined);
       void showCurrentWindow()
@@ -483,6 +487,7 @@ export function NotePad({
     setMode("new");
     setStatus("empty");
     setErrorMessage(null);
+    setShowPreview(false);
   };
 
   const isTile = surfaceMode === "tile";
@@ -588,6 +593,36 @@ export function NotePad({
                 </button>
 
                 <button
+                  onClick={() => setShowPreview((v) => !v)}
+                  className={`group w-7 h-7 flex items-center justify-center rounded-lg transition-all duration-200 cursor-pointer ${showPreview ? "text-bamboo bg-bamboo-mist/60" : "text-ink-ghost hover:text-ink-faint hover:bg-paper-warm"}`}
+                  title={t("notepad.tooltip.preview", { defaultValue: "预览渲染" })}
+                >
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    {showPreview ? (
+                      <>
+                        <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
+                        <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
+                        <line x1="1" y1="1" x2="23" y2="23" />
+                      </>
+                    ) : (
+                      <>
+                        <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                        <circle cx="12" cy="12" r="3" />
+                      </>
+                    )}
+                  </svg>
+                </button>
+
+                <button
                   onClick={() => void handleClose()}
                   className="group w-7 h-7 flex items-center justify-center rounded-lg text-ink-ghost hover:bg-danger-bg hover:text-red-400 transition-all duration-200 cursor-pointer"
                   title={t("notepad.tooltip.close", { defaultValue: "关闭" })}
@@ -625,6 +660,7 @@ export function NotePad({
                   onKeyDown={(event) => {
                     if (event.key === "Enter" || event.key === "ArrowDown") {
                       event.preventDefault();
+                      if (showPreview) return;
                       contentRef.current?.focus();
                     }
                   }}
@@ -633,29 +669,35 @@ export function NotePad({
                   style={{ fontSize: `${surfaceFontSize}px` }}
                 />
 
-                <textarea
-                  ref={contentRef}
-                  value={content}
-                  onChange={(event) => {
-                    setContent(event.target.value);
-                    setStatus("dirty");
-                  }}
-                  onKeyDown={(event) => {
-                    if (event.key === "ArrowUp") {
-                      const ta = contentRef.current;
-                      if (ta && ta.selectionStart === ta.selectionEnd) {
-                        const textBeforeCursor = content.slice(0, ta.selectionStart);
-                        if (!textBeforeCursor.includes("\n")) {
-                          event.preventDefault();
-                          titleRef.current?.focus();
+                {showPreview ? (
+                  <div className="flex-1 min-h-0 overflow-y-auto pb-2">
+                    <MarkdownPreview content={content} fontSize={surfaceFontSize} />
+                  </div>
+                ) : (
+                  <textarea
+                    ref={contentRef}
+                    value={content}
+                    onChange={(event) => {
+                      setContent(event.target.value);
+                      setStatus("dirty");
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key === "ArrowUp") {
+                        const ta = contentRef.current;
+                        if (ta && ta.selectionStart === ta.selectionEnd) {
+                          const textBeforeCursor = content.slice(0, ta.selectionStart);
+                          if (!textBeforeCursor.includes("\n")) {
+                            event.preventDefault();
+                            titleRef.current?.focus();
+                          }
                         }
                       }
-                    }
-                  }}
-                  placeholder={t("notepad.placeholder.content", { defaultValue: "写点什么……" })}
-                  className="w-full flex-1 min-h-0 pb-2 leading-relaxed text-ink-soft font-body placeholder:text-ink-ghost/50"
-                  style={{ fontSize: `${surfaceFontSize}px` }}
-                />
+                    }}
+                    placeholder={t("notepad.placeholder.content", { defaultValue: "写点什么……" })}
+                    className="w-full flex-1 min-h-0 pb-2 leading-relaxed text-ink-soft font-body placeholder:text-ink-ghost/50"
+                    style={{ fontSize: `${surfaceFontSize}px` }}
+                  />
+                )}
 
                 <div className="flex items-center justify-between mt-auto pt-2 border-t border-paper-deep/30 shrink-0">
                   <span className="text-[11px] text-ink-ghost font-mono tabular-nums truncate max-w-[170px]">

--- a/src/locales/en-US/translation.json
+++ b/src/locales/en-US/translation.json
@@ -163,7 +163,8 @@
     "tooltip": {
       "close": "Close",
       "openInEditor": "Open in Editor",
-      "pinToTile": "Pin to Tile"
+      "pinToTile": "Pin to Tile",
+      "preview": "Preview Render"
     }
   },
   "settings": {

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -163,7 +163,8 @@
     "tooltip": {
       "close": "关闭",
       "openInEditor": "在编辑器中打开",
-      "pinToTile": "转为磁贴"
+      "pinToTile": "转为磁贴",
+      "preview": "预览渲染"
     }
   },
   "settings": {

--- a/src/locales/zh-HK/translation.json
+++ b/src/locales/zh-HK/translation.json
@@ -163,7 +163,8 @@
     "tooltip": {
       "close": "關閉",
       "openInEditor": "在編輯器中開啟",
-      "pinToTile": "轉為磁貼"
+      "pinToTile": "轉為磁貼",
+      "preview": "預覽渲染"
     }
   },
   "settings": {


### PR DESCRIPTION
## 变更内容

在快捷便签（NotePad）小窗的标题栏新增一个 **Markdown 预览渲染** 切换按钮，用户可以一键将当前编辑的文本内容以渲染后的 Markdown 格式预览。

## 修改文件

| 文件 | 修改说明 |
|------|----------|
| `src/components/NotePad.tsx` | 新增 `showPreview` 状态、预览切换按钮、条件渲染 `MarkdownPreview` 组件 |
| `src/locales/zh-CN/translation.json` | 新增 `notepad.tooltip.preview` 翻译键（"预览渲染"） |
| `src/locales/zh-HK/translation.json` | 新增 `notepad.tooltip.preview` 翻译键（"預覽渲染"） |
| `src/locales/en-US/translation.json` | 新增 `notepad.tooltip.preview` 翻译键（"Preview Render"） |

## 实现细节

1. **按钮位置**：标题栏右侧，位于「转为磁贴」按钮和「关闭」按钮之间，与现有图标按钮风格完全一致（`w-7 h-7` 圆角图标按钮）
2. **图标切换**：默认显示眼睛图标（eye），激活后显示带斜线的闭眼图标（eye-off），表示当前处于预览模式
3. **高亮状态**：激活时按钮变为 `text-bamboo bg-bamboo-mist/60`，与应用内其他激活态按钮风格统一
4. **预览渲染**：复用已有的 `MarkdownPreview` 组件，支持 GFM（表格、任务列表、删除线等）、KaTeX 数学公式渲染
5. **状态管理**：
   - 新建笔记（`resetDraft`）时自动关闭预览
   - 打开已有笔记（`applyNote`）时自动关闭预览
   - 快捷键唤起小窗（`notepad:activate` 事件）时自动关闭预览
6. **i18n**：三语翻译（zh-CN / zh-HK / en-US），tooltip 使用 `defaultValue` 回退

## 测试

- [x] TypeScript 类型检查通过（`tsc --noEmit` 无报错）
- [x] Vite 生产构建通过（`npm run build` 成功）
- [x] 预提交 hooks（oxfmt 格式化）通过
- [x] 按钮点击可正常切换编辑/预览模式
- [x] 预览模式下 Markdown 内容正确渲染（标题、粗体、代码块、列表、数学公式等）
- [x] 编辑模式下键盘导航（ArrowUp/ArrowDown）正常工作，预览模式下不会误触发
- [x] 新建/打开笔记/唤起小窗时预览状态正确重置
