### PR TITLE
fix: resolve cold-start race condition when opening external files

### DIFF
--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -32,6 +32,12 @@ const TRAY_TOGGLE_AUTOSTART_ID: &str = "toggle-autostart";
 const TRAY_QUIT_ID: &str = "quit";
 const NOTEPAD_POOL_CAPACITY: usize = 2;
 
+/// Stores the file path passed as a command-line argument on cold start.
+/// The frontend retrieves and clears this value after initialization via
+/// the `take_startup_file` command, avoiding a race condition with the
+/// previous approach of emitting an event after a hardcoded delay.
+static STARTUP_FILE: Mutex<Option<String>> = Mutex::new(None);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TrayMenuAction {
     ShowMain,
@@ -579,6 +585,13 @@ pub fn extract_file_arg(args: &[String]) -> Option<String> {
         .cloned()
 }
 
+/// Takes the startup file path stored during cold start, consuming it so
+/// subsequent calls return `None`. Called by the frontend after it finishes
+/// initializing to deterministically load the file without any timing risk.
+pub fn take_startup_file() -> Option<String> {
+    STARTUP_FILE.lock().ok()?.take()
+}
+
 pub fn setup_desktop(app: &mut App) -> Result<(), Box<dyn Error>> {
     app.manage(RuntimeState::default());
     app.manage(NotepadPool::default());
@@ -597,11 +610,9 @@ pub fn setup_desktop(app: &mut App) -> Result<(), Box<dyn Error>> {
 
     let args: Vec<String> = std::env::args().collect();
     if let Some(file_path) = extract_file_arg(&args) {
-        let app_handle = app.handle().clone();
-        std::thread::spawn(move || {
-            std::thread::sleep(std::time::Duration::from_millis(500));
-            let _ = app_handle.emit("open-external-file", file_path);
-        });
+        if let Ok(mut guard) = STARTUP_FILE.lock() {
+            *guard = Some(file_path);
+        }
     }
 
     Ok(())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -253,6 +253,11 @@ async fn open_note_in_editor(app: AppHandle, note_id: String) -> Result<(), AppE
     Ok(())
 }
 
+#[tauri::command]
+fn take_startup_file() -> Option<String> {
+    desktop::take_startup_file()
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -294,7 +299,8 @@ pub fn run() {
             recycle_notepad_window,
             open_tile_window,
             toggle_tile_window,
-            open_note_in_editor
+            open_note_in_editor,
+            take_startup_file
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -47,7 +47,7 @@ import {
   getNoteContextMenuItems,
   type NoteContextMenuAction,
 } from "../features/notes/noteContextMenu";
-import { openNotepadWindow, toggleTileWindow } from "../features/windows/api";
+import { openNotepadWindow, takeStartupFile, toggleTileWindow } from "../features/windows/api";
 import {
   closeCurrentWindow,
   minimizeCurrentWindow,
@@ -558,6 +558,13 @@ export function MainWindow({
           if (!cancelled) applyNote(note);
         } else {
           clearCurrentNote();
+        }
+
+        if (!cancelled) {
+          const startupFile = await takeStartupFile();
+          if (!cancelled && startupFile) {
+            await loadExternalFile(startupFile);
+          }
         }
       } catch (error) {
         if (!cancelled) setErrorMessage(getErrorMessage(error));

--- a/src/features/windows/api.ts
+++ b/src/features/windows/api.ts
@@ -25,3 +25,7 @@ export function toggleTileWindow(noteId: string, bounds?: WindowBounds): Promise
 export function openNoteInEditor(noteId: string): Promise<void> {
   return invoke("open_note_in_editor", { noteId });
 }
+
+export function takeStartupFile(): Promise<string | null> {
+  return invoke("take_startup_file");
+}


### PR DESCRIPTION
Replace the unreliable 500ms sleep in setup_desktop() with a deterministic pull-based mechanism. The startup file path is now stored in a static Mutex and retrieved by the frontend after its initialization is complete, eliminating the timing assumption that caused blank windows on cold start.

Closes #137