### PR TITLE
feat:添加Linux构建

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -337,7 +337,7 @@ jobs:
 
           appimage_source="$(find src-tauri/target/release/bundle/appimage -type f -name '*.AppImage' | sort | head -n 1)"
           if [ -n "$appimage_source" ]; then
-            cp "$appimage_source" "release-assets/floral-notepaper_${ver}_x86_64.AppImage"
+            cp "$appimage_source" "release-assets/floral-notepaper_${ver}_amd64.AppImage"
           fi
 
           shopt -s nullglob

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -277,6 +277,84 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+  build-linux:
+    needs: prepare-build
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare-build.outputs.checkout_ref }}
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+          cache: npm
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Set version
+        run: |
+          ver='${{ needs.prepare-build.outputs.version }}'
+          cat > set-version.cjs << 'SCRIPT'
+          const fs = require("fs");
+          const ver = process.argv[2];
+          const conf = JSON.parse(fs.readFileSync("src-tauri/tauri.conf.json", "utf8"));
+          conf.version = ver;
+          fs.writeFileSync("src-tauri/tauri.conf.json", JSON.stringify(conf, null, 2));
+          let toml = fs.readFileSync("src-tauri/Cargo.toml", "utf8");
+          toml = toml.replace(/^version = "[^"]*"/m, 'version = "' + ver + '"');
+          fs.writeFileSync("src-tauri/Cargo.toml", toml);
+          SCRIPT
+          node set-version.cjs "$ver"
+
+      - name: Build
+        run: npm run tauri build
+
+      - name: Collect artifacts
+        run: |
+          ver='${{ needs.prepare-build.outputs.version }}'
+          mkdir -p release-assets
+
+          deb_source="$(find src-tauri/target/release/bundle/deb -type f -name '*.deb' | sort | head -n 1)"
+          if [ -n "$deb_source" ]; then
+            cp "$deb_source" "release-assets/floral-notepaper_${ver}_amd64.deb"
+          fi
+
+          rpm_source="$(find src-tauri/target/release/bundle/rpm -type f -name '*.rpm' | sort | head -n 1)"
+          if [ -n "$rpm_source" ]; then
+            cp "$rpm_source" "release-assets/floral-notepaper-${ver}-1.x86_64.rpm"
+          fi
+
+          appimage_source="$(find src-tauri/target/release/bundle/appimage -type f -name '*.AppImage' | sort | head -n 1)"
+          if [ -n "$appimage_source" ]; then
+            cp "$appimage_source" "release-assets/floral-notepaper_${ver}_x86_64.AppImage"
+          fi
+
+          shopt -s nullglob
+          assets=(release-assets/*)
+          if [ ${#assets[@]} -eq 0 ]; then
+            echo "No Linux build artifacts found." >&2
+            exit 1
+          fi
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: floral-notepaper-linux-${{ needs.prepare-build.outputs.source_label }}-${{ needs.prepare-build.outputs.version_label }}
+          path: release-assets/*
+          if-no-files-found: error
+          retention-days: 14
+
   build-macos-x86_64:
     needs: prepare-build
     runs-on: macos-15-intel

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -297,7 +297,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev patchelf libssl-dev libxdo-dev
 
       - name: Install frontend dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
 
           macOS Apple Silicon 版：\`floral-notepaper_${ver}_aarch64.dmg\`；macOS Intel 版：\`floral-notepaper_${ver}_x64.dmg\`。
 
-          Linux 版：\`floral-notepaper_${ver}_amd64.deb\`（Debian/Ubuntu）、\`floral-notepaper-${ver}-1.x86_64.rpm\`（Fedora/RHEL）、\`floral-notepaper_${ver}_x86_64.AppImage\`（通用 Linux）。
+          Linux 版：\`floral-notepaper_${ver}_amd64.deb\`（Debian/Ubuntu）、\`floral-notepaper-${ver}-1.x86_64.rpm\`（Fedora/RHEL）、\`floral-notepaper_${ver}_amd64.AppImage\`（通用 Linux）。
 
           macOS 版安装流程请参考视频（Bilibili）：[Mac云课堂 - 在 Mac 上装软件，要学会和苹果斗智斗勇](https://www.bilibili.com/video/BV1tg411t7hN)
           EOF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
 
           macOS Apple Silicon 版：\`floral-notepaper_${ver}_aarch64.dmg\`；macOS Intel 版：\`floral-notepaper_${ver}_x64.dmg\`。
 
+          Linux 版：\`floral-notepaper_${ver}_amd64.deb\`（Debian/Ubuntu）、\`floral-notepaper-${ver}-1.x86_64.rpm\`（Fedora/RHEL）、\`floral-notepaper_${ver}_x86_64.AppImage\`（通用 Linux）。
+
           macOS 版安装流程请参考视频（Bilibili）：[Mac云课堂 - 在 Mac 上装软件，要学会和苹果斗智斗勇](https://www.bilibili.com/video/BV1tg411t7hN)
           EOF
 
@@ -243,6 +245,82 @@ jobs:
           )
           gh release upload $env:TAG_NAME $files --clobber --repo $env:GITHUB_REPOSITORY
 
+  build-linux:
+    needs: prepare-release
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+          cache: npm
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Set version
+        run: |
+          ver="$(echo '${{ github.event.inputs.version }}' | sed 's/^v//')"
+          cat > set-version.cjs << 'SCRIPT'
+          const fs = require("fs");
+          const ver = process.argv[2];
+          const conf = JSON.parse(fs.readFileSync("src-tauri/tauri.conf.json", "utf8"));
+          conf.version = ver;
+          fs.writeFileSync("src-tauri/tauri.conf.json", JSON.stringify(conf, null, 2));
+          let toml = fs.readFileSync("src-tauri/Cargo.toml", "utf8");
+          toml = toml.replace(/^version = "[^"]*"/m, 'version = "' + ver + '"');
+          fs.writeFileSync("src-tauri/Cargo.toml", toml);
+          SCRIPT
+          node set-version.cjs "$ver"
+
+      - name: Build
+        run: npm run tauri build
+
+      - name: Upload release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.event.inputs.version }}
+        run: |
+          ver="$(echo "$TAG_NAME" | sed 's/^v//')"
+          mkdir -p release-assets
+
+          # DEB
+          deb_source="$(find src-tauri/target/release/bundle/deb -type f -name '*.deb' | sort | head -n 1)"
+          if [ -n "$deb_source" ]; then
+            cp "$deb_source" "release-assets/floral-notepaper_${ver}_amd64.deb"
+          fi
+
+          # RPM
+          rpm_source="$(find src-tauri/target/release/bundle/rpm -type f -name '*.rpm' | sort | head -n 1)"
+          if [ -n "$rpm_source" ]; then
+            cp "$rpm_source" "release-assets/floral-notepaper-${ver}-1.x86_64.rpm"
+          fi
+
+          # AppImage
+          appimage_source="$(find src-tauri/target/release/bundle/appimage -type f -name '*.AppImage' | sort | head -n 1)"
+          if [ -n "$appimage_source" ]; then
+            cp "$appimage_source" "release-assets/floral-notepaper_${ver}_x86_64.AppImage"
+          fi
+
+          shopt -s nullglob
+          assets=(release-assets/*)
+          if [ ${#assets[@]} -eq 0 ]; then
+            echo "No Linux release assets found." >&2
+            exit 1
+          fi
+
+          gh release upload "$TAG_NAME" release-assets/* --clobber --repo "$GITHUB_REPOSITORY"
+
   build-macos-x86_64:
     needs: prepare-release
     runs-on: macos-15-intel
@@ -358,7 +436,7 @@ jobs:
           gh release upload "$TAG_NAME" "$dmg_asset" --clobber --repo "$GITHUB_REPOSITORY"
 
   cleanup-release:
-    needs: [prepare-release, build-windows, build-macos-x86_64, build-macos-aarch64]
+    needs: [prepare-release, build-windows, build-linux, build-macos-x86_64, build-macos-aarch64]
     if: failure() && needs.prepare-release.outputs.created == 'true'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,7 +309,7 @@ jobs:
           # AppImage
           appimage_source="$(find src-tauri/target/release/bundle/appimage -type f -name '*.AppImage' | sort | head -n 1)"
           if [ -n "$appimage_source" ]; then
-            cp "$appimage_source" "release-assets/floral-notepaper_${ver}_x86_64.AppImage"
+            cp "$appimage_source" "release-assets/floral-notepaper_${ver}_amd64.AppImage"
           fi
 
           shopt -s nullglob

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,7 +263,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev patchelf libssl-dev libxdo-dev
 
       - name: Install frontend dependencies
         run: npm ci

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ src-tauri/icons/macOS
 
 ## Temp
 temp/
+nul

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,3 +1,3 @@
 {
-  "ignorePatterns": []
+  "ignorePatterns": ["**/*.hbs"]
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-简体中文 | [繁體中文](README_zh-HK.md) | [English](README_en-US.md)
+**简体中文** | [繁體中文](README_zh-HK.md) | [English](README_en-US.md)
 
 <!-- markdownlint-disable -->
 

--- a/README_en-US.md
+++ b/README_en-US.md
@@ -1,3 +1,4 @@
+[简体中文](README.md) | [繁體中文](README_zh-HK.md) | **English**
 <!-- markdownlint-disable -->
 
 <div align="center">

--- a/README_en-US.md
+++ b/README_en-US.md
@@ -1,4 +1,5 @@
 [简体中文](README.md) | [繁體中文](README_zh-HK.md) | **English**
+
 <!-- markdownlint-disable -->
 
 <div align="center">

--- a/README_zh-HK.md
+++ b/README_zh-HK.md
@@ -1,3 +1,4 @@
+[简体中文](README.md) | **繁體中文** | [English](README_en-US.md)
 <!-- markdownlint-disable -->
 
 <div align="center">
@@ -9,7 +10,6 @@
 輕巧、優雅、現代化的本機便箋工具<br>
 基於 Tauri 2 + React 構建
 
-[简体中文](README.md) · [English](README_en-US.md)<br>
 [回報問題](https://github.com/Achilng/floral-notepaper/issues) · [更新日誌](https://github.com/Achilng/floral-notepaper/releases)
 
 [![Version](https://img.shields.io/github/v/release/Achilng/floral-notepaper)](https://github.com/Achilng/floral-notepaper/releases/latest)

--- a/README_zh-HK.md
+++ b/README_zh-HK.md
@@ -1,4 +1,5 @@
 [简体中文](README.md) | **繁體中文** | [English](README_en-US.md)
+
 <!-- markdownlint-disable -->
 
 <div align="center">

--- a/nul
+++ b/nul
@@ -1,0 +1,1 @@
+sh: 1: taskkill: not found

--- a/nul
+++ b/nul
@@ -1,1 +1,0 @@
-sh: 1: taskkill: not found

--- a/src-tauri/linux-desktop-template.hbs
+++ b/src-tauri/linux-desktop-template.hbs
@@ -1,4 +1,7 @@
-[Desktop Entry] Type=Application Name=花笺 Exec={{exec}}
+[Desktop Entry]
+Type=Application
+Name=花笺
+Exec={{exec}}
 Icon={{icon}}
 Categories={{categories}}
 {{#if comment}}Comment={{comment}}{{/if}}

--- a/src-tauri/linux-desktop-template.hbs
+++ b/src-tauri/linux-desktop-template.hbs
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name=花笺
+Exec={{exec}}
+Icon={{icon}}
+Categories={{categories}}
+{{#if comment}}Comment={{comment}}{{/if}}

--- a/src-tauri/linux-desktop-template.hbs
+++ b/src-tauri/linux-desktop-template.hbs
@@ -1,7 +1,4 @@
-[Desktop Entry]
-Type=Application
-Name=花笺
-Exec={{exec}}
+[Desktop Entry] Type=Application Name=花笺 Exec={{exec}}
 Icon={{icon}}
 Categories={{categories}}
 {{#if comment}}Comment={{comment}}{{/if}}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -36,6 +36,11 @@
   "bundle": {
     "active": true,
     "targets": ["app", "dmg", "nsis", "deb", "rpm", "appimage"],
+    "linux": {
+      "appimage": {
+        "bundleMediaFramework": false
+      }
+    },
     "macOS": {
       "minimumSystemVersion": "15.0"
     },

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,7 +38,9 @@
     "targets": ["app", "dmg", "nsis", "deb", "rpm", "appimage"],
     "linux": {
       "deb": {
-        "depends": []
+        "depends": [],
+        "section": "utils",
+        "priority": "optional"
       },
       "rpm": {
         "epoch": 0,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -35,7 +35,19 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["app", "dmg", "nsis"],
+    "targets": ["app", "dmg", "nsis", "deb", "rpm", "appimage"],
+    "linux": {
+      "deb": {
+        "depends": []
+      },
+      "rpm": {
+        "epoch": 0,
+        "release": "1"
+      },
+      "appimage": {
+        "bundleMediaFramework": false
+      }
+    },
     "macOS": {
       "minimumSystemVersion": "15.0"
     },

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -36,20 +36,6 @@
   "bundle": {
     "active": true,
     "targets": ["app", "dmg", "nsis", "deb", "rpm", "appimage"],
-    "linux": {
-      "deb": {
-        "depends": [],
-        "section": "utils",
-        "priority": "optional"
-      },
-      "rpm": {
-        "epoch": 0,
-        "release": "1"
-      },
-      "appimage": {
-        "bundleMediaFramework": false
-      }
-    },
     "macOS": {
       "minimumSystemVersion": "15.0"
     },

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,13 @@
+{
+  "productName": "floral-notepaper",
+  "bundle": {
+    "linux": {
+      "deb": {
+        "desktopTemplate": "linux-desktop-template.hbs"
+      },
+      "rpm": {
+        "desktopTemplate": "linux-desktop-template.hbs"
+      }
+    }
+  }
+}

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -1,5 +1,7 @@
 {
   "productName": "floral-notepaper",
+  "version": "1.0.4",
+  "identifier": "com.floral-notepaper.app",
   "bundle": {
     "linux": {
       "deb": {

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -3,10 +3,18 @@
   "bundle": {
     "linux": {
       "deb": {
+        "depends": [],
+        "section": "utils",
+        "priority": "optional",
         "desktopTemplate": "linux-desktop-template.hbs"
       },
       "rpm": {
+        "epoch": 0,
+        "release": "1",
         "desktopTemplate": "linux-desktop-template.hbs"
+      },
+      "appimage": {
+        "bundleMediaFramework": false
       }
     }
   }


### PR DESCRIPTION
Related to #172


- CI/CD 添加Linux版本构建.

- `tauri.conf.json`添加Linux常见安装包`deb`,`rpm`,`AppImage`.

- 本机测试构建暗验证 [ ✔ ]

本机信息
```
OS: Ubuntu 26.04 LTS (Resolute Raccoon) x86_64
   Host: BoF-XX (M1010)
   Kernel: Linux 7.0.0-22-generic
   CPU: 12th Gen Intel(R) Core(TM) i7-1260P (16) @ 4.70 GHz
   GPU: Intel Iris Xe Graphics @ 1.40 GHz [Integrated]
   Memory: 14.84 GiB
   Display: 1920x1080 in 15", 60 Hz
   DE: GNOME 50.1
   WM: Mutter (Wayland)
   Shell: bash 5.3.9
   Locale: zh_CN.UTF-8
```

>构建的deb包安装好后测试运行的截图
<img width="1920" height="1052" alt="image" src="https://github.com/user-attachments/assets/8475a818-8bf9-4b04-8e97-f45e6360686d" />

- fork仓库CI/CD测试验证 [ ✔ ]

ubuntu 22.04构建，适合现代桌面发行版

[https://github.com/xingwangzhe/floral-notepaper/releases](https://github.com/xingwangzhe/floral-notepaper/releases)

<img width="902" height="479" alt="image" src="https://github.com/user-attachments/assets/38b6c64b-3a6e-48bd-b3f2-91056f0c1944" />
