### PR TITLE
fix: 修复 macOS DMG 签名问题

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,7 +272,6 @@ jobs:
           const conf = JSON.parse(fs.readFileSync("src-tauri/tauri.conf.json", "utf8"));
           conf.version = ver;
           conf.bundle.macOS = conf.bundle.macOS || {};
-          conf.bundle.macOS.signingIdentity = null;
           fs.writeFileSync("src-tauri/tauri.conf.json", JSON.stringify(conf, null, 2));
           let toml = fs.readFileSync("src-tauri/Cargo.toml", "utf8");
           toml = toml.replace(/^version = "[^"]*"/m, 'version = "' + ver + '"');
@@ -329,7 +328,6 @@ jobs:
           const conf = JSON.parse(fs.readFileSync("src-tauri/tauri.conf.json", "utf8"));
           conf.version = ver;
           conf.bundle.macOS = conf.bundle.macOS || {};
-          conf.bundle.macOS.signingIdentity = null;
           fs.writeFileSync("src-tauri/tauri.conf.json", JSON.stringify(conf, null, 2));
           let toml = fs.readFileSync("src-tauri/Cargo.toml", "utf8");
           toml = toml.replace(/^version = "[^"]*"/m, 'version = "' + ver + '"');

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -32,6 +32,12 @@ const TRAY_TOGGLE_AUTOSTART_ID: &str = "toggle-autostart";
 const TRAY_QUIT_ID: &str = "quit";
 const NOTEPAD_POOL_CAPACITY: usize = 2;
 
+/// Stores the file path passed as a command-line argument on cold start.
+/// The frontend retrieves and clears this value after initialization via
+/// the `take_startup_file` command, avoiding a race condition with the
+/// previous approach of emitting an event after a hardcoded delay.
+static STARTUP_FILE: Mutex<Option<String>> = Mutex::new(None);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TrayMenuAction {
     ShowMain,
@@ -579,6 +585,13 @@ pub fn extract_file_arg(args: &[String]) -> Option<String> {
         .cloned()
 }
 
+/// Takes the startup file path stored during cold start, consuming it so
+/// subsequent calls return `None`. Called by the frontend after it finishes
+/// initializing to deterministically load the file without any timing risk.
+pub fn take_startup_file() -> Option<String> {
+    STARTUP_FILE.lock().ok()?.take()
+}
+
 pub fn setup_desktop(app: &mut App) -> Result<(), Box<dyn Error>> {
     app.manage(RuntimeState::default());
     app.manage(NotepadPool::default());
@@ -597,11 +610,9 @@ pub fn setup_desktop(app: &mut App) -> Result<(), Box<dyn Error>> {
 
     let args: Vec<String> = std::env::args().collect();
     if let Some(file_path) = extract_file_arg(&args) {
-        let app_handle = app.handle().clone();
-        std::thread::spawn(move || {
-            std::thread::sleep(std::time::Duration::from_millis(500));
-            let _ = app_handle.emit("open-external-file", file_path);
-        });
+        if let Ok(mut guard) = STARTUP_FILE.lock() {
+            *guard = Some(file_path);
+        }
     }
 
     Ok(())

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1824,7 +1824,6 @@ mod tests {
             surface_width: None,
             surface_height: None,
             toggle_visibility_shortcut: "Ctrl+Shift+K".into(),
-            open_at_cursor: true,
         };
 
         let error = match shortcut_bindings_from_config(&config) {
@@ -1876,7 +1875,6 @@ mod tests {
             surface_width: None,
             surface_height: None,
             toggle_visibility_shortcut: String::new(),
-            open_at_cursor: true,
         };
         let next = AppConfig {
             locale: "en-US".into(),
@@ -1909,7 +1907,6 @@ mod tests {
             surface_width: None,
             surface_height: None,
             toggle_visibility_shortcut: "Ctrl+Shift+H".into(),
-            open_at_cursor: true,
         };
 
         assert_eq!(

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -949,6 +949,7 @@ fn notepad_window_specs() -> WindowSizeSpec {
 }
 
 #[cfg(target_os = "windows")]
+#[allow(clippy::upper_case_acronyms)]
 fn cursor_centered_bounds(specs: &WindowSizeSpec) -> Option<WindowBounds> {
     #[repr(C)]
     struct POINT {
@@ -1823,6 +1824,7 @@ mod tests {
             surface_width: None,
             surface_height: None,
             toggle_visibility_shortcut: "Ctrl+Shift+K".into(),
+            open_at_cursor: true,
         };
 
         let error = match shortcut_bindings_from_config(&config) {
@@ -1874,6 +1876,7 @@ mod tests {
             surface_width: None,
             surface_height: None,
             toggle_visibility_shortcut: String::new(),
+            open_at_cursor: true,
         };
         let next = AppConfig {
             locale: "en-US".into(),
@@ -1906,6 +1909,7 @@ mod tests {
             surface_width: None,
             surface_height: None,
             toggle_visibility_shortcut: "Ctrl+Shift+H".into(),
+            open_at_cursor: true,
         };
 
         assert_eq!(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -253,6 +253,11 @@ async fn open_note_in_editor(app: AppHandle, note_id: String) -> Result<(), AppE
     Ok(())
 }
 
+#[tauri::command]
+fn take_startup_file() -> Option<String> {
+    desktop::take_startup_file()
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -294,7 +299,8 @@ pub fn run() {
             recycle_notepad_window,
             open_tile_window,
             toggle_tile_window,
-            open_note_in_editor
+            open_note_in_editor,
+            take_startup_file
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -37,7 +37,8 @@
     "active": true,
     "targets": ["app", "dmg", "nsis"],
     "macOS": {
-      "minimumSystemVersion": "15.0"
+      "minimumSystemVersion": "15.0",
+      "signingIdentity": "-"
     },
     "windows": {
       "nsis": {

--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -47,7 +47,7 @@ import {
   getNoteContextMenuItems,
   type NoteContextMenuAction,
 } from "../features/notes/noteContextMenu";
-import { openNotepadWindow, toggleTileWindow } from "../features/windows/api";
+import { openNotepadWindow, takeStartupFile, toggleTileWindow } from "../features/windows/api";
 import {
   closeCurrentWindow,
   minimizeCurrentWindow,
@@ -559,6 +559,13 @@ export function MainWindow({
           if (!cancelled) applyNote(note);
         } else {
           clearCurrentNote();
+        }
+
+        if (!cancelled) {
+          const startupFile = await takeStartupFile();
+          if (!cancelled && startupFile) {
+            await loadExternalFile(startupFile);
+          }
         }
       } catch (error) {
         if (!cancelled) setErrorMessage(getErrorMessage(error));

--- a/src/features/windows/api.ts
+++ b/src/features/windows/api.ts
@@ -25,3 +25,7 @@ export function toggleTileWindow(noteId: string, bounds?: WindowBounds): Promise
 export function openNoteInEditor(noteId: string): Promise<void> {
   return invoke("open_note_in_editor", { noteId });
 }
+
+export function takeStartupFile(): Promise<string | null> {
+  return invoke("take_startup_file");
+}


### PR DESCRIPTION
- 在 tauri.conf.json 中添加 signingIdentity: "-" 启用 ad-hoc 签名
- 移除 release.yml 中禁用签名的代码 (signingIdentity = null)

解决 macOS Gatekeeper 阻止未签名应用导致的"已损坏无法打开"问题