### PR TITLE
fix: 修复#165 @13Aurora描述的问题

### DIFF
--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -226,9 +226,11 @@ impl RuntimeState {
         }
 
         if let Ok(mut guard) = self.hidden_window_labels.lock() {
-            guard.retain(|hidden_label| hidden_label != label);
-            if guard.is_empty() {
-                self.windows_hidden.store(false, Ordering::SeqCst);
+            if let Some(index) = guard.iter().position(|hidden_label| hidden_label == label) {
+                guard.remove(index);
+                if guard.is_empty() {
+                    self.windows_hidden.store(false, Ordering::SeqCst);
+                }
             }
         }
     }
@@ -521,6 +523,8 @@ fn toggle_app_visibility(app: &AppHandle) {
             if let Some(window) = app.get_webview_window(&label) {
                 let _ = window.set_focus();
             }
+        } else if let Err(error) = show_main_window(app) {
+            eprintln!("failed to show main window from visibility shortcut: {error}");
         }
         return;
     }
@@ -629,6 +633,7 @@ pub fn setup_desktop(app: &mut App) -> Result<(), Box<dyn Error>> {
 
 pub fn handle_window_event(window: &Window, event: &WindowEvent) {
     if matches!(event, WindowEvent::Destroyed) {
+        untrack_hidden_window(window.app_handle(), window.label());
         if let Some(note_id) = window.label().strip_prefix("tile-") {
             let _ = window
                 .app_handle()

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -220,6 +220,19 @@ impl RuntimeState {
             .ok()
     }
 
+    fn remove_hidden_window_label(&self, label: &str) {
+        if !self.windows_hidden.load(Ordering::SeqCst) {
+            return;
+        }
+
+        if let Ok(mut guard) = self.hidden_window_labels.lock() {
+            guard.retain(|hidden_label| hidden_label != label);
+            if guard.is_empty() {
+                self.windows_hidden.store(false, Ordering::SeqCst);
+            }
+        }
+    }
+
     fn hide_windows(&self, labels: Vec<String>) {
         if labels.is_empty() {
             self.clear_hidden_windows();
@@ -481,21 +494,9 @@ pub fn runtime_config_changes(previous: &AppConfig, next: &AppConfig) -> Runtime
     }
 }
 
-fn clear_hidden_window_state(app: &AppHandle) {
-    let labels = app
-        .try_state::<RuntimeState>()
-        .and_then(|state| state.take_hidden_window_labels());
-
-    let Some(labels) = labels else {
-        return;
-    };
-
-    for label in &labels {
-        if label.starts_with("notepad-") || label.starts_with("tile-") {
-            if let Some(window) = app.get_webview_window(label) {
-                let _ = window.close();
-            }
-        }
+fn untrack_hidden_window(app: &AppHandle, label: &str) {
+    if let Some(state) = app.try_state::<RuntimeState>() {
+        state.remove_hidden_window_label(label);
     }
 }
 
@@ -531,6 +532,14 @@ fn toggle_app_visibility(app: &AppHandle) {
             let _ = window.hide();
         }
     }
+
+    if labels.is_empty() {
+        if let Err(error) = show_main_window(app) {
+            eprintln!("failed to show main window from visibility shortcut: {error}");
+        }
+        return;
+    }
+
     state.hide_windows(labels);
 }
 
@@ -745,10 +754,10 @@ fn toggle_close_to_tray(_app: &AppHandle) -> Result<AppConfig, Box<dyn Error>> {
 }
 
 pub fn show_main_window(app: &AppHandle) -> Result<(), AppError> {
-    clear_hidden_window_state(app);
     let locale = configured_locale();
 
     if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
+        untrack_hidden_window(app, MAIN_WINDOW_LABEL);
         window.set_title(locales::main_window_title(locale))?;
         window.unminimize()?;
         window.show()?;
@@ -790,7 +799,7 @@ fn open_notepad_window_now(
 ) -> Result<String, AppError> {
     if note_id.is_none() {
         if let Some(reused) = activate_pooled_notepad(app, bounds) {
-            clear_hidden_window_state(app);
+            untrack_hidden_window(app, &reused);
             return Ok(reused);
         }
     }
@@ -1134,11 +1143,10 @@ fn open_or_focus_window(
     label: &str,
     opts: WindowOpenOptions,
 ) -> Result<String, AppError> {
-    clear_hidden_window_state(app);
-
     let visual_options = dynamic_window_visual_options(label);
 
     if let Some(window) = app.get_webview_window(label) {
+        untrack_hidden_window(app, label);
         window.set_title(&opts.title)?;
         apply_window_bounds(&window, opts.bounds)?;
         window.set_shadow(opts.shadow)?;
@@ -1828,6 +1836,7 @@ mod tests {
             background_position_x: 50.0,
             background_position_y: 50.0,
             remember_surface_size: true,
+            open_at_cursor: true,
             tile_ctrl_close: true,
             tile_render_markdown: false,
             render_html_markdown: false,
@@ -1879,6 +1888,7 @@ mod tests {
             background_position_x: 50.0,
             background_position_y: 50.0,
             remember_surface_size: true,
+            open_at_cursor: true,
             tile_ctrl_close: true,
             tile_render_markdown: false,
             render_html_markdown: false,
@@ -1911,6 +1921,7 @@ mod tests {
             background_position_x: 50.0,
             background_position_y: 50.0,
             remember_surface_size: true,
+            open_at_cursor: true,
             tile_ctrl_close: true,
             tile_render_markdown: false,
             render_html_markdown: false,
@@ -1936,6 +1947,36 @@ mod tests {
                 toggle_visibility_shortcut_changed: false,
             }
         );
+    }
+
+    #[test]
+    fn untracks_reopened_hidden_window_without_discarding_others() {
+        let state = RuntimeState::default();
+        state.hide_windows(vec![
+            MAIN_WINDOW_LABEL.to_string(),
+            "notepad-existing".to_string(),
+            "tile-existing".to_string(),
+        ]);
+
+        state.remove_hidden_window_label(MAIN_WINDOW_LABEL);
+
+        assert_eq!(
+            state.take_hidden_window_labels(),
+            Some(vec![
+                "notepad-existing".to_string(),
+                "tile-existing".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn untracking_last_hidden_window_clears_hidden_state() {
+        let state = RuntimeState::default();
+        state.hide_windows(vec![MAIN_WINDOW_LABEL.to_string()]);
+
+        state.remove_hidden_window_label(MAIN_WINDOW_LABEL);
+
+        assert_eq!(state.take_hidden_window_labels(), None);
     }
 
     #[test]


### PR DESCRIPTION
现在打开/聚焦某个窗口时 只把这个窗口从“隐藏窗口列表”里移除 不再关闭其他隐藏窗口
```rust
fn remove_hidden_window_label(&self, label: &str) {
    if !self.windows_hidden.load(Ordering::SeqCst) {
        return;
    }

    if let Ok(mut guard) = self.hidden_window_labels.lock() {
        guard.retain(|hidden_label| hidden_label != label);
        if guard.is_empty() {
            self.windows_hidden.store(false, Ordering::SeqCst);
        }
    }
}
```
再通过↓ 在窗口真正重新显示时调用它
```rust
fn untrack_hidden_window(app: &AppHandle, label: &str) {
    if let Some(state) = app.try_state::<RuntimeState>() {
        state.remove_hidden_window_label(label);
    }
}
```
在针对后台无窗口时快捷键无反应 在`toggle_app_visibility`里加了兜底
```rust
if labels.is_empty() {
    show_main_window(app)?;
}
```

Fixes #165