### PR TITLE
feat: 文章内标题链接滚动

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "rehype-katex": "^7.0.1",
         "rehype-raw": "^7.0.0",
         "rehype-sanitize": "^6.0.0",
+        "rehype-slug": "^6.0.0",
         "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0"
       },
@@ -3254,6 +3255,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "license": "ISC"
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -3324,6 +3331,19 @@
         "vfile": "^6.0.0",
         "vfile-location": "^5.0.0",
         "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-heading-rank": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
+      "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3436,6 +3456,19 @@
         "space-separated-tokens": "^2.0.0",
         "web-namespaces": "^2.0.0",
         "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5395,6 +5428,23 @@
       "dependencies": {
         "@types/hast": "^3.0.0",
         "hast-util-sanitize": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-slug": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmmirror.com/rehype-slug/-/rehype-slug-6.0.0.tgz",
+      "integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "github-slugger": "^2.0.0",
+        "hast-util-heading-rank": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "rehype-katex": "^7.0.1",
     "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
+    "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0"
   },

--- a/src/features/markdown/MarkdownPreview.tsx
+++ b/src/features/markdown/MarkdownPreview.tsx
@@ -6,6 +6,7 @@ import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
+import rehypeSlug from "rehype-slug";
 import type { Pluggable } from "unified";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import type { Components } from "react-markdown";
@@ -67,31 +68,32 @@ const sanitizeSchema = {
     abbr: ["title"],
   },
 };
-const rehypePluginsDefault = [rehypeKatex];
+const rehypePluginsDefault = [rehypeKatex, rehypeSlug];
 const rehypePluginsWithHtml: Pluggable[] = [
   rehypeRaw,
   [rehypeSanitize, sanitizeSchema],
   rehypeKatex,
+  rehypeSlug,
 ];
 
 const components: Components = {
-  h1: ({ children }) => (
-    <h1 className="text-[1.57em] font-display font-bold text-ink mt-6 mb-4 tracking-wide">
+  h1: ({ children, id }) => (
+    <h1 id={id} className="text-[1.57em] font-display font-bold text-ink mt-6 mb-4 tracking-wide">
       {children}
     </h1>
   ),
-  h2: ({ children }) => (
-    <h2 className="text-[1.21em] font-display font-bold text-ink mt-7 mb-3 tracking-wide">
+  h2: ({ children, id }) => (
+    <h2 id={id} className="text-[1.21em] font-display font-bold text-ink mt-7 mb-3 tracking-wide">
       {children}
     </h2>
   ),
-  h3: ({ children }) => (
-    <h3 className="text-[1.07em] font-display font-bold text-ink mt-5 mb-2 tracking-wide">
+  h3: ({ children, id }) => (
+    <h3 id={id} className="text-[1.07em] font-display font-bold text-ink mt-5 mb-2 tracking-wide">
       {children}
     </h3>
   ),
-  h4: ({ children }) => (
-    <h4 className="text-[1em] font-display font-semibold text-ink mt-4 mb-2 tracking-wide">
+  h4: ({ children, id }) => (
+    <h4 id={id} className="text-[1em] font-display font-semibold text-ink mt-4 mb-2 tracking-wide">
       {children}
     </h4>
   ),
@@ -138,7 +140,13 @@ const components: Components = {
       href={href}
       onClick={(e) => {
         e.preventDefault();
-        if (href && /^https?:\/\//i.test(href)) openUrl(href);
+        if (!href) return;
+        if (/^https?:\/\//i.test(href)) {
+          openUrl(href);
+        } else if (href.startsWith("#")) {
+          const id = decodeURIComponent(href.slice(1));
+          document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
+        }
       }}
       className="text-bamboo hover:text-bamboo-light underline underline-offset-2 cursor-pointer"
     >


### PR DESCRIPTION
Closes: https://github.com/Achilng/floral-notepaper/issues/179 — 文章内标题链接滚动

rebase之后重新提交一遍（在main上最新提交的地方rebase了一下，重新应用了更改），一个很简单的修改，改的Markdown的预览渲染：

- 添加 `rehype-slug` 依赖
- 给标题组件添加id传到DOM
- 点击 `href` 事件里添加对 `#` 开头的链接的处理，即点击时平滑滚动至对应标题（如果有对应的话）

<img width="1280" height="824" alt="QQ20260530-013004" src="https://github.com/user-attachments/assets/fce07a44-c9d2-4237-a159-8b73058c6394" />

所以到底发生什么事了要force push一下hhh