### PR TITLE
feat(markdown): add support for rendering PlantUML diagrams

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "rehype-sanitize": "^6.0.0",
         "rehype-slug": "^6.0.0",
         "remark-gfm": "^4.0.1",
+        "remark-kroki": "^0.3.8",
         "remark-math": "^6.0.0"
       },
       "devDependencies": {
@@ -2970,6 +2971,15 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3215,6 +3225,41 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/fsevents": {
@@ -3746,6 +3791,12 @@
         "katex": "cli.js"
       }
     },
+    "node_modules/kebab-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/kebab-case/-/kebab-case-2.0.2.tgz",
+      "integrity": "sha512-NhIP7vecGtqJfNZ85ct0yRQfx//gCJHapJCBZP6/BBcBw/U218Jw7YX7rO6TI5/cCp5dJvlIjN3vbcRTqq7nWA==",
+      "license": "MIT"
+    },
     "node_modules/lightningcss": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
@@ -4150,6 +4201,15 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/markdown-code-block-meta": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/markdown-code-block-meta/-/markdown-code-block-meta-0.0.2.tgz",
+      "integrity": "sha512-ZHoiTBgMIEP71IN5HJo3eU/7F2A1J4on8LU0bzMe7+n09oANJMKht6/VGHQmA41OK117WZ225f7Imd4IF2bokw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/markdown-table": {
@@ -5037,7 +5097,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
       "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -5069,6 +5128,44 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-releases": {
@@ -5196,6 +5293,22 @@
         "oxlint-tsgolint": {
           "optional": true
         }
+      }
+    },
+    "node_modules/p-memoize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/p-memoize/-/p-memoize-8.0.0.tgz",
+      "integrity": "sha512-jdZ10MCxavHoIHwJ5oweOtYy6ElPixEHaMkz0AuaEMovR1MRpVvYFzIEHRxgMEpXYzNpRVByFAniAzwmd1/uug==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.1",
+        "type-fest": "^4.41.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/p-memoize?sponsor=1"
       }
     },
     "node_modules/parse-entities": {
@@ -5467,6 +5580,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-kroki": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/remark-kroki/-/remark-kroki-0.3.8.tgz",
+      "integrity": "sha512-WQ+RaijsjCzb2gOQmRbQlm1SOS+v+CL+zVc+kZo6mxLiLdleRFUULhVzEsiCim0v9X/ZrxY9Nx2LPBUkok7TZA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^4.1.0",
+        "kebab-case": "^2.0.2",
+        "markdown-code-block-meta": "^0.0.2",
+        "node-fetch": "^3.3.2",
+        "p-memoize": "^8.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0 || ^16.13.0"
       }
     },
     "node_modules/remark-math": {
@@ -5871,6 +6001,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -6264,6 +6406,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/why-is-node-running": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "rehype-sanitize": "^6.0.0",
     "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.1",
+    "remark-kroki": "^0.3.8",
     "remark-math": "^6.0.0"
   },
   "devDependencies": {

--- a/src/App.css
+++ b/src/App.css
@@ -515,3 +515,28 @@ input::placeholder {
   font-size: 0.85em;
   font-family: var(--font-mono);
 }
+
+/* PlantUML diagram styles */
+.plantuml-diagram {
+  margin: 1.5em 0;
+  text-align: center;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding: 1em;
+  background: var(--color-paper-warm);
+  border-radius: 8px;
+  border: 1px solid var(--color-paper-deep);
+}
+.plantuml-diagram svg {
+  max-width: 100%;
+  height: auto;
+  display: inline-block;
+}
+.plantuml-diagram .kroki-error {
+  color: var(--color-danger, #ef4444);
+  font-size: 0.85em;
+  font-family: var(--font-mono);
+  padding: 1em;
+  background: var(--color-danger-bg);
+  border-radius: 4px;
+}

--- a/src/features/markdown/MarkdownPreview.tsx
+++ b/src/features/markdown/MarkdownPreview.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -11,6 +11,78 @@ import type { Pluggable } from "unified";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import type { Components } from "react-markdown";
 import "katex/dist/katex.min.css";
+
+interface PlantUmlDiagramProps {
+  code: string;
+}
+
+function PlantUmlDiagram({ code }: PlantUmlDiagramProps) {
+  const { t } = useTranslation();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [svgContent, setSvgContent] = useState("");
+
+  useEffect(() => {
+    let cleanedCode = code
+      .replace(/```plantuml\s*/gi, "")
+      .replace(/```\s*$/g, "")
+      .replace(/^@startuml\s*/m, "")
+      .replace(/@enduml\s*$/m, "")
+      .trim();
+
+    if (!cleanedCode.startsWith("@startuml")) {
+      cleanedCode = "@startuml\n" + cleanedCode + "\n@enduml";
+    }
+
+    const blob = new Blob([cleanedCode], { type: "text/plain" });
+
+    fetch("https://kroki.io/plantuml/svg", {
+      method: "POST",
+      body: blob,
+      headers: {
+        "Content-Type": "text/plain",
+      },
+    })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        return response.text();
+      })
+      .then((text) => {
+        setSvgContent(text);
+        setLoading(false);
+      })
+      .catch(() => {
+        setError(true);
+        setLoading(false);
+      });
+  }, [code]);
+
+  if (error) {
+    return (
+      <div className="my-4 p-4 bg-red-50 rounded border border-red-200 text-sm text-red-600">
+        {t("markdown.plantumlLoadError", {
+          defaultValue: "图表加载失败，请检查网络连接或 PlantUML 语法",
+        })}
+      </div>
+    );
+  }
+
+  return (
+    <div className="my-4 p-4 bg-white rounded-lg border border-gray-200 text-center overflow-x-auto shadow-sm">
+      {loading && (
+        <div className="text-gray-500 text-sm py-8">
+          {t("markdown.loadingDiagram", { defaultValue: "正在加载图表..." })}
+        </div>
+      )}
+      <div
+        className={`max-w-full h-auto ${loading ? "hidden" : "block mx-auto"}`}
+        dangerouslySetInnerHTML={{ __html: svgContent }}
+      />
+    </div>
+  );
+}
 
 function CodeBlock({ children }: { children: React.ReactNode }) {
   const { t } = useTranslation();
@@ -134,7 +206,21 @@ const components: Components = {
       </code>
     );
   },
-  pre: ({ children }) => <CodeBlock>{children}</CodeBlock>,
+  pre: ({ children }) => {
+    const codeElement = children as React.ReactElement<{
+      className?: string;
+      children?: React.ReactNode;
+    }>;
+    const codeClassName = codeElement?.props?.className || "";
+    const isPlantUml = codeClassName.includes("language-plantuml");
+
+    if (isPlantUml) {
+      const code = extractText(codeElement?.props?.children);
+      return <PlantUmlDiagram code={code} />;
+    }
+
+    return <CodeBlock>{children}</CodeBlock>;
+  },
   a: ({ href, children }) => (
     <a
       href={href}


### PR DESCRIPTION
close #213 

1. 新增PlantUML渲染组件，支持在Markdown中嵌入PlantUML图表
2. 自定义PlantUML图表样式与错误加载状态
3. 适配markdown代码块渲染逻辑，自动识别plantuml代码块并转换为svg图表

使用示例：
\\\plantuml
@startuml
Alice -> Bob: Hello
Bob --> Alice: Hi!
@enduml
\\\

当前缺点及待改进方案：
- PlantUML解析使用的是开源的第三方服务器(kroki.io)
- 后续在设置中增加设置选项，支持配置个人PlantUML服务器地址