### PR TITLE
提高可读性的默认设置和窗口对比度

### DIFF
--- a/src-tauri/src/services/notes.rs
+++ b/src-tauri/src/services/notes.rs
@@ -1001,11 +1001,11 @@ fn default_theme() -> String {
 }
 
 fn default_font_size() -> u32 {
-    14
+    16
 }
 
 fn default_surface_font_size() -> u32 {
-    14
+    16
 }
 
 fn default_tab_indent_size() -> u32 {
@@ -1242,8 +1242,8 @@ mod tests {
         assert_eq!(loaded.tile_color_mode, "system");
         assert_eq!(loaded.theme, "system");
         assert_eq!(loaded.locale, "zh-CN");
-        assert_eq!(loaded.font_size, 14);
-        assert_eq!(loaded.surface_font_size, 14);
+        assert_eq!(loaded.font_size, 16);
+        assert_eq!(loaded.surface_font_size, 16);
     }
 
     #[cfg(target_os = "macos")]

--- a/src/App.css
+++ b/src/App.css
@@ -13,9 +13,9 @@
   --color-paper-warm: #f0ebe0;
   --color-paper-deep: #e8e1d3;
   --color-ink: #1a1a18;
-  --color-ink-soft: #3d3d38;
-  --color-ink-faint: #8a8a80;
-  --color-ink-ghost: #b8b8ae;
+  --color-ink-soft: #2f2f2b;
+  --color-ink-faint: #68685f;
+  --color-ink-ghost: #949489;
   --color-bamboo: #2d5a3d;
   --color-bamboo-light: #3a7a52;
   --color-bamboo-mist: #e8f0eb;
@@ -45,9 +45,9 @@
   --color-paper-warm: #2c2a27;
   --color-paper-deep: #3c3935;
   --color-ink: #e5e1da;
-  --color-ink-soft: #b5b1a8;
-  --color-ink-faint: #928f87;
-  --color-ink-ghost: #706d67;
+  --color-ink-soft: #cbc6bc;
+  --color-ink-faint: #aaa59a;
+  --color-ink-ghost: #858176;
   --color-bamboo: #4faa70;
   --color-bamboo-light: #5fc085;
   --color-bamboo-mist: #1c2e22;
@@ -116,10 +116,17 @@ body {
 
 .app-main-frame {
   border-radius: var(--app-window-radius);
+  border: 1px solid color-mix(in srgb, var(--color-paper-deep) 82%, var(--color-ink) 18%);
+  box-shadow:
+    0 18px 48px rgba(26, 26, 24, 0.18),
+    0 0 0 1px rgba(26, 26, 24, 0.05);
 }
 
 .app-surface-frame {
   border-radius: var(--app-surface-radius);
+  box-shadow:
+    0 14px 38px rgba(26, 26, 24, 0.2),
+    0 0 0 1px rgba(26, 26, 24, 0.08);
 }
 
 .mac-window-controls {

--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -2197,7 +2197,7 @@ export function MainWindow({
                           }}
                           className="w-full h-full leading-[1.9] text-ink-soft font-body placeholder:text-ink-ghost/40"
                           style={{
-                            fontSize: `${settingsConfig?.fontSize ?? 14}px`,
+                            fontSize: `${settingsConfig?.fontSize ?? 16}px`,
                             tabSize: `var(--tab-indent-size, 2)`,
                           }}
                           placeholder={t("main.editor.contentPlaceholder", {
@@ -2246,7 +2246,7 @@ export function MainWindow({
                       >
                         <MarkdownPreview
                           content={content}
-                          fontSize={settingsConfig?.fontSize ?? 14}
+                          fontSize={settingsConfig?.fontSize ?? 16}
                           renderHtml={settingsConfig?.renderHtmlMarkdown ?? false}
                         />
                       </div>

--- a/src/components/NotePad.tsx
+++ b/src/components/NotePad.tsx
@@ -124,7 +124,7 @@ export function NotePad({
   const [noteSurfaceAutoSave, setNoteSurfaceAutoSave] = useState(initialAutoSave);
   const [tileColorRaw, setTileColorRaw] = useState(normalizeTileColor(initialTileColor));
   const [tileColorMode, setTileColorMode] = useState<TileColorMode>("system");
-  const [surfaceFontSize, setSurfaceFontSize] = useState(14);
+  const [surfaceFontSize, setSurfaceFontSize] = useState(16);
   const [tileRenderMarkdown, setTileRenderMarkdown] = useState(false);
   const [tileColor, setTileColor] = useState(() =>
     resolveTileColor("system", normalizeTileColor(initialTileColor)),
@@ -179,7 +179,7 @@ export function NotePad({
         const [loadedConfig] = await Promise.all([getConfig(), refreshNotes()]);
         if (!cancelled) {
           setNoteSurfaceAutoSave(loadedConfig.noteSurfaceAutoSave);
-          setSurfaceFontSize(loadedConfig.surfaceFontSize ?? 14);
+          setSurfaceFontSize(loadedConfig.surfaceFontSize ?? 16);
           setTileRenderMarkdown(loadedConfig.tileRenderMarkdown ?? false);
           setTileColorRaw(normalizeTileColor(loadedConfig.tileColor));
           setTileColorMode(loadedConfig.tileColorMode ?? "system");

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -251,12 +251,12 @@ export function SettingsPanel({ config, onChange, onChooseNotesDir, onClose }: S
               min={8}
               max={30}
               step={1}
-              value={config.fontSize ?? 14}
+              value={config.fontSize ?? 16}
               onChange={(event) => setConfigValue("fontSize", Number(event.target.value))}
               className="flex-1 h-1 accent-bamboo cursor-pointer appearance-none bg-transparent [&::-webkit-slider-runnable-track]:h-[3px] [&::-webkit-slider-runnable-track]:rounded-full [&::-webkit-slider-runnable-track]:bg-paper-deep/50 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-bamboo [&::-webkit-slider-thumb]:-mt-[4.5px] [&::-webkit-slider-thumb]:shadow-[0_1px_3px_rgba(0,0,0,0.15)]"
             />
             <span className="text-[12px] font-mono text-ink-soft tabular-nums w-8 text-right">
-              {config.fontSize ?? 14}px
+              {config.fontSize ?? 16}px
             </span>
           </div>
         </section>
@@ -271,12 +271,12 @@ export function SettingsPanel({ config, onChange, onChooseNotesDir, onClose }: S
               min={8}
               max={30}
               step={1}
-              value={config.surfaceFontSize ?? 14}
+              value={config.surfaceFontSize ?? 16}
               onChange={(event) => setConfigValue("surfaceFontSize", Number(event.target.value))}
               className="flex-1 h-1 accent-bamboo cursor-pointer appearance-none bg-transparent [&::-webkit-slider-runnable-track]:h-[3px] [&::-webkit-slider-runnable-track]:rounded-full [&::-webkit-slider-runnable-track]:bg-paper-deep/50 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-bamboo [&::-webkit-slider-thumb]:-mt-[4.5px] [&::-webkit-slider-thumb]:shadow-[0_1px_3px_rgba(0,0,0,0.15)]"
             />
             <span className="text-[12px] font-mono text-ink-soft tabular-nums w-8 text-right">
-              {config.surfaceFontSize ?? 14}px
+              {config.surfaceFontSize ?? 16}px
             </span>
           </div>
         </section>

--- a/src/components/Tile.tsx
+++ b/src/components/Tile.tsx
@@ -73,7 +73,7 @@ export function Tile({
   color = DEFAULT_TILE_COLOR,
   width = 260,
   rotation = 0,
-  fontSize = 14,
+  fontSize = 16,
   renderMarkdown = false,
   className = "",
   style,


### PR DESCRIPTION
摘要
在浅色模式下加深次要文本颜色，并在深色模式下提高弱对比文本的对比度

为主窗口和浮动笔记窗口添加更清晰的边框 / 阴影效果

将默认编辑器和笔记面板字体大小从 14px 增加到 16px，同时保留现有手动调整大小的控件

验证
npm run build

cargo test

这是一次针对 UI 可读性的集中改进，提取自我的本地分支，不包含个人发布脚本或私有笔记数据。

