### PR TITLE
fix: remove direct unified type dependency

### DIFF
--- a/src/features/markdown/MarkdownPreview.tsx
+++ b/src/features/markdown/MarkdownPreview.tsx
@@ -7,7 +7,6 @@ import rehypeKatex from "rehype-katex";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import rehypeSlug from "rehype-slug";
-import type { Pluggable } from "unified";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import type { Components } from "react-markdown";
@@ -80,12 +79,12 @@ const sanitizeSchema = {
   },
 };
 const rehypePluginsDefault = [rehypeKatex, rehypeSlug];
-const rehypePluginsWithHtml: Pluggable[] = [
+const rehypePluginsWithHtml = [
   rehypeRaw,
   [rehypeSanitize, sanitizeSchema],
   rehypeKatex,
   rehypeSlug,
-];
+] as Parameters<typeof Markdown>[0]["rehypePlugins"];
 
 const staticComponents: Components = {
   h1: ({ children, id }) => (


### PR DESCRIPTION
<!--
  提交 PR 前请逐项勾选确认。Please check all boxes before submitting.
  选择性填写，没有就不写。Fill in what's relevant; leave blank if not applicable.
-->

## Summary / 概要

## 问题
`import type { Pluggable } from "unified"` 导致 TypeScript 编译报错 TS2307，
因为 `unified` 是间接依赖，没有显式安装。

## 修复
移除对 `unified` 的直接引用，改从 `react-markdown` 自身的类型中推导，
消除隐式跨包类型依赖。

### Related Issue / 关联 Issue

<!-- Fixes #123, Closes #456, or related to #789 -->

### Affected Platforms / 影响平台

<!-- 勾选受影响或已验证的平台。Check platforms affected or verified. -->

- [x] Windows
- [ ] macOS
- [ ] Linux
- [ ] Platform-agnostic / 平台无关

## Screenshots or Recordings / 截图或录屏

<!-- 前端变更请附截图或录屏。Attach screenshots or recordings for frontend changes. -->

## Testing / 测试

<!-- 提供复现和验证步骤。Provide steps to verify the change. -->

无

## Checklist / 检查清单

### Code quality / 代码质量

您确认您运行并通过了：

- [x] `npx oxfmt --check`
- [x] `npx oxlint`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `npm test`

<!-- 感谢你对花笺 Floral Notepaper 的贡献！Thank you for your contribution! -->
