### PR TITLE
refactor: centralize locale option metadata

### DIFF
--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -18,7 +18,7 @@ import {
 import { useShortcutRecorder } from "../features/settings/useShortcutRecorder";
 import { DEFAULT_TILE_COLOR, normalizeTileColor } from "../features/settings/tileColor";
 import { applyTheme, watchSystemTheme } from "../features/settings/theme";
-import { SUPPORTED_LOCALES } from "../locales/locale-whitelist";
+import { LOCALE_OPTIONS } from "../locales/locale-whitelist";
 import { SlidingButtonGroup } from "./SlidingButtonGroup";
 
 const HARMONY_FONT_LICENSE_URL = new URL("../assets/fonts/LICENSE_Fonts", import.meta.url).href;
@@ -80,14 +80,9 @@ export function SettingsPanel({ config, onChange, onChooseNotesDir, onClose }: S
   );
   const localeOptions = useMemo(
     () =>
-      SUPPORTED_LOCALES.map((locale) => ({
-        value: locale,
-        label:
-          locale === "zh-CN"
-            ? t("settings.locale.zhCN", { defaultValue: "简体中文" })
-            : locale === "en-US"
-              ? t("settings.locale.enUS", { defaultValue: "English" })
-              : t("settings.locale.zhHK", { defaultValue: "繁體中文" }),
+      LOCALE_OPTIONS.map(({ value, labelKey, defaultLabel }) => ({
+        value,
+        label: t(labelKey, { defaultValue: defaultLabel }),
       })),
     [t],
   );

--- a/src/locales/locale-whitelist.test.ts
+++ b/src/locales/locale-whitelist.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "vitest";
-import { normalizeLocale, resolveAppLocale } from "./locale-whitelist";
+import {
+  LOCALE_OPTIONS,
+  SUPPORTED_LOCALES,
+  normalizeLocale,
+  resolveAppLocale,
+} from "./locale-whitelist";
 
 describe("locale whitelist", () => {
   test("normalizes supported locales and known aliases", () => {
@@ -7,6 +12,14 @@ describe("locale whitelist", () => {
     expect(normalizeLocale("zh-cn")).toBe("zh-CN");
     expect(normalizeLocale("zh-TW")).toBe("zh-HK");
     expect(normalizeLocale("en-GB")).toBe("en-US");
+  });
+
+  test("keeps display metadata in sync with supported locales", () => {
+    expect(LOCALE_OPTIONS.map((option) => option.value)).toEqual([...SUPPORTED_LOCALES]);
+    for (const option of LOCALE_OPTIONS) {
+      expect(option.labelKey).toMatch(/^settings\.locale\./);
+      expect(option.defaultLabel.length).toBeGreaterThan(0);
+    }
   });
 
   test("returns null for unsupported locales", () => {

--- a/src/locales/locale-whitelist.ts
+++ b/src/locales/locale-whitelist.ts
@@ -2,6 +2,18 @@ export const SUPPORTED_LOCALES = ["zh-CN", "en-US", "zh-HK"] as const;
 
 export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
 
+export interface LocaleOption {
+  value: SupportedLocale;
+  labelKey: string;
+  defaultLabel: string;
+}
+
+export const LOCALE_OPTIONS = [
+  { value: "zh-CN", labelKey: "settings.locale.zhCN", defaultLabel: "简体中文" },
+  { value: "en-US", labelKey: "settings.locale.enUS", defaultLabel: "English" },
+  { value: "zh-HK", labelKey: "settings.locale.zhHK", defaultLabel: "繁體中文" },
+] as const satisfies readonly LocaleOption[];
+
 export const DEFAULT_LOCALE: SupportedLocale = "zh-CN";
 
 const SUPPORTED_LOCALE_SET = new Set<string>(SUPPORTED_LOCALES);


### PR DESCRIPTION
## 变更内容

- 将受支持语言的展示元数据集中到 `locale-whitelist.ts`
- 将 `SettingsPanel` 中语言选项的硬编码分支改为读取统一的 locale metadata
- 新增测试，确保 `LOCALE_OPTIONS` 与 `SUPPORTED_LOCALES` 保持同步

## 调整原因

当前设置页里语言选项的展示文案是通过 `zh-CN / en-US / zh-HK` 分支硬编码出来的。后续如果继续新增语言，需要同时修改 locale 白名单和设置页 UI 分支，维护成本会逐渐变高。

这次调整把语言值、翻译 key 和默认展示文案集中维护，方便后续扩展新语言时只改统一配置，减少 UI 层重复判断。

## 验证

- `npm ci`
- `npm test`
- `npm run build`
- `npm run lint`
- `npm run fmt`
