### PR TITLE
refactor: extract markdown image source resolver

### DIFF
--- a/src/features/markdown/MarkdownPreview.tsx
+++ b/src/features/markdown/MarkdownPreview.tsx
@@ -12,6 +12,7 @@ import { convertFileSrc } from "@tauri-apps/api/core";
 import type { Components } from "react-markdown";
 import "katex/dist/katex.min.css";
 import remarkAlerts from "./remarkAlerts";
+import { resolveMarkdownImageSrc } from "./imageSrc";
 
 function CodeBlock({ children, language }: { children: React.ReactNode; language?: string }) {
   const { t } = useTranslation();
@@ -285,10 +286,7 @@ export function MarkdownPreview({
     () => ({
       ...staticComponents,
       img: ({ src, alt, ...props }) => {
-        let resolvedSrc = src ?? "";
-        if (src?.startsWith("images/") && imageBaseDir) {
-          resolvedSrc = convertFileSrc(imageBaseDir + "/" + src);
-        }
+        const resolvedSrc = resolveMarkdownImageSrc(src, imageBaseDir, convertFileSrc);
         return (
           <img
             src={resolvedSrc}

--- a/src/features/markdown/imageSrc.test.ts
+++ b/src/features/markdown/imageSrc.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { resolveMarkdownImageSrc } from "./imageSrc";
+
+describe("resolveMarkdownImageSrc", () => {
+  const convertFileSrc = vi.fn((path: string) => `asset://${path}`);
+
+  beforeEach(() => {
+    convertFileSrc.mockClear();
+  });
+
+  test("resolves note image paths under the images directory", () => {
+    expect(resolveMarkdownImageSrc("images/photo.png", "/notes/note-1", convertFileSrc)).toBe(
+      "asset:///notes/note-1/images/photo.png",
+    );
+    expect(convertFileSrc).toHaveBeenCalledWith("/notes/note-1/images/photo.png");
+  });
+
+  test("normalizes Windows-style separators before resolving note images", () => {
+    expect(resolveMarkdownImageSrc("images\\photo.png", "C:/notes/note-1", convertFileSrc)).toBe(
+      "asset://C:/notes/note-1/images/photo.png",
+    );
+    expect(convertFileSrc).toHaveBeenCalledWith("C:/notes/note-1/images/photo.png");
+  });
+
+  test("keeps non-note image paths unchanged", () => {
+    expect(
+      resolveMarkdownImageSrc("https://example.com/photo.png", "/notes/note-1", convertFileSrc),
+    ).toBe("https://example.com/photo.png");
+    expect(resolveMarkdownImageSrc("./photo.png", "/notes/note-1", convertFileSrc)).toBe(
+      "./photo.png",
+    );
+    expect(convertFileSrc).not.toHaveBeenCalled();
+  });
+
+  test("keeps image paths unchanged when the base directory is unavailable", () => {
+    expect(resolveMarkdownImageSrc("images/photo.png", undefined, convertFileSrc)).toBe(
+      "images/photo.png",
+    );
+    expect(convertFileSrc).not.toHaveBeenCalled();
+  });
+
+  test("returns an empty string for missing sources", () => {
+    expect(resolveMarkdownImageSrc(undefined, "/notes/note-1", convertFileSrc)).toBe("");
+  });
+});

--- a/src/features/markdown/imageSrc.ts
+++ b/src/features/markdown/imageSrc.ts
@@ -1,0 +1,20 @@
+export type FileSrcConverter = (path: string) => string;
+
+const NOTE_IMAGE_PREFIX = "images/";
+
+export function resolveMarkdownImageSrc(
+  src: string | undefined,
+  imageBaseDir: string | undefined,
+  convertFileSrc: FileSrcConverter,
+): string {
+  if (!src) {
+    return "";
+  }
+
+  const normalizedSrc = src.replace(/\\/g, "/");
+  if (!imageBaseDir || !normalizedSrc.startsWith(NOTE_IMAGE_PREFIX)) {
+    return src;
+  }
+
+  return convertFileSrc(`${imageBaseDir}/${normalizedSrc}`);
+}


### PR DESCRIPTION
## 变更内容

- 将 Markdown 预览中的本地图片路径解析逻辑提取到 `imageSrc.ts`
- 兼容 `images/foo.png` 与 `images\\foo.png` 两种笔记图片路径写法
- 为图片路径解析补充单元测试，覆盖本地图片、Windows 风格分隔符、外部链接、缺少基础目录和空路径等场景

## 调整原因

当前 `MarkdownPreview` 中直接内联处理图片路径，只判断 `images/` 前缀。将这段逻辑抽成纯函数后，图片路径解析规则更集中，也更方便测试和后续扩展。

同时，兼容 `images\\foo.png` 这类 Windows 风格路径，可以减少从不同系统或编辑器写入 Markdown 时的路径展示问题。

## 验证

- `npm test`
- `npm run build`
- `npm run lint`
- `npm run fmt`
