### PR TITLE
feat: support bulk markdown import

### DIFF
--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -4,7 +4,7 @@ import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import { emit, listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { exportMarkdownNote, importMarkdownNote } from "../features/importExport/api";
+import { exportMarkdownNote, importMarkdownNotes } from "../features/importExport/api";
 import { MarkdownPreview } from "../features/markdown/MarkdownPreview";
 import {
   chooseNotesDirectory,
@@ -911,11 +911,13 @@ export function MainWindow({
         if (!saved) return;
       }
 
-      const note = await importMarkdownNote(activeCategory);
-      if (!note) return;
+      const importedNotes = await importMarkdownNotes(activeCategory);
+      if (importedNotes.length === 0) return;
 
-      replaceNoteMetadata(note);
-      applyNote(note);
+      for (const note of importedNotes) {
+        replaceNoteMetadata(note);
+      }
+      applyNote(importedNotes[importedNotes.length - 1]);
     } catch (error) {
       setErrorMessage(getErrorMessage(error));
     }

--- a/src/features/importExport/api.test.ts
+++ b/src/features/importExport/api.test.ts
@@ -1,7 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { open, save } from "@tauri-apps/plugin-dialog";
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { exportMarkdownNote, importMarkdownNote } from "./api";
+import { exportMarkdownNote, importMarkdownNote, importMarkdownNotes } from "./api";
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn(),
@@ -49,10 +49,52 @@ describe("importExport api", () => {
     expect(note?.id).toBe("note-1");
   });
 
-  test("returns null when the file picker is cancelled", async () => {
+  test("imports multiple selected markdown paths through Rust", async () => {
+    mockedOpen.mockResolvedValue(["D:\\notes\\one.md", "D:\\notes\\two.md"]);
+    mockedInvoke
+      .mockResolvedValueOnce({
+        id: "note-1",
+        title: "one",
+        fileName: "note-1.md",
+        createdAt: "2026-04-28T00:00:00Z",
+        updatedAt: "2026-04-28T00:00:00Z",
+        wordCount: 1,
+        content: "# One",
+      })
+      .mockResolvedValueOnce({
+        id: "note-2",
+        title: "two",
+        fileName: "note-2.md",
+        createdAt: "2026-04-28T00:00:00Z",
+        updatedAt: "2026-04-28T00:00:00Z",
+        wordCount: 1,
+        content: "# Two",
+      });
+
+    const notes = await importMarkdownNotes("work");
+
+    expect(notes.map((note) => note.id)).toEqual(["note-1", "note-2"]);
+    expect(invoke).toHaveBeenNthCalledWith(1, "notes_import_markdown", {
+      path: "D:\\notes\\one.md",
+      category: "work",
+    });
+    expect(invoke).toHaveBeenNthCalledWith(2, "notes_import_markdown", {
+      path: "D:\\notes\\two.md",
+      category: "work",
+    });
+  });
+
+  test("returns null when the single file picker is cancelled", async () => {
     mockedOpen.mockResolvedValue(null);
 
     await expect(importMarkdownNote()).resolves.toBeNull();
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  test("returns empty results when the bulk file picker is cancelled", async () => {
+    mockedOpen.mockResolvedValue(null);
+
+    await expect(importMarkdownNotes()).resolves.toEqual([]);
     expect(invoke).not.toHaveBeenCalled();
   });
 

--- a/src/features/importExport/api.ts
+++ b/src/features/importExport/api.ts
@@ -24,6 +24,26 @@ export async function importMarkdownNote(category = ""): Promise<Note | null> {
   return invoke("notes_import_markdown", { path, category });
 }
 
+export async function importMarkdownNotes(category = ""): Promise<Note[]> {
+  const paths = await open({
+    multiple: true,
+    directory: false,
+    filters: markdownFilters,
+  });
+
+  if (!paths) {
+    return [];
+  }
+
+  const selectedPaths = Array.isArray(paths) ? paths : [paths];
+  const notes: Note[] = [];
+  for (const path of selectedPaths) {
+    notes.push(await invoke("notes_import_markdown", { path, category }));
+  }
+
+  return notes;
+}
+
 export async function exportMarkdownNote(note: ExportableNote): Promise<boolean> {
   const path = await save({
     defaultPath: markdownFileName(note.title),


### PR DESCRIPTION
## 变更内容

- 新增 `importMarkdownNotes`，支持一次选择多个 Markdown 文件导入
- 主窗口导入入口改为批量导入，导入完成后选中最后一个导入的笔记
- 保留原有 `importMarkdownNote` 单文件 API，避免影响既有调用语义
- 补充批量导入相关单元测试

## 调整原因

当前导入 Markdown 时文件选择器只能选择一个 `.md` 文件。如果用户需要迁移多篇 Markdown 笔记，需要重复打开文件选择器，操作成本较高。

这次调整让导入入口支持多选 Markdown 文件，同时保持单文件导入 API 不变，方便后续其他场景继续复用。

## 验证

- `npm test`
- `npm run build`
- `npm run lint`
- `npm run fmt`
