### PR TITLE
fix: improve clipboard image detection

### DIFF
--- a/src/features/images/useImagePaste.test.ts
+++ b/src/features/images/useImagePaste.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test, vi } from "vitest";
+import { getImageFiles, imageExtensionFromFile } from "./useImagePaste";
+
+function createFile(name: string, type = "") {
+  return new File(["image-data"], name, { type });
+}
+
+function createDataTransfer(files: File[], itemFiles: File[] = files): DataTransfer {
+  return {
+    files,
+    items: itemFiles.map((file) => ({
+      kind: "file",
+      type: file.type,
+      getAsFile: vi.fn(() => file),
+    })),
+  } as unknown as DataTransfer;
+}
+
+describe("useImagePaste helpers", () => {
+  test("detects image extension from mime type", () => {
+    expect(imageExtensionFromFile({ name: "clipboard", type: "image/png" })).toBe("png");
+    expect(imageExtensionFromFile({ name: "clipboard", type: "image/jpeg" })).toBe("jpg");
+  });
+
+  test("falls back to file extension when clipboard file type is missing", () => {
+    expect(imageExtensionFromFile({ name: "screenshot.PNG", type: "" })).toBe("png");
+    expect(imageExtensionFromFile({ name: "photo.jpeg", type: "" })).toBe("jpeg");
+  });
+
+  test("reads image files from dataTransfer.files when items do not expose files", () => {
+    const image = createFile("screenshot.png");
+    const text = createFile("note.txt", "text/plain");
+    const dataTransfer = createDataTransfer([image, text], []);
+
+    expect(getImageFiles(dataTransfer)).toEqual([image]);
+  });
+});

--- a/src/features/images/useImagePaste.ts
+++ b/src/features/images/useImagePaste.ts
@@ -13,6 +13,8 @@ const MIME_TO_EXT: Record<string, string> = {
   "image/svg+xml": "svg",
 };
 
+const IMAGE_EXTENSIONS = new Set(["png", "jpg", "jpeg", "gif", "webp", "bmp", "svg"]);
+
 interface UseImagePasteOptions {
   noteId: string | null;
   textareaRef: React.RefObject<HTMLTextAreaElement | null>;
@@ -32,12 +34,24 @@ async function processImageFile(file: File, noteId: string, t?: TFunction): Prom
     );
   }
 
-  const ext = MIME_TO_EXT[file.type];
+  const ext = imageExtensionFromFile(file);
   if (!ext) return null;
 
   const buffer = await file.arrayBuffer();
   const data = Array.from(new Uint8Array(buffer));
   return saveImage(noteId, data, ext);
+}
+
+export function imageExtensionFromFile(file: Pick<File, "name" | "type">): string | null {
+  const mimeExt = MIME_TO_EXT[file.type];
+  if (mimeExt) return mimeExt;
+
+  const extension = file.name.split(".").pop()?.toLowerCase();
+  return extension && IMAGE_EXTENSIONS.has(extension) ? extension : null;
+}
+
+function isImageFile(file: Pick<File, "name" | "type">): boolean {
+  return imageExtensionFromFile(file) !== null;
 }
 
 function insertTextAtCursor(
@@ -60,15 +74,27 @@ function insertTextAtCursor(
   });
 }
 
-function getImageFiles(dataTransfer: DataTransfer): File[] {
+export function getImageFiles(dataTransfer: DataTransfer): File[] {
   const files: File[] = [];
+  const seen = new Set<File>();
+
   for (let i = 0; i < dataTransfer.items.length; i++) {
     const item = dataTransfer.items[i];
-    if (item.kind === "file" && item.type in MIME_TO_EXT) {
-      const file = item.getAsFile();
-      if (file) files.push(file);
+    if (item.kind !== "file") continue;
+
+    const file = item.getAsFile();
+    if (file && isImageFile(file)) {
+      files.push(file);
+      seen.add(file);
     }
   }
+
+  for (let i = 0; i < dataTransfer.files.length; i++) {
+    const file = dataTransfer.files[i];
+    if (seen.has(file) || !isImageFile(file)) continue;
+    files.push(file);
+  }
+
   return files;
 }
 
@@ -149,9 +175,12 @@ export function useImagePaste({
   const handleDragOver = useCallback(
     (event: React.DragEvent<HTMLTextAreaElement>) => {
       if (disabled) return;
-      const hasImage = Array.from(event.dataTransfer.items).some(
-        (item) => item.kind === "file" && item.type in MIME_TO_EXT,
-      );
+      const hasImage =
+        Array.from(event.dataTransfer.items).some((item) => {
+          if (item.kind !== "file") return false;
+          const file = item.getAsFile();
+          return file ? isImageFile(file) : item.type in MIME_TO_EXT;
+        }) || Array.from(event.dataTransfer.files).some(isImageFile);
       if (hasImage) {
         event.preventDefault();
         event.dataTransfer.dropEffect = "copy";


### PR DESCRIPTION
## 变更内容

- 图片粘贴/拖拽时同时检查 `DataTransfer.items` 和 `DataTransfer.files`
- 当剪贴板图片文件缺少 MIME type 时，回退到文件名后缀识别图片类型
- 补充测试覆盖无 MIME type 的图片文件和 `dataTransfer.files` fallback 场景

## 调整原因

当前图片粘贴逻辑只识别 `DataTransfer.items` 中 `kind=file` 且 MIME type 明确为 `image/*` 的文件。部分 Windows 剪贴板/拖拽场景下，图片文件可能出现在 `DataTransfer.files` 中，或者文件 MIME type 为空但文件名后缀仍然是 `.png` / `.jpg` 等图片格式，导致图片被忽略，粘贴后没有任何效果。

这次调整让图片检测逻辑更宽容，提升 Windows 下复制粘贴/拖拽图片的兼容性。

## 验证

- `npm test`
- `npm run build`
- `npm run lint`
- `npm run fmt`
