### PR TITLE
fix: 修复 Windows 快捷方式目标路径错误

### DIFF
--- a/src-tauri/nsis-hooks.nsh
+++ b/src-tauri/nsis-hooks.nsh
@@ -1,8 +1,0 @@
-!macro NSIS_HOOK_PREINSTALL
-  ; Append product name subdirectory if user selected a generic folder
-  StrLen $R0 "\${PRODUCTNAME}"
-  IntOp $R0 0 - $R0
-  StrCpy $R1 "$INSTDIR" "" $R0
-  StrCmp $R1 "\${PRODUCTNAME}" +2
-    StrCpy $INSTDIR "$INSTDIR\${PRODUCTNAME}"
-!macroend

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -49,8 +49,7 @@
         "installMode": "both",
         "languages": ["SimpChinese"],
         "displayLanguageSelector": false,
-        "installerIcon": "icons/icon.ico",
-        "installerHooks": "nsis-hooks.nsh"
+        "installerIcon": "icons/icon.ico"
       }
     },
     "fileAssociations": [

--- a/tests/WindowsInstallerConfig.test.ts
+++ b/tests/WindowsInstallerConfig.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, test } from "vitest";
+
+describe("Windows installer configuration", () => {
+  test("respects the custom install directory selected by the user", () => {
+    const config = JSON.parse(
+      readFileSync(new URL("../src-tauri/tauri.conf.json", import.meta.url), "utf8"),
+    );
+
+    expect(config.bundle.windows.nsis).not.toHaveProperty("installerHooks");
+  });
+});


### PR DESCRIPTION
本次修复与测试由 Codex GPT-5.5 完成

分支名：
fix/windows-shortcut-target-path

建议 PR 标题：
fix: 修复 Windows 快捷方式目标路径错误

关联 Issue：
Fixes #243

## 问题

Windows 安装器在选择自定义安装目录时，桌面快捷方式的目标路径可能会多出一层 `花笺` 目录。

例如用户选择：

```text
D:\Program Files\FloralNotepaper
```

快捷方式可能会指向：

```text
D:\Program Files\FloralNotepaper\花笺\floral-notepaper.exe
```

这会导致快捷方式无法正确启动应用。

## 原因

原来的 NSIS 安装器 hook 会在安装前修改 `$INSTDIR`：如果用户选择的目录不是以产品名结尾，就自动追加一层 `${PRODUCTNAME}`。

也就是说，安装器会把用户选择的自定义目录再包一层 `花笺`，从而造成快捷方式目标路径不符合预期。

## 修复

移除了自定义 NSIS installer hook，并删除了 `tauri.conf.json` 中对该 hook 的引用。

这样 Windows 安装器会直接尊重用户选择的安装目录，不再自动追加额外的产品名目录。

## 测试

- `npm test -- tests/WindowsInstallerConfig.test.ts`
- `npm test`

## 说明

本次增加了一个配置级回归测试，确保 Windows NSIS 安装器不再引用这个自定义 hook，避免之后重新引入同类问题。

完整的 Windows 桌面快捷方式创建流程仍建议在 Windows 环境下最终确认。
