### PR TITLE
feat: add local image insert action

### DIFF
--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { MouseEvent } from "react";
+import type { ChangeEvent, MouseEvent } from "react";
 import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import { emit, listen } from "@tauri-apps/api/event";
@@ -33,7 +33,12 @@ import {
   saveExternalFile,
   updateNote,
 } from "../features/notes/api";
-import { cleanUnusedImages } from "../features/images/api";
+import { cleanUnusedImages, saveImage } from "../features/images/api";
+import {
+  imageExtensionFromFile,
+  insertMarkdownAtSelection,
+  markdownImageText,
+} from "../features/images/insertImage";
 import { useImagePaste } from "../features/images/useImagePaste";
 import { useImageBaseDir } from "../features/images/useImageBaseDir";
 import type { ExternalFile, Note, NoteMetadata } from "../features/notes/types";
@@ -323,6 +328,7 @@ export function MainWindow({
   const [categoryMenuClosing, setCategoryMenuClosing] = useState(false);
   const [categoryMenuConfirmDelete, setCategoryMenuConfirmDelete] = useState(false);
   const contentRef = useRef<HTMLTextAreaElement>(null);
+  const localImageInputRef = useRef<HTMLInputElement>(null);
   const externalFileMtimeRef = useRef<number>(0);
   const lastExternalSaveRef = useRef<number>(0);
   const imageBaseDir = useImageBaseDir();
@@ -1159,6 +1165,45 @@ export function MainWindow({
     onError: setErrorMessage,
     t,
   });
+
+  const handleInsertLocalImage = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+    if (!file || isExternal) return;
+
+    setErrorMessage(null);
+    try {
+      const ext = imageExtensionFromFile(file);
+      if (!ext) {
+        setErrorMessage(t("errors.unsupportedImageFormat", { defaultValue: "不支持的图片格式" }));
+        return;
+      }
+
+      const resolvedId = selectedId ?? (await ensureNoteSaved());
+      if (!resolvedId) return;
+
+      const textarea = contentRef.current;
+      if (!textarea) return;
+
+      const buffer = await file.arrayBuffer();
+      const relativePath = await saveImage(resolvedId, Array.from(new Uint8Array(buffer)), ext);
+      const next = insertMarkdownAtSelection(
+        textarea.value,
+        textarea.selectionStart,
+        textarea.selectionEnd,
+        markdownImageText(relativePath),
+      );
+
+      setContent(next.value);
+      markDirty();
+      requestAnimationFrame(() => {
+        textarea.focus();
+        textarea.setSelectionRange(next.cursor, next.cursor);
+      });
+    } catch (error) {
+      setErrorMessage(getErrorMessage(error));
+    }
+  };
 
   const handleCleanUnusedImages = async () => {
     if (!selectedId || isExternal) return;
@@ -2220,6 +2265,13 @@ export function MainWindow({
                       style={{ width: viewMode === "split" ? `${splitRatio * 100}%` : "100%" }}
                     >
                       <div className="flex items-center gap-0.5 px-4 pt-2 pb-1 shrink-0">
+                        <input
+                          ref={localImageInputRef}
+                          type="file"
+                          accept="image/png,image/jpeg,image/gif,image/webp,image/bmp,image/svg+xml"
+                          className="hidden"
+                          onChange={(event) => void handleInsertLocalImage(event)}
+                        />
                         {toolbarButtons.map((button) => (
                           <button
                             key={button.label}
@@ -2241,6 +2293,16 @@ export function MainWindow({
                             {button.label}
                           </button>
                         ))}
+                        <button
+                          type="button"
+                          title={t("main.toolbar.image", { defaultValue: "插入图片" })}
+                          disabled={!selectedId || isExternal}
+                          onMouseDown={(e) => e.preventDefault()}
+                          onClick={() => localImageInputRef.current?.click()}
+                          className="w-6 h-6 flex items-center justify-center rounded text-[11px] text-ink-ghost hover:text-ink-faint hover:bg-paper-warm disabled:opacity-40 disabled:hover:bg-transparent transition-all cursor-pointer disabled:cursor-not-allowed"
+                        >
+                          🖼
+                        </button>
                       </div>
 
                       <div className="flex-1 overflow-hidden px-5 pb-4">

--- a/src/features/images/insertImage.test.ts
+++ b/src/features/images/insertImage.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+import {
+  imageExtensionFromFile,
+  insertMarkdownAtSelection,
+  markdownImageText,
+} from "./insertImage";
+
+describe("insertImage helpers", () => {
+  test("resolves image extension from mime type", () => {
+    expect(imageExtensionFromFile({ name: "clipboard", type: "image/png" })).toBe("png");
+    expect(imageExtensionFromFile({ name: "clipboard", type: "image/jpeg" })).toBe("jpg");
+  });
+
+  test("falls back to file extension when mime type is missing", () => {
+    expect(imageExtensionFromFile({ name: "photo.PNG", type: "" })).toBe("png");
+    expect(imageExtensionFromFile({ name: "photo.jpeg", type: "" })).toBe("jpeg");
+  });
+
+  test("ignores unsupported file types", () => {
+    expect(imageExtensionFromFile({ name: "document.pdf", type: "application/pdf" })).toBeNull();
+    expect(imageExtensionFromFile({ name: "README", type: "" })).toBeNull();
+  });
+
+  test("builds markdown image text", () => {
+    expect(markdownImageText("images/note/photo.png")).toBe("![](images/note/photo.png)");
+  });
+
+  test("inserts markdown image text at selection with line breaks", () => {
+    expect(insertMarkdownAtSelection("hello world", 6, 11, "![](images/photo.png)")).toEqual({
+      value: "hello \n![](images/photo.png)\n",
+      cursor: 29,
+    });
+  });
+});

--- a/src/features/images/insertImage.ts
+++ b/src/features/images/insertImage.ts
@@ -1,0 +1,39 @@
+const IMAGE_MIME_TO_EXT: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/gif": "gif",
+  "image/webp": "webp",
+  "image/bmp": "bmp",
+  "image/svg+xml": "svg",
+};
+
+const IMAGE_EXTENSIONS = new Set(["png", "jpg", "jpeg", "gif", "webp", "bmp", "svg"]);
+
+export function imageExtensionFromFile(file: Pick<File, "name" | "type">): string | null {
+  const mimeExt = IMAGE_MIME_TO_EXT[file.type];
+  if (mimeExt) return mimeExt;
+
+  const extension = file.name.split(".").pop()?.toLowerCase();
+  return extension && IMAGE_EXTENSIONS.has(extension) ? extension : null;
+}
+
+export function markdownImageText(relativePath: string, alt = ""): string {
+  return `![${alt}](${relativePath})`;
+}
+
+export function insertMarkdownAtSelection(
+  value: string,
+  selectionStart: number,
+  selectionEnd: number,
+  markdown: string,
+): { value: string; cursor: number } {
+  const before = value.slice(0, selectionStart);
+  const after = value.slice(selectionEnd);
+  const needsLeadingNewline = before.length > 0 && !before.endsWith("\n");
+  const insertion = (needsLeadingNewline ? "\n" : "") + markdown + "\n";
+
+  return {
+    value: before + insertion + after,
+    cursor: before.length + insertion.length,
+  };
+}

--- a/src/features/images/useImagePaste.ts
+++ b/src/features/images/useImagePaste.ts
@@ -1,17 +1,9 @@
 import { useCallback, useRef } from "react";
 import type { TFunction } from "i18next";
 import { saveImage } from "./api";
+import { imageExtensionFromFile } from "./insertImage";
 
 const MAX_IMAGE_SIZE = 20 * 1024 * 1024; // 20 MB
-
-const MIME_TO_EXT: Record<string, string> = {
-  "image/png": "png",
-  "image/jpeg": "jpg",
-  "image/gif": "gif",
-  "image/webp": "webp",
-  "image/bmp": "bmp",
-  "image/svg+xml": "svg",
-};
 
 interface UseImagePasteOptions {
   noteId: string | null;
@@ -32,7 +24,7 @@ async function processImageFile(file: File, noteId: string, t?: TFunction): Prom
     );
   }
 
-  const ext = MIME_TO_EXT[file.type];
+  const ext = imageExtensionFromFile(file);
   if (!ext) return null;
 
   const buffer = await file.arrayBuffer();
@@ -64,10 +56,10 @@ function getImageFiles(dataTransfer: DataTransfer): File[] {
   const files: File[] = [];
   for (let i = 0; i < dataTransfer.items.length; i++) {
     const item = dataTransfer.items[i];
-    if (item.kind === "file" && item.type in MIME_TO_EXT) {
-      const file = item.getAsFile();
-      if (file) files.push(file);
-    }
+    if (item.kind !== "file") continue;
+
+    const file = item.getAsFile();
+    if (file && imageExtensionFromFile(file)) files.push(file);
   }
   return files;
 }
@@ -150,7 +142,7 @@ export function useImagePaste({
     (event: React.DragEvent<HTMLTextAreaElement>) => {
       if (disabled) return;
       const hasImage = Array.from(event.dataTransfer.items).some(
-        (item) => item.kind === "file" && item.type in MIME_TO_EXT,
+        (item) => item.kind === "file" && imageExtensionFromFile({ name: "", type: item.type }),
       );
       if (hasImage) {
         event.preventDefault();


### PR DESCRIPTION
## 变更内容

- 在 Markdown 编辑工具栏新增“插入图片”按钮
- 支持从本地选择 png/jpg/gif/webp/bmp/svg 图片，并保存到当前笔记图片目录
- 自动在当前光标位置插入 Markdown 图片语法
- 抽出图片扩展名识别和 Markdown 插入 helper，并补充单元测试
- 复用同一图片扩展名识别逻辑，避免粘贴与手动插入判断不一致

## 调整原因

当前编辑器已经支持粘贴/拖拽图片，但没有显式的“选择本地图片插入”入口。对于不方便使用剪贴板或拖拽的用户，添加工具栏按钮可以更直观地完成图片插入。

这次实现复用现有 `images_save` 存储能力，不新增后端命令，保持改动范围较小。

## 验证

- `npm test`
- `npm run build`
- `npm run lint`
- `npm run fmt`
