### PR TITLE
fix: 支持处理 WSL 路径下的笔记删除失败

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -19,6 +19,7 @@
     "core:window:allow-show",
     "core:window:allow-hide",
     "core:window:allow-set-focus",
+    "dialog:allow-message",
     "dialog:allow-open",
     "dialog:allow-save",
     "opener:default",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -38,8 +38,8 @@ fn notes_update(app: AppHandle, id: String, request: SaveNoteRequest) -> Result<
 }
 
 #[tauri::command]
-fn notes_delete(app: AppHandle, id: String) -> Result<(), AppError> {
-    default_store()?.delete_note(&id)?;
+fn notes_delete(app: AppHandle, id: String, permanent: Option<bool>) -> Result<(), AppError> {
+    default_store()?.delete_note(&id, permanent.unwrap_or(false))?;
     let _ = app.emit("notes-changed", ());
     Ok(())
 }

--- a/src-tauri/src/services/notes.rs
+++ b/src-tauri/src/services/notes.rs
@@ -417,6 +417,15 @@ impl NoteStore {
     }
 
     pub fn update_note(&self, id: &str, request: SaveNoteRequest) -> Result<Note, AppError> {
+        self.update_note_with(id, request, |path| trash::delete(path))
+    }
+
+    fn update_note_with<E: fmt::Display>(
+        &self,
+        id: &str,
+        request: SaveNoteRequest,
+        delete_stale_to_trash: impl FnOnce(&Path) -> Result<(), E>,
+    ) -> Result<Note, AppError> {
         self.ensure_storage()?;
         let mut metadata_file = self.load_metadata()?;
         let note = metadata_file
@@ -441,8 +450,11 @@ impl NoteStore {
         if old_file_name != new_file_name || old_category != new_category {
             let old_path = self.note_path_in_category(&old_file_name, &old_category);
             if old_path.exists() && old_path != new_path {
-                trash::delete(&old_path)
-                    .map_err(|e| AppError::new("trash", format!("移入回收站失败: {e}")))?;
+                delete_note_file_with(
+                    &old_path,
+                    NoteFileDeleteMode::StaleRenameCleanup,
+                    delete_stale_to_trash,
+                )?;
             }
         }
 
@@ -468,7 +480,16 @@ impl NoteStore {
         Ok(result)
     }
 
-    pub fn delete_note(&self, id: &str) -> Result<(), AppError> {
+    pub fn delete_note(&self, id: &str, permanent: bool) -> Result<(), AppError> {
+        self.delete_note_with(id, permanent, |path| trash::delete(path))
+    }
+
+    fn delete_note_with<E: fmt::Display>(
+        &self,
+        id: &str,
+        permanent: bool,
+        delete_to_trash: impl FnOnce(&Path) -> Result<(), E>,
+    ) -> Result<(), AppError> {
         self.ensure_storage()?;
         let mut metadata_file = self.load_metadata()?;
         let index = metadata_file
@@ -476,12 +497,16 @@ impl NoteStore {
             .iter()
             .position(|note| note.id == id)
             .ok_or_else(|| AppError::note_not_found(id))?;
-        let metadata = metadata_file.notes.remove(index);
+        let metadata = metadata_file.notes[index].clone();
         let path = self.note_path_in_category(&metadata.file_name, &metadata.category);
         if path.exists() {
-            trash::delete(&path)
-                .map_err(|e| AppError::new("trash", format!("移入回收站失败: {e}")))?;
+            delete_note_file_with(
+                &path,
+                NoteFileDeleteMode::Explicit { permanent },
+                delete_to_trash,
+            )?;
         }
+        metadata_file.notes.remove(index);
         self.save_metadata(&metadata_file)?;
         let _ = self.delete_note_images(id);
         Ok(())
@@ -1036,6 +1061,76 @@ fn is_markdown_path(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
+#[derive(Clone, Copy)]
+enum NoteFileDeleteMode {
+    Explicit { permanent: bool },
+    StaleRenameCleanup,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum NoteFileTrashFailure {
+    RemoveFile,
+    WslTrashUnavailable,
+    TrashUnavailable,
+}
+
+fn classify_note_file_trash_failure(path: &Path, mode: NoteFileDeleteMode) -> NoteFileTrashFailure {
+    if matches!(mode, NoteFileDeleteMode::StaleRenameCleanup) && is_wsl_markdown_path(path) {
+        return NoteFileTrashFailure::RemoveFile;
+    }
+
+    if is_wsl_markdown_path(path) {
+        NoteFileTrashFailure::WslTrashUnavailable
+    } else {
+        NoteFileTrashFailure::TrashUnavailable
+    }
+}
+
+fn delete_note_file_with<E: fmt::Display>(
+    path: &Path,
+    mode: NoteFileDeleteMode,
+    delete_to_trash: impl FnOnce(&Path) -> Result<(), E>,
+) -> Result<(), AppError> {
+    if matches!(mode, NoteFileDeleteMode::Explicit { permanent: true }) {
+        fs::remove_file(path)?;
+        return Ok(());
+    }
+
+    // EN: Rename cleanup can remove stale WSL files because the new note was already written.
+    // ZH: 重命名清理可以直接删除旧 WSL 文件，因为新笔记已经写入完成。
+    let trash_failure = classify_note_file_trash_failure(path, mode);
+
+    match delete_to_trash(path) {
+        Ok(()) => Ok(()),
+        Err(_) if matches!(trash_failure, NoteFileTrashFailure::RemoveFile) => {
+            fs::remove_file(path)?;
+            Ok(())
+        }
+        Err(error) if matches!(trash_failure, NoteFileTrashFailure::WslTrashUnavailable) => Err(AppError::new(
+            "wslTrashUnavailable",
+            "Windows 回收站无法处理 WSL 路径。请确认后使用永久删除，或先把笔记移到 Windows 文件夹。",
+        )
+        .with_detail("path", path.to_string_lossy())
+        .with_detail("trashError", error.to_string())),
+        Err(error) => Err(AppError::new(
+            "trash",
+            format!("移入回收站失败: {error}"),
+        )),
+    }
+}
+
+fn is_wsl_markdown_path(path: &Path) -> bool {
+    is_markdown_path(path) && is_windows_wsl_unc_path(path)
+}
+
+fn is_windows_wsl_unc_path(path: &Path) -> bool {
+    let normalized = path
+        .to_string_lossy()
+        .replace('/', "\\")
+        .to_ascii_lowercase();
+    normalized.starts_with(r"\\wsl.localhost\") || normalized.starts_with(r"\\wsl$\")
+}
+
 fn imported_markdown_title(path: &Path, content: &str) -> String {
     let first_line = content.lines().next().unwrap_or_default();
     let first_line = first_line.trim_start_matches('\u{feff}').trim_start();
@@ -1135,7 +1230,10 @@ fn default_locale() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{fs, path::PathBuf};
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+    };
 
     fn test_root(name: &str) -> PathBuf {
         let base = std::env::var_os("FLORAL_NOTEPAPER_TEST_TEMP_DIR")
@@ -1147,6 +1245,187 @@ mod tests {
         }
         fs::create_dir_all(&root).expect("create test root");
         root
+    }
+
+    #[test]
+    fn recognizes_windows_wsl_unc_note_paths() {
+        assert!(is_windows_wsl_unc_path(Path::new(
+            r"\\wsl.localhost\Ubuntu-22.04\home\me\notes\a.md"
+        )));
+        assert!(is_windows_wsl_unc_path(Path::new(
+            r"\\wsl$\Ubuntu-22.04\home\me\notes\a.md"
+        )));
+        assert!(!is_windows_wsl_unc_path(Path::new(
+            r"\\server\share\home\me\notes\a.md"
+        )));
+        assert!(!is_wsl_markdown_path(Path::new(
+            r"\\wsl.localhost\Ubuntu-22.04\home\me\notes\a.txt"
+        )));
+    }
+
+    #[test]
+    fn classifies_wsl_trash_failures_without_touching_unc_share() {
+        let wsl_note = Path::new(r"\\wsl.localhost\Ubuntu-22.04\home\me\notes\a.md");
+        let local_note = Path::new("notes/a.md");
+
+        assert_eq!(
+            classify_note_file_trash_failure(
+                wsl_note,
+                NoteFileDeleteMode::Explicit { permanent: false }
+            ),
+            NoteFileTrashFailure::WslTrashUnavailable
+        );
+        assert_eq!(
+            classify_note_file_trash_failure(wsl_note, NoteFileDeleteMode::StaleRenameCleanup),
+            NoteFileTrashFailure::RemoveFile
+        );
+        assert_eq!(
+            classify_note_file_trash_failure(local_note, NoteFileDeleteMode::StaleRenameCleanup),
+            NoteFileTrashFailure::TrashUnavailable
+        );
+    }
+
+    #[test]
+    fn permanently_removes_note_file_when_permanent_is_requested() {
+        let root = test_root("permanent-delete");
+        let note_path = root.join("note.md");
+        fs::write(&note_path, "hello").expect("write note");
+
+        delete_note_file_with(
+            &note_path,
+            NoteFileDeleteMode::Explicit { permanent: true },
+            |_| -> Result<(), &str> { panic!("trash should not be used for permanent delete") },
+        )
+        .expect("permanent delete removes note");
+
+        assert!(!note_path.exists());
+    }
+
+    #[test]
+    fn returns_trash_error_and_keeps_note_file_when_non_wsl_trash_fails() {
+        let root = test_root("trash-error-no-fallback");
+        let note_path = root.join("note.md");
+        fs::write(&note_path, "hello").expect("write note");
+
+        let error = delete_note_file_with(
+            &note_path,
+            NoteFileDeleteMode::Explicit { permanent: false },
+            |_| Err("simulated trash failure"),
+        )
+        .expect_err("trash failure is returned");
+
+        assert_eq!(error.code, "trash");
+        assert_eq!(error.message, "移入回收站失败: simulated trash failure");
+        assert!(note_path.exists());
+    }
+
+    #[test]
+    fn normal_delete_reports_wsl_trash_unavailable_for_synthetic_wsl_path() {
+        let wsl_note = Path::new(r"\\wsl.localhost\Ubuntu-22.04\home\me\notes\a.md");
+
+        let error = delete_note_file_with(
+            wsl_note,
+            NoteFileDeleteMode::Explicit { permanent: false },
+            |_| Err("simulated trash failure"),
+        )
+        .expect_err("WSL trash failure is returned");
+
+        assert_eq!(error.code, "wslTrashUnavailable");
+        assert_eq!(
+            error.details.get("path").map(String::as_str),
+            Some(wsl_note.to_string_lossy().as_ref())
+        );
+        assert_eq!(
+            error.details.get("trashError").map(String::as_str),
+            Some("simulated trash failure")
+        );
+    }
+
+    #[test]
+    fn normal_delete_keeps_note_and_metadata_when_trash_fails() {
+        let store = NoteStore::new(test_root("trash-unavailable-keeps-note"));
+        let note = store
+            .create_note(SaveNoteRequest {
+                title: "Local note".into(),
+                content: "hello".into(),
+                category: String::new(),
+            })
+            .expect("create note");
+        let note_path = store.note_path_in_category(&note.file_name, &note.category);
+
+        let error = store
+            .delete_note_with(&note.id, false, |_| Err("simulated trash failure"))
+            .expect_err("trash failure is returned");
+
+        assert_eq!(error.code, "trash");
+        assert!(note_path.exists());
+        assert_eq!(
+            store
+                .read_note(&note.id)
+                .expect("note metadata remains")
+                .content,
+            "hello"
+        );
+        assert_eq!(store.list_notes().expect("list notes").len(), 1);
+    }
+
+    #[test]
+    fn update_note_removes_stale_note_when_delete_callback_succeeds() {
+        let store = NoteStore::new(test_root("update-cleanup"));
+        let note = store
+            .create_note(SaveNoteRequest {
+                title: "Local note".into(),
+                content: "hello".into(),
+                category: String::new(),
+            })
+            .expect("create note");
+        let old_path = store.note_path_in_category(&note.file_name, &note.category);
+
+        let updated = store
+            .update_note_with(
+                &note.id,
+                SaveNoteRequest {
+                    title: "Renamed local note".into(),
+                    content: "new body".into(),
+                    category: String::new(),
+                },
+                |path| fs::remove_file(path).map_err(|error| error.to_string()),
+            )
+            .expect("rename cleanup removes stale note");
+        let new_path = store.note_path_in_category(&updated.file_name, &updated.category);
+
+        assert_ne!(old_path, new_path);
+        assert!(!old_path.exists());
+        assert!(new_path.exists());
+        assert_eq!(
+            store
+                .read_note(&note.id)
+                .expect("updated metadata remains")
+                .content,
+            "new body"
+        );
+        assert_eq!(store.list_notes().expect("list notes").len(), 1);
+    }
+
+    #[test]
+    fn permanent_delete_removes_note_and_metadata() {
+        let store = NoteStore::new(test_root("permanent-delete-note"));
+        let note = store
+            .create_note(SaveNoteRequest {
+                title: "Local note".into(),
+                content: "hello".into(),
+                category: String::new(),
+            })
+            .expect("create note");
+        let note_path = store.note_path_in_category(&note.file_name, &note.category);
+
+        store
+            .delete_note(&note.id, true)
+            .expect("permanent delete note");
+
+        assert!(!note_path.exists());
+        assert!(store.read_note(&note.id).is_err());
+        assert!(store.list_notes().expect("list after delete").is_empty());
     }
 
     #[test]
@@ -1190,7 +1469,7 @@ mod tests {
         assert_eq!(updated.content, "# 新标题\nsecond line");
         assert_ne!(updated.file_name, created.file_name);
 
-        store.delete_note(&created.id).expect("delete note");
+        store.delete_note(&created.id, false).expect("delete note");
         assert!(store.read_note(&created.id).is_err());
         assert!(store.list_notes().expect("list after delete").is_empty());
     }

--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -4,6 +4,7 @@ import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import { emit, listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import { confirm } from "@tauri-apps/plugin-dialog";
 import { exportMarkdownNote, importMarkdownNote } from "../features/importExport/api";
 import { MarkdownPreview } from "../features/markdown/MarkdownPreview";
 import {
@@ -25,6 +26,7 @@ import {
   getErrorMessage,
   getFileModifiedTime,
   getNote,
+  isWslTrashUnavailableError,
   listCategories,
   listNotes,
   moveNoteCategory,
@@ -987,6 +989,15 @@ export function MainWindow({
     }
   };
 
+  const refreshAfterDeletedNote = async (noteId: string) => {
+    const remaining = await refreshNotes();
+    if (noteId === selectedId && remaining[0]) {
+      await loadNote(remaining[0].id);
+    } else if (noteId === selectedId) {
+      clearCurrentNote();
+    }
+  };
+
   const handleDeleteNote = async (noteId = selectedId) => {
     if (!noteId) return;
 
@@ -994,13 +1005,39 @@ export function MainWindow({
     setErrorMessage(null);
     try {
       await deleteNote(noteId);
-      const remaining = await refreshNotes();
-      if (noteId === selectedId && remaining[0]) {
-        await loadNote(remaining[0].id);
-      } else if (noteId === selectedId) {
-        clearCurrentNote();
-      }
+      await refreshAfterDeletedNote(noteId);
     } catch (error) {
+      if (isWslTrashUnavailableError(error)) {
+        const shouldDeletePermanently = await confirm(
+          t("main.confirm.wslTrashUnavailableMessage", {
+            defaultValue:
+              "This note is stored in a WSL path, where the Windows Recycle Bin is unavailable. Keep the note, or permanently delete it instead?",
+          }),
+          {
+            title: t("main.confirm.wslTrashUnavailableTitle", {
+              defaultValue: "Recycle Bin unavailable",
+            }),
+            kind: "warning",
+            okLabel: t("main.confirm.permanentlyDelete", {
+              defaultValue: "Permanently Delete",
+            }),
+            cancelLabel: t("main.confirm.keepNote", {
+              defaultValue: "Keep Note",
+            }),
+          },
+        );
+
+        if (!shouldDeletePermanently) return;
+
+        try {
+          await deleteNote(noteId, { permanent: true });
+          await refreshAfterDeletedNote(noteId);
+        } catch (permanentError) {
+          setErrorMessage(getErrorMessage(permanentError));
+        }
+        return;
+      }
+
       setErrorMessage(getErrorMessage(error));
     }
   };

--- a/src/features/notes/api.test.ts
+++ b/src/features/notes/api.test.ts
@@ -1,6 +1,43 @@
 import { i18n } from "../../locales";
-import { describe, expect, test } from "vitest";
-import { getErrorMessage } from "./api";
+import { invoke } from "@tauri-apps/api/core";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { deleteNote, getErrorMessage, isWslTrashUnavailableError } from "./api";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+const mockedInvoke = vi.mocked(invoke);
+
+describe("notes api commands", () => {
+  beforeEach(() => {
+    mockedInvoke.mockReset();
+  });
+
+  test("deletes a note through the trash by default", async () => {
+    mockedInvoke.mockResolvedValue(undefined);
+
+    await deleteNote("note-1");
+
+    expect(invoke).toHaveBeenCalledWith("notes_delete", { id: "note-1" });
+  });
+
+  test("passes the permanent flag when permanent deletion is requested", async () => {
+    mockedInvoke.mockResolvedValue(undefined);
+
+    await deleteNote("note-1", { permanent: true });
+
+    expect(invoke).toHaveBeenCalledWith("notes_delete", { id: "note-1", permanent: true });
+  });
+});
+
+describe("notes api error helpers", () => {
+  test("detects WSL trash errors by backend code or name", () => {
+    expect(isWslTrashUnavailableError({ code: "wslTrashUnavailable" })).toBe(true);
+    expect(isWslTrashUnavailableError({ name: "wslTrashUnavailable" })).toBe(true);
+    expect(isWslTrashUnavailableError({ code: "noteNotFound" })).toBe(false);
+  });
+});
 
 describe("notes api error localization", () => {
   test("localizes structured backend errors with interpolation details", () => {

--- a/src/features/notes/api.ts
+++ b/src/features/notes/api.ts
@@ -4,11 +4,16 @@ import type { Note, NoteMetadata, SaveNoteRequest } from "./types";
 
 interface SerializedAppError {
   code?: unknown;
+  name?: unknown;
   message?: unknown;
   details?: unknown;
 }
 
 type ErrorDetails = Record<string, string>;
+
+export interface DeleteNoteOptions {
+  permanent?: boolean;
+}
 
 const LOCALIZED_ERROR_CODES = new Set([
   "categoryAlreadyExists",
@@ -39,8 +44,8 @@ export function updateNote(id: string, request: SaveNoteRequest): Promise<Note> 
   return invoke("notes_update", { id, request });
 }
 
-export function deleteNote(id: string): Promise<void> {
-  return invoke("notes_delete", { id });
+export function deleteNote(id: string, options: DeleteNoteOptions = {}): Promise<void> {
+  return invoke("notes_delete", options.permanent ? { id, permanent: true } : { id });
 }
 
 export function moveNoteCategory(id: string, category: string): Promise<NoteMetadata> {
@@ -96,6 +101,7 @@ function normalizeErrorDetails(value: unknown): ErrorDetails {
 
 function parseAppError(error: unknown): {
   code?: string;
+  name?: string;
   message?: string;
   details: ErrorDetails;
 } | null {
@@ -105,9 +111,15 @@ function parseAppError(error: unknown): {
 
   return {
     code: typeof error.code === "string" ? error.code : undefined,
+    name: typeof error.name === "string" ? error.name : undefined,
     message: typeof error.message === "string" ? error.message : undefined,
     details: normalizeErrorDetails(error.details),
   };
+}
+
+export function isWslTrashUnavailableError(error: unknown): boolean {
+  const appError = parseAppError(error);
+  return appError?.code === "wslTrashUnavailable" || appError?.name === "wslTrashUnavailable";
 }
 
 function shortcutFieldLabel(field: string | undefined, translate: TFunction): string | null {

--- a/src/locales/en-US/translation.json
+++ b/src/locales/en-US/translation.json
@@ -68,7 +68,11 @@
       "uncategorized": "Uncategorized"
     },
     "confirm": {
-      "unsavedExternalFile": "\"{{title}}\" has unsaved changes. Save to the original file?"
+      "keepNote": "Keep Note",
+      "permanentlyDelete": "Permanently Delete",
+      "unsavedExternalFile": "\"{{title}}\" has unsaved changes. Save to the original file?",
+      "wslTrashUnavailableMessage": "This note is stored in a WSL path, where the Windows Recycle Bin is unavailable. Keep the note, or permanently delete it instead?",
+      "wslTrashUnavailableTitle": "Recycle Bin unavailable"
     },
     "editor": {
       "confirmDelete": "Confirm delete?",

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -68,6 +68,10 @@
       "uncategorized": "未分类"
     },
     "confirm": {
+      "keepNote": "保留笔记",
+      "permanentlyDelete": "永久删除",
+      "wslTrashUnavailableMessage": "这篇笔记存储在 WSL 路径中，Windows 回收站不可用。要保留笔记，还是改为永久删除？",
+      "wslTrashUnavailableTitle": "回收站不可用",
       "unsavedExternalFile": "「{{title}}」有未保存的更改，是否保存到原文件？"
     },
     "editor": {

--- a/src/locales/zh-HK/translation.json
+++ b/src/locales/zh-HK/translation.json
@@ -68,6 +68,10 @@
       "uncategorized": "未分類"
     },
     "confirm": {
+      "keepNote": "保留筆記",
+      "permanentlyDelete": "永久刪除",
+      "wslTrashUnavailableMessage": "這篇筆記儲存在 WSL 路徑中，Windows 資源回收筒不可用。要保留筆記，還是改為永久刪除？",
+      "wslTrashUnavailableTitle": "資源回收筒不可用",
       "unsavedExternalFile": "「{{title}}」有未儲存的變更，是否儲存到原檔案？"
     },
     "editor": {


### PR DESCRIPTION
本次修复与测试由 Codex GPT-5.5 完成

分支名：
fix/wsl-trash-removal

建议 PR 标题：
fix: 支持处理 WSL 路径下的笔记删除失败

关联 Issue：
Fixes #224

## 问题

Windows 用户把笔记目录设置到 WSL 路径时，可以正常创建笔记，但右键删除笔记可能会失败。

例如笔记目录位于：

```text
\\wsl.localhost\Ubuntu-22.04\...
```

删除时报错类似：

```text
移入回收站失败
```

## 原因

当前删除笔记时会优先调用系统回收站能力，把文件移入回收站。

但 Windows 上的 WSL UNC 路径，例如 `\\wsl.localhost\...` 或 `\\wsl$\...`，不一定能被 Windows 回收站正常处理。也就是说，普通文件创建、写入可以成功，但“移入回收站”这一步可能失败。

之前这一步失败后，后端会直接返回错误，导致笔记无法从应用中删除。

## 修复

本次修复保留“优先移入系统回收站”的行为。

当移入回收站失败，并且目标是 WSL UNC 路径下的 Markdown 笔记文件时，后端不会直接永久删除文件，而是返回一个可识别的 `wslTrashUnavailable` 错误。

前端收到这个错误后，会弹出原生确认对话框，说明 Windows 回收站无法处理该 WSL 路径，并让用户选择：

- 保留笔记
- 直接永久删除

只有当用户明确选择“直接永久删除”时，前端才会再次调用删除接口，并传入 permanent delete 标记。

这样既解决了 WSL 路径下无法删除的问题，也避免在用户不知情的情况下静默永久删除笔记。

## 额外处理

笔记重命名或移动分类时，应用可能需要清理旧路径下的 Markdown 文件。

这种场景不是用户主动删除笔记，而是内部清理旧副本；新笔记文件已经写入完成。因此这类内部清理在 WSL 路径下仍允许在回收站失败后直接移除旧文件，避免重命名/移动后留下多余旧文件。

## 测试

已本地通过：

- `git diff --check`
- `npm test`
- `npm run lint`
- `npm run build`

其中 `npm run build` 仍有既有的大 chunk 提示，但构建成功。

由于当前本机没有 Rust 工具链，以下 Rust 检查无法在本地运行，需要由 GitHub CI 覆盖：

- `cargo fmt`
- `cargo test`
- `cargo clippy`

## 说明

本次新增了针对 WSL UNC 路径识别、前端 permanent delete 参数、WSL 回收站失败识别、以及用户确认后永久删除流程的回归测试。

完整的 WSL UNC 删除流程仍建议在 Windows + WSL 环境下最终确认。
