### PR TITLE
feat: add Ctrl+W shortcut to close main window and notepad

### DIFF
--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -1003,9 +1003,17 @@ export function MainWindow({
 
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
-      if ((event.ctrlKey || event.metaKey) && event.key === "s") {
+      if (!(event.ctrlKey || event.metaKey)) return;
+
+      if (event.key === "s") {
         event.preventDefault();
         void saveCurrentNote();
+        return;
+      }
+
+      if (event.key === "w") {
+        event.preventDefault();
+        void closeCurrentWindow();
       }
     }
 

--- a/src/components/NotePad.tsx
+++ b/src/components/NotePad.tsx
@@ -440,18 +440,6 @@ export function NotePad({
     }
   }, [saveNote]);
 
-  useEffect(() => {
-    function handleKeyDown(event: KeyboardEvent) {
-      if ((event.ctrlKey || event.metaKey) && event.key === "s") {
-        event.preventDefault();
-        void handleSave();
-      }
-    }
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [handleSave]);
-
   const handleOpenNote = async (noteId: string) => {
     try {
       const note = await getNote(noteId);
@@ -481,6 +469,26 @@ export function NotePad({
       showToast(getErrorMessage(error));
     });
   }, [surfaceMode]);
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (!(event.ctrlKey || event.metaKey)) return;
+
+      if (event.key === "s") {
+        event.preventDefault();
+        void handleSave();
+        return;
+      }
+
+      if (event.key === "w") {
+        event.preventDefault();
+        handleClose();
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [handleClose, handleSave]);
 
   const copyTileContent = useCallback(async () => {
     try {


### PR DESCRIPTION
<!--
  提交 PR 前请逐项勾选确认。Please check all boxes before submitting.
  选择性填写，没有就不写。Fill in what's relevant; leave blank if not applicable.
-->

## Summary / 概要

- 主窗口支持 Ctrl+W（macOS 为 Cmd+W）关闭，行为与点击标题栏关闭按钮一致；开启「关闭到托盘」时隐藏到系统托盘
- 快捷便签/磁贴窗口同样支持 Ctrl+W 关闭（便签回收、磁贴直接关闭）

## Related Issue / 关联 Issue

Closes Achilng/floral-notepaper#210

## Affected Platforms / 影响平台

- [x] Windows
- [ ] macOS
- [ ] Linux
- [x] Platform-agnostic / 平台无关

## Screenshots or Recordings / 截图或录屏

N/A

## Testing / 测试

1. 主窗口按 Ctrl+W → 隐藏到托盘（需开启「关闭到托盘」）或退出应用
2. 快捷便签（Ctrl+Space 唤出）按 Ctrl+W → 窗口关闭/回收
3. 磁贴窗口按 Ctrl+W → 窗口关闭

## Checklist / 检查清单

### Code quality / 代码质量

您确认您运行并通过了：

- [x] `npx oxfmt --check`
- [x] `npx oxlint`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `npm test`

<!-- 感谢你对花笺 Floral Notepaper 的贡献！Thank you for your contribution! -->
