### PR TITLE
快捷便签小窗「打开」标签页增加搜索/Linux 打包与构建工具链

### DIFF
--- a/scripts/fetch-contributors.mjs
+++ b/scripts/fetch-contributors.mjs
@@ -5,6 +5,11 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const OUTPUT = resolve(__dirname, "../src/generated/contributors.json");
 
+function writeContributors(contributors) {
+  mkdirSync(dirname(OUTPUT), { recursive: true });
+  writeFileSync(OUTPUT, JSON.stringify(contributors, null, 2) + "\n");
+}
+
 const REPO = "Achilng/floral-notepaper";
 const API_URL = `https://api.github.com/repos/${REPO}/contributors?per_page=100`;
 
@@ -31,8 +36,7 @@ async function fetchContributors() {
 
 try {
   const contributors = await fetchContributors();
-  mkdirSync(dirname(OUTPUT), { recursive: true });
-  writeFileSync(OUTPUT, JSON.stringify(contributors, null, 2) + "\n");
+  writeContributors(contributors);
   console.log(`[contributors] wrote ${contributors.length} contributors`);
 } catch (err) {
   if (existsSync(OUTPUT)) {
@@ -41,7 +45,7 @@ try {
       `[contributors] API failed (${err.message}), keeping cached ${cached.length} contributors`,
     );
   } else {
-    writeFileSync(OUTPUT, "[]\n");
+    writeContributors([]);
     console.warn(`[contributors] API failed (${err.message}), wrote empty fallback`);
   }
 }

--- a/scripts/fetch-contributors.mjs
+++ b/scripts/fetch-contributors.mjs
@@ -15,8 +15,9 @@ const API_URL = `https://api.github.com/repos/${REPO}/contributors?per_page=100`
 
 async function fetchContributors() {
   const headers = { "User-Agent": "floral-notepaper-build" };
-  if (process.env.GITHUB_TOKEN) {
-    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
   }
 
   const res = await fetch(API_URL, { headers });

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1204,6 +1204,7 @@ fn hide_fullscreen_window(window: &Window) {
     use objc2_app_kit::NSView;
     use objc2_foundation::{NSNotificationCenter, NSString};
     use raw_window_handle::{HasWindowHandle as _, RawWindowHandle};
+    use std::rc::Rc;
 
     let Ok(handle) = window.window_handle() else {
         let _ = window.hide();
@@ -1225,9 +1226,9 @@ fn hide_fullscreen_window(window: &Window) {
 
     let retained = window.app_handle().clone();
     let label = window.label().to_string();
-    let observer_holder: Arc<OnceLock<objc2::rc::Retained<objc2::runtime::AnyObject>>> =
-        Arc::new(OnceLock::new());
-    let observer_ref = Arc::clone(&observer_holder);
+    let observer_holder: Rc<OnceLock<objc2::rc::Retained<objc2::runtime::AnyObject>>> =
+        Rc::new(OnceLock::new());
+    let observer_ref = Rc::clone(&observer_holder);
     let block = RcBlock::new(move |_notification: std::ptr::NonNull<_>| {
         if FULLSCREEN_HIDING.swap(false, Ordering::SeqCst) {
             if let Some(w) = retained.get_webview_window(&label) {

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1249,7 +1249,7 @@ fn hide_fullscreen_window(window: &Window) {
             &block,
         )
     };
-    let _ = observer_holder.set(observer);
+    let _ = observer_holder.set(observer.into());
 
     FULLSCREEN_HIDING.store(true, Ordering::SeqCst);
     let _ = window.set_fullscreen(false);

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 #[cfg(target_os = "macos")]
-use std::sync::{Arc, OnceLock};
+use std::sync::OnceLock;
 use std::{
     error::Error,
     sync::{

--- a/src/components/AboutPanel.tsx
+++ b/src/components/AboutPanel.tsx
@@ -3,8 +3,16 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { UpdateSettingsSection } from "../features/update/UpdateSettingsSection";
-import contributors from "../generated/contributors.json";
+import contributorsData from "../generated/contributors.json";
 import { getTips, parseTip } from "../locales/tips";
+
+interface Contributor {
+  login: string;
+  avatar_url: string;
+  html_url: string;
+}
+
+const contributors = contributorsData as Contributor[];
 
 interface AboutPanelProps {
   onClose: () => void;

--- a/src/components/NotePad.tsx
+++ b/src/components/NotePad.tsx
@@ -9,12 +9,7 @@ import { reportInstallPreparation } from "../features/update/api";
 import type { UpdateInstallPrepareRequest } from "../features/update/types";
 import { showToast } from "./Toast";
 import type { Note, NoteMetadata } from "../features/notes/types";
-import {
-  countNoteChars,
-  formatShortDate,
-  getDisplayTitle,
-  metadataFromNote,
-} from "../features/notes/noteUtils";
+import { countNoteChars, metadataFromNote } from "../features/notes/noteUtils";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
@@ -27,7 +22,6 @@ import {
   startCurrentWindowDrag,
   startCurrentWindowResize,
 } from "../features/windows/controls";
-import { openNoteInEditor } from "../features/windows/api";
 import type { ResizeDirection } from "../features/windows/controls";
 import { getConfig } from "../features/settings/api";
 import {
@@ -51,6 +45,7 @@ import {
   emitTileWindowUnpinned,
   tileSurfaceModeUnpinNoteId,
 } from "../features/windows/tileWindowEvents";
+import { NotepadOpenPanel } from "./NotepadOpenPanel";
 import { Tile } from "./Tile";
 
 type OpenMode = "new" | "open";
@@ -123,7 +118,6 @@ export function NotePad({
   const [editingNoteId, setEditingNoteId] = useState<string | null>(null);
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
-  const [hoveredNote, setHoveredNote] = useState<string | null>(null);
   const [status, setStatus] = useState<NotePadStatus>("empty");
   const [noteSurfaceAutoSave, setNoteSurfaceAutoSave] = useState(initialAutoSave);
   const [tileColorRaw, setTileColorRaw] = useState(normalizeTileColor(initialTileColor));
@@ -754,66 +748,10 @@ export function NotePad({
                 </div>
               </div>
             ) : (
-              <div className="p-2 flex-1 min-h-0 overflow-y-auto">
-                <div className="space-y-0.5">
-                  {notes.map((note) => (
-                    <button
-                      key={note.id}
-                      onClick={() => void handleOpenNote(note.id)}
-                      onMouseEnter={() => setHoveredNote(note.id)}
-                      onMouseLeave={() => setHoveredNote(null)}
-                      className="w-full text-left px-3.5 py-3 rounded-xl transition-all duration-200 cursor-pointer group hover:bg-paper-warm/70"
-                    >
-                      <div className="flex items-center justify-between mb-0.5">
-                        <span className="text-[13px] font-display font-medium text-ink-soft group-hover:text-ink transition-colors truncate pr-2">
-                          {getDisplayTitle(note)}
-                        </span>
-                        <div className="flex items-center gap-1.5 shrink-0">
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              void openNoteInEditor(note.id);
-                            }}
-                            className="w-6 h-6 flex items-center justify-center rounded-md text-ink-ghost hover:text-bamboo hover:bg-bamboo-mist/50 transition-all duration-200 opacity-0 group-hover:opacity-100 cursor-pointer"
-                            title={t("notepad.tooltip.openInEditor", {
-                              defaultValue: "在编辑器中打开",
-                            })}
-                          >
-                            <svg
-                              width="13"
-                              height="13"
-                              viewBox="0 0 24 24"
-                              fill="none"
-                              stroke="currentColor"
-                              strokeWidth="2"
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                            >
-                              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-                              <polyline points="15 3 21 3 21 9" />
-                              <line x1="10" y1="14" x2="21" y2="3" />
-                            </svg>
-                          </button>
-                          <span className="text-[11px] text-ink-ghost font-mono tabular-nums">
-                            {formatShortDate(note.updatedAt)}
-                          </span>
-                        </div>
-                      </div>
-                      <p className="text-[12px] text-ink-ghost leading-relaxed line-clamp-1 group-hover:text-ink-faint transition-colors">
-                        {note.preview || t("common.blankNote", { defaultValue: "空白笔记" })}
-                      </p>
-                      {hoveredNote === note.id && (
-                        <div className="mt-1.5 h-px bg-bamboo/10 transition-all duration-300" />
-                      )}
-                    </button>
-                  ))}
-                  {notes.length === 0 && (
-                    <div className="px-4 py-8 text-center text-[12px] text-ink-ghost">
-                      {t("notepad.emptyState", { defaultValue: "还没有可打开的笔记" })}
-                    </div>
-                  )}
-                </div>
-              </div>
+              <NotepadOpenPanel
+                notes={notes}
+                onOpenNote={(noteId) => void handleOpenNote(noteId)}
+              />
             )}
           </>
           <SurfaceResizeHandles />

--- a/src/components/NotepadOpenPanel.tsx
+++ b/src/components/NotepadOpenPanel.tsx
@@ -1,0 +1,133 @@
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { openNoteInEditor } from "../features/windows/api";
+import { filterNotes, formatShortDate, getDisplayTitle } from "../features/notes/noteUtils";
+import type { NoteMetadata } from "../features/notes/types";
+
+interface NotepadOpenPanelProps {
+  notes: NoteMetadata[];
+  onOpenNote: (noteId: string) => void;
+}
+
+export function NotepadOpenPanel({ notes, onOpenNote }: NotepadOpenPanelProps) {
+  const { t } = useTranslation();
+  const [searchQuery, setSearchQuery] = useState("");
+  const [hoveredNote, setHoveredNote] = useState<string | null>(null);
+
+  const filteredNotes = useMemo(() => filterNotes(notes, searchQuery), [notes, searchQuery]);
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <div className="px-3 pt-2 pb-1.5 shrink-0">
+        <div className="flex items-center gap-2 px-2.5 py-1.5 rounded-lg bg-paper-warm/60 border border-paper-deep/30">
+          <svg
+            width="13"
+            height="13"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            className="text-ink-ghost shrink-0"
+          >
+            <circle cx="11" cy="11" r="8" />
+            <path d="m21 21-4.35-4.35" />
+          </svg>
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder={t("notepad.search.placeholder", { defaultValue: "搜索笔记…" })}
+            className="flex-1 text-[12px] font-body text-ink placeholder:text-ink-ghost/60 bg-transparent"
+          />
+          {searchQuery && (
+            <button
+              type="button"
+              onClick={() => setSearchQuery("")}
+              className="text-ink-ghost hover:text-ink-faint transition-colors cursor-pointer"
+              title={t("notepad.search.clear", { defaultValue: "清空搜索" })}
+            >
+              <svg
+                width="10"
+                height="10"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="3"
+                strokeLinecap="round"
+              >
+                <path d="M18 6L6 18M6 6l12 12" />
+              </svg>
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="p-2 pt-0 flex-1 min-h-0 overflow-y-auto">
+        <div className="space-y-0.5">
+          {filteredNotes.map((note) => (
+            <button
+              key={note.id}
+              type="button"
+              onClick={() => onOpenNote(note.id)}
+              onMouseEnter={() => setHoveredNote(note.id)}
+              onMouseLeave={() => setHoveredNote(null)}
+              className="w-full text-left px-3.5 py-3 rounded-xl transition-all duration-200 cursor-pointer group hover:bg-paper-warm/70"
+            >
+              <div className="flex items-center justify-between mb-0.5">
+                <span className="text-[13px] font-display font-medium text-ink-soft group-hover:text-ink transition-colors truncate pr-2">
+                  {getDisplayTitle(note)}
+                </span>
+                <div className="flex items-center gap-1.5 shrink-0">
+                  <button
+                    type="button"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      void openNoteInEditor(note.id);
+                    }}
+                    className="w-6 h-6 flex items-center justify-center rounded-md text-ink-ghost hover:text-bamboo hover:bg-bamboo-mist/50 transition-all duration-200 opacity-0 group-hover:opacity-100 cursor-pointer"
+                    title={t("notepad.tooltip.openInEditor", { defaultValue: "在编辑器中打开" })}
+                  >
+                    <svg
+                      width="13"
+                      height="13"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                      <polyline points="15 3 21 3 21 9" />
+                      <line x1="10" y1="14" x2="21" y2="3" />
+                    </svg>
+                  </button>
+                  <span className="text-[11px] text-ink-ghost font-mono tabular-nums">
+                    {formatShortDate(note.updatedAt)}
+                  </span>
+                </div>
+              </div>
+              <p className="text-[12px] text-ink-ghost leading-relaxed line-clamp-1 group-hover:text-ink-faint transition-colors">
+                {note.preview || t("common.blankNote", { defaultValue: "空白笔记" })}
+              </p>
+              {hoveredNote === note.id && (
+                <div className="mt-1.5 h-px bg-bamboo/10 transition-all duration-300" />
+              )}
+            </button>
+          ))}
+          {notes.length === 0 && (
+            <div className="px-4 py-8 text-center text-[12px] text-ink-ghost">
+              {t("notepad.emptyState", { defaultValue: "还没有可打开的笔记" })}
+            </div>
+          )}
+          {notes.length > 0 && filteredNotes.length === 0 && (
+            <div className="px-4 py-8 text-center text-[12px] text-ink-ghost">
+              {t("notepad.search.noResults", { defaultValue: "没有匹配的笔记" })}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/locales/en-US/translation.json
+++ b/src/locales/en-US/translation.json
@@ -170,6 +170,11 @@
       "clear": "Clear"
     },
     "emptyState": "No notes available",
+    "search": {
+      "clear": "Clear search",
+      "noResults": "No matching notes",
+      "placeholder": "Search notes…"
+    },
     "error": {
       "copyUnsupported": "Copy is not supported in this environment"
     },

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -170,6 +170,11 @@
       "clear": "清空"
     },
     "emptyState": "还没有可打开的笔记",
+    "search": {
+      "clear": "清空搜索",
+      "noResults": "没有匹配的笔记",
+      "placeholder": "搜索笔记…"
+    },
     "error": {
       "copyUnsupported": "当前环境不支持复制"
     },

--- a/src/locales/zh-HK/translation.json
+++ b/src/locales/zh-HK/translation.json
@@ -170,6 +170,11 @@
       "clear": "清除"
     },
     "emptyState": "還沒有可開啟的筆記",
+    "search": {
+      "clear": "清除搜尋",
+      "noResults": "沒有符合的筆記",
+      "placeholder": "搜尋筆記…"
+    },
     "error": {
       "copyUnsupported": "目前環境不支援複製"
     },


### PR DESCRIPTION
<!--
  提交 PR 前请逐项勾选确认。Please check all boxes before submitting.
  选择性填写，没有就不写。Fill in what's relevant; leave blank if not applicable.
-->

## Summary / 概要

- 新增 `NotepadOpenPanel`，复用 `filterNotes` 实现小窗笔记搜索


本 PR 在 upstream main 基础上，为快捷便签小窗「打开」标签页增加搜索功能。搜索逻辑复用主窗口已有的 `filterNotes`，`NotePad.tsx` 。

## Related Issue / 关联 Issue

N/A

## Affected Platforms / 影响平台

- [] Windows
- [] macOS
- [] Linux
- [x] Platform-agnostic / 平台无关

## Screenshots or Recordings / 截图或录屏
<img width="437" height="366" alt="屏幕截图 2026-06-08 144421" src="https://github.com/user-attachments/assets/932af5e1-c6fd-48d5-b9d2-078b48cb00b9" />

<!-- 前端变更请附截图或录屏。Attach screenshots or recordings for frontend changes. -->

1. `Ctrl+Space` 呼出小窗 → 切换到「打开」标签页
2. 在搜索框输入关键词，列表实时过滤
3. 点击笔记条目打开；悬停可「在编辑器中打开」

## Testing / 测试

**快捷便签搜索（Windows / Linux 均已经手动测试）**
1. `npm run tauri dev` 启动应用
2. 创建若干笔记（不同标题、内容、文件名）
3. `Ctrl+Space` →「打开」→ 输入关键词，确认列表正确过滤

**自动化检查（Windows + Linux WSL 均已执行）**

| 检查项 | Windows | Linux (WSL) |
|--------|---------|-------------|
| `npm test` | 71 passed | 71 passed |
| `npx oxfmt --check` | 通过 | 通过 |
| `npx oxlint` | 通过 | 通过 |
| `cargo fmt --check` | 通过 | 通过 |
| `cargo clippy --all-targets -- -D warnings` | 通过 | 通过 |
| `cargo test --lib` | 134 passed | 134 passed |

## Checklist / 检查清单

### Code quality / 代码质量

您确认您运行并通过了：

- [x] `npx oxfmt --check`
- [x] `npx oxlint`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `npm test`

<!-- 感谢你对花笺 Floral Notepaper 的贡献！Thank you for your contribution! -->