### PR TITLE
refactor: 替换硬编码SVG图标为lucide-react组件

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "floral-notepaper",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "floral-notepaper",
-      "version": "1.0.4",
+      "version": "1.1.0",
       "dependencies": {
         "@tauri-apps/api": "~2.11.0",
         "@tauri-apps/plugin-clipboard-manager": "^2.3.2",

--- a/src/components/AboutPanel.tsx
+++ b/src/components/AboutPanel.tsx
@@ -1,3 +1,4 @@
+import { Bug, ExternalLink, ScrollText, X } from "lucide-react";
 import { getVersion } from "@tauri-apps/api/app";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -58,17 +59,7 @@ export function AboutPanel({ onClose }: AboutPanelProps) {
           className="w-7 h-7 flex items-center justify-center rounded-lg text-ink-ghost hover:text-ink-soft hover:bg-paper-warm transition-colors cursor-pointer"
           title={t("about.closeTitle", { defaultValue: "关闭关于" })}
         >
-          <svg
-            width="12"
-            height="12"
-            viewBox="0 0 12 12"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            strokeLinecap="round"
-          >
-            <path d="M2 2l8 8M10 2l-8 8" />
-          </svg>
+          <X size={12} />
         </button>
       </div>
 
@@ -116,18 +107,7 @@ export function AboutPanel({ onClose }: AboutPanelProps) {
                 </span>
               </span>
               <span className="inline-flex items-center">
-                <svg
-                  width="12"
-                  height="12"
-                  viewBox="0 0 16 16"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <path d="M6 3h7v7M13 3L3 13" />
-                </svg>
+                <ExternalLink size={12} />
               </span>
             </button>
             <button
@@ -136,32 +116,13 @@ export function AboutPanel({ onClose }: AboutPanelProps) {
               className="w-full h-8 px-1 flex items-center justify-between text-[11px] text-ink-faint hover:text-bamboo cursor-pointer transition-colors"
             >
               <span className="inline-flex items-center gap-1.5">
-                <svg
-                  width="14"
-                  height="14"
-                  viewBox="0 0 16 16"
-                  fill="currentColor"
-                  className="shrink-0"
-                >
-                  <path d="M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8zm9 3a1 1 0 11-2 0 1 1 0 012 0zm-.25-6.25a.75.75 0 00-1.5 0v3.5a.75.75 0 001.5 0v-3.5z" />
-                </svg>
+                <Bug size={14} className="shrink-0" />
                 <span className="leading-none">
                   {t("about.feedback", { defaultValue: "反馈问题" })}
                 </span>
               </span>
               <span className="inline-flex items-center">
-                <svg
-                  width="12"
-                  height="12"
-                  viewBox="0 0 16 16"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <path d="M6 3h7v7M13 3L3 13" />
-                </svg>
+                <ExternalLink size={12} />
               </span>
             </button>
             <button
@@ -172,32 +133,13 @@ export function AboutPanel({ onClose }: AboutPanelProps) {
               className="w-full h-8 px-1 flex items-center justify-between text-[11px] text-ink-faint hover:text-bamboo cursor-pointer transition-colors"
             >
               <span className="inline-flex items-center gap-1.5">
-                <svg
-                  width="14"
-                  height="14"
-                  viewBox="0 0 16 16"
-                  fill="currentColor"
-                  className="shrink-0"
-                >
-                  <path d="M4 1.5c-.83 0-1.5.67-1.5 1.5v10c0 .83.67 1.5 1.5 1.5h8c.83 0 1.5-.67 1.5-1.5V5.5L9.5 1.5H4zm0 1h5v3.5h3.5V13a.5.5 0 01-.5.5H4a.5.5 0 01-.5-.5V3a.5.5 0 01.5-.5zm5.5.707L11.793 5.5H9.5V3.207zM5.5 7.5v1h5v-1h-5zm0 2v1h5v-1h-5zm0 2v1h3v-1h-3z" />
-                </svg>
+                <ScrollText size={14} className="shrink-0" />
                 <span className="leading-none">
                   {t("about.license", { defaultValue: "许可证" })}
                 </span>
               </span>
               <span className="inline-flex items-center">
-                <svg
-                  width="12"
-                  height="12"
-                  viewBox="0 0 16 16"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <path d="M6 3h7v7M13 3L3 13" />
-                </svg>
+                <ExternalLink size={12} />
               </span>
             </button>
           </section>
@@ -247,18 +189,7 @@ export function AboutPanel({ onClose }: AboutPanelProps) {
                   className="inline-flex items-center gap-0.5 text-ink-faint hover:text-bamboo cursor-pointer transition-colors"
                 >
                   {seg.text}
-                  <svg
-                    width="9"
-                    height="9"
-                    viewBox="0 0 16 16"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <path d="M6 3h7v7M13 3L3 13" />
-                  </svg>
+                  <ExternalLink size={9} />
                 </button>
               ) : (
                 <span key={i}>{seg.text}</span>

--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -1,10 +1,12 @@
 import {
+  ArrowUpCircle,
   ChevronLeft,
   ChevronRight,
   Copy,
   Download,
   File,
   Folder,
+  Info,
   Minus,
   NotebookPen,
   PanelLeft,
@@ -1657,37 +1659,9 @@ export function MainWindow({
               aria-label={aboutButtonTitle}
             >
               {aboutUpdateReminder.hasPendingUpdate ? (
-                <svg
-                  data-testid="main-about-update-icon"
-                  width="14"
-                  height="14"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <circle cx="12" cy="12" r="9" />
-                  <path d="M12 16V8" />
-                  <path d="m8.5 11.5 3.5-3.5 3.5 3.5" />
-                </svg>
+                <ArrowUpCircle data-testid="main-about-update-icon" size={14} />
               ) : (
-                <svg
-                  data-testid="main-about-info-icon"
-                  width="14"
-                  height="14"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <circle cx="12" cy="12" r="10" />
-                  <path d="M12 16v-4" />
-                  <path d="M12 8h.01" />
-                </svg>
+                <Info data-testid="main-about-info-icon" size={14} />
               )}
               {aboutUpdateReminder.hasPendingUpdate ? (
                 <span

--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -1,4 +1,4 @@
-import { Copy, Minus, NotebookPen, Settings, Square } from "lucide-react";
+import { Copy, Minus, NotebookPen, Settings, Square, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { MouseEvent } from "react";
 import type { TFunction } from "i18next";
@@ -1709,17 +1709,7 @@ export function MainWindow({
               className="w-11 h-11 flex items-center justify-center text-ink-ghost hover:text-red-500 hover:bg-danger-bg transition-all cursor-pointer"
               title={t("main.window.close", { defaultValue: "关闭" })}
             >
-              <svg
-                width="12"
-                height="12"
-                viewBox="0 0 12 12"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-              >
-                <path d="M2 2l8 8M10 2l-8 8" />
-              </svg>
+              <X size={12} />
             </button>
           </div>
         </div>

--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -1,12 +1,21 @@
 import {
+  ChevronLeft,
+  ChevronRight,
   Copy,
   Download,
+  File,
+  Folder,
   Minus,
   NotebookPen,
+  PanelLeft,
+  Pin,
   Plus,
+  Redo,
   Search,
   Settings,
   Square,
+  Trash2,
+  Undo,
   X,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -1852,20 +1861,7 @@ export function MainWindow({
                                   isSelected ? "text-bamboo" : "text-ink-soft"
                                 }`}
                               >
-                                <svg
-                                  width="12"
-                                  height="12"
-                                  viewBox="0 0 24 24"
-                                  fill="none"
-                                  stroke="currentColor"
-                                  strokeWidth="2"
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                  className="shrink-0 opacity-60"
-                                >
-                                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-                                  <polyline points="14 2 14 8 20 8" />
-                                </svg>
+                                <File size={12} className="shrink-0 opacity-60" />
                                 {file.title}
                               </span>
                               <button
@@ -1878,18 +1874,7 @@ export function MainWindow({
                                   defaultValue: "从列表移除",
                                 })}
                               >
-                                <svg
-                                  width="12"
-                                  height="12"
-                                  viewBox="0 0 24 24"
-                                  fill="none"
-                                  stroke="currentColor"
-                                  strokeWidth="2"
-                                  strokeLinecap="round"
-                                >
-                                  <line x1="18" y1="6" x2="6" y2="18" />
-                                  <line x1="6" y1="6" x2="18" y2="18" />
-                                </svg>
+                                <X size={12} />
                               </button>
                             </div>
 
@@ -2027,32 +2012,11 @@ export function MainWindow({
                             if (noteId) void handleMoveNote(noteId, group.category);
                           }}
                         >
-                          <svg
-                            width="10"
-                            height="10"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth="2.5"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
+                          <ChevronRight
+                            size={10}
                             className={`text-bamboo/50 shrink-0 transition-transform duration-200 ${isCollapsed ? "" : "rotate-90"}`}
-                          >
-                            <polyline points="9 18 15 12 9 6" />
-                          </svg>
-                          <svg
-                            width="12"
-                            height="12"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth="2"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            className="text-bamboo/50 shrink-0"
-                          >
-                            <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
-                          </svg>
+                          />
+                          <Folder size={12} className="text-bamboo/50 shrink-0" />
                           {renamingCategory === group.category ? (
                             <input
                               type="text"
@@ -2212,19 +2176,7 @@ export function MainWindow({
                       : t("main.window.collapseSidebar", { defaultValue: "收起侧栏" })
                   }
                 >
-                  <svg
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
-                    <line x1="9" y1="3" x2="9" y2="21" />
-                  </svg>
+                  <PanelLeft size={14} />
                 </button>
 
                 <div className="h-4 w-px bg-paper-deep/30 mx-1" />
@@ -2240,19 +2192,7 @@ export function MainWindow({
                   }`}
                   title={pinTileButtonTitle(selectedTilePinned)}
                 >
-                  <svg
-                    width="13"
-                    height="13"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <path d="M12 17v5" />
-                    <path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 1 1 0 0 0 1-1V4a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v1a1 1 0 0 0 1 1 1 1 0 0 1 1 1z" />
-                  </svg>
+                  <Pin size={13} />
                 </button>
 
                 <button
@@ -2263,21 +2203,7 @@ export function MainWindow({
                   title={t("main.editor.undo", { defaultValue: "撤销（Ctrl+Z）" })}
                   aria-label={t("main.editor.undoLabel", { defaultValue: "撤销" })}
                 >
-                  <svg
-                    data-testid="main-editor-undo-icon"
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    aria-hidden="true"
-                  >
-                    <path d="M9 14 4 9l5-5" />
-                    <path d="M4 9h10a6 6 0 0 1 0 12h-1" />
-                  </svg>
+                  <Undo data-testid="main-editor-undo-icon" size={14} aria-hidden="true" />
                 </button>
 
                 <button
@@ -2288,22 +2214,12 @@ export function MainWindow({
                   title={t("main.editor.redo", { defaultValue: "重做（Ctrl+Y）" })}
                   aria-label={t("main.editor.redoLabel", { defaultValue: "重做" })}
                 >
-                  <svg
+                  <Redo
                     data-testid="main-editor-redo-icon"
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
+                    size={14}
                     aria-hidden="true"
                     style={{ transform: "scaleX(-1)" }}
-                  >
-                    <path d="M9 14 4 9l5-5" />
-                    <path d="M4 9h10a6 6 0 0 1 0 12h-1" />
-                  </svg>
+                  />
                 </button>
 
                 <button
@@ -2355,19 +2271,7 @@ export function MainWindow({
                     className="w-7 h-7 flex items-center justify-center rounded-lg text-ink-ghost hover:text-red-400 hover:bg-danger-bg transition-all cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed"
                     title={t("noteMenu.delete", { defaultValue: "删除笔记" })}
                   >
-                    <svg
-                      width="13"
-                      height="13"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    >
-                      <polyline points="3,6 5,6 21,6" />
-                      <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
-                    </svg>
+                    <Trash2 size={13} />
                   </button>
                 )}
               </div>
@@ -2654,18 +2558,7 @@ export function MainWindow({
                 onClick={() => setNoteMenuMode("main")}
                 className="w-full flex items-center gap-1.5 px-3 py-1.5 text-[12px] font-body text-ink-ghost hover:bg-paper-warm transition-colors cursor-pointer border-b border-paper-deep/20"
               >
-                <svg
-                  width="10"
-                  height="10"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <polyline points="15 18 9 12 15 6" />
-                </svg>
+                <ChevronLeft size={10} />
                 <span>{t("common.back", { defaultValue: "返回" })}</span>
               </button>
               <button

--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -1,4 +1,4 @@
-import { Copy, Minus, NotebookPen, Settings, Square, X } from "lucide-react";
+import { Copy, Minus, NotebookPen, Search, Settings, Square, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { MouseEvent } from "react";
 import type { TFunction } from "i18next";
@@ -1722,19 +1722,7 @@ export function MainWindow({
             <div className="flex flex-col h-full" style={{ width: `${sidebarWidth}px` }}>
               <div className="px-3 pt-3 pb-2 shrink-0">
                 <div className="flex items-center gap-2 px-2.5 h-8 rounded-lg bg-paper-warm/80 border border-paper-deep/40 focus-within:border-bamboo/30 focus-within:bg-cloud transition-all">
-                  <svg
-                    width="13"
-                    height="13"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2.5"
-                    strokeLinecap="round"
-                    className="text-ink-ghost shrink-0"
-                  >
-                    <circle cx="11" cy="11" r="8" />
-                    <path d="m21 21-4.35-4.35" />
-                  </svg>
+                  <Search size={13} className="text-ink-ghost shrink-0" />
                   <input
                     type="text"
                     value={searchQuery}
@@ -1748,17 +1736,7 @@ export function MainWindow({
                       className="text-ink-ghost hover:text-ink-faint transition-colors cursor-pointer"
                       title={t("main.sidebar.clearSearch", { defaultValue: "清空搜索" })}
                     >
-                      <svg
-                        width="10"
-                        height="10"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="3"
-                        strokeLinecap="round"
-                      >
-                        <path d="M18 6L6 18M6 6l12 12" />
-                      </svg>
+                      <X size={10} />
                     </button>
                   )}
                 </div>

--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -1,4 +1,4 @@
-import { Minus, NotebookPen, Settings } from "lucide-react";
+import { Copy, Minus, NotebookPen, Settings, Square } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { MouseEvent } from "react";
 import type { TFunction } from "i18next";
@@ -1702,30 +1702,7 @@ export function MainWindow({
                   : t("main.window.maximize", { defaultValue: "最大化" })
               }
             >
-              {isMaximized ? (
-                <svg
-                  width="12"
-                  height="12"
-                  viewBox="0 0 12 12"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.2"
-                >
-                  <rect x="3" y="3" width="7" height="7" rx="1" />
-                  <path d="M3 5H2V2a1 1 0 0 1 1-1h5v1" />
-                </svg>
-              ) : (
-                <svg
-                  width="12"
-                  height="12"
-                  viewBox="0 0 12 12"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.2"
-                >
-                  <rect x="1.5" y="1.5" width="9" height="9" rx="1.5" />
-                </svg>
-              )}
+              {isMaximized ? <Copy size={12} /> : <Square size={12} />}
             </button>
             <button
               onClick={handleClose}

--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -1,4 +1,14 @@
-import { Copy, Minus, NotebookPen, Search, Settings, Square, X } from "lucide-react";
+import {
+  Copy,
+  Download,
+  Minus,
+  NotebookPen,
+  Plus,
+  Search,
+  Settings,
+  Square,
+  X,
+} from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { MouseEvent } from "react";
 import type { TFunction } from "i18next";
@@ -1747,38 +1757,17 @@ export function MainWindow({
                   onClick={handleNewNote}
                   className="w-full flex items-center gap-2 px-2.5 py-1.5 rounded-lg text-[12px] font-body text-bamboo hover:bg-bamboo-mist/60 transition-all cursor-pointer group"
                 >
-                  <svg
-                    width="13"
-                    height="13"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2.5"
-                    strokeLinecap="round"
+                  <Plus
+                    size={13}
                     className="group-hover:rotate-90 transition-transform duration-200"
-                  >
-                    <path d="M12 5v14M5 12h14" />
-                  </svg>
+                  />
                   <span>{t("main.sidebar.newNote", { defaultValue: "新建笔记" })}</span>
                 </button>
                 <button
                   onClick={() => void handleImportNote()}
                   className="w-full flex items-center gap-2 px-2.5 py-1.5 rounded-lg text-[12px] font-body text-ink-faint hover:text-bamboo hover:bg-bamboo-mist/50 transition-all cursor-pointer group"
                 >
-                  <svg
-                    width="13"
-                    height="13"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2.2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <path d="M12 3v12" />
-                    <path d="m7 10 5 5 5-5" />
-                    <path d="M5 21h14" />
-                  </svg>
+                  <Download size={13} />
                   <span>{t("main.sidebar.importMarkdown", { defaultValue: "导入 Markdown" })}</span>
                 </button>
               </div>
@@ -1801,17 +1790,7 @@ export function MainWindow({
                   className="text-[10px] text-ink-ghost hover:text-bamboo transition-colors cursor-pointer"
                   title={t("main.category.new", { defaultValue: "新建分类" })}
                 >
-                  <svg
-                    width="12"
-                    height="12"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2.5"
-                    strokeLinecap="round"
-                  >
-                    <path d="M12 5v14M5 12h14" />
-                  </svg>
+                  <Plus size={12} />
                 </button>
               </div>
 

--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -1,3 +1,4 @@
+import { NotebookPen, Settings } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { MouseEvent } from "react";
 import type { TFunction } from "i18next";
@@ -1619,38 +1620,14 @@ export function MainWindow({
               className="w-10 h-11 flex items-center justify-center text-ink-ghost hover:text-bamboo hover:bg-bamboo-mist/50 transition-all cursor-pointer"
               title={t("main.window.quickNotepad", { defaultValue: "快捷便签" })}
             >
-              <svg
-                width="14"
-                height="14"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <path d="M4 4h16v14H7l-3 3V4z" />
-                <path d="M8 9h8M8 13h5" />
-              </svg>
+              <NotebookPen size={14} />
             </button>
             <button
               onClick={() => void handleOpenSettings()}
               className="w-10 h-11 flex items-center justify-center text-ink-ghost hover:text-ink-faint hover:bg-paper-warm transition-all cursor-pointer"
               title={t("main.window.settings", { defaultValue: "设置" })}
             >
-              <svg
-                width="14"
-                height="14"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <circle cx="12" cy="12" r="3" />
-                <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
-              </svg>
+              <Settings size={14} />
             </button>
             <button
               onClick={handleOpenAbout}

--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -1,4 +1,4 @@
-import { NotebookPen, Settings } from "lucide-react";
+import { Minus, NotebookPen, Settings } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { MouseEvent } from "react";
 import type { TFunction } from "i18next";
@@ -1691,9 +1691,7 @@ export function MainWindow({
               className="w-11 h-11 flex items-center justify-center text-ink-ghost hover:text-ink-soft hover:bg-paper-warm transition-all cursor-pointer"
               title={t("main.window.minimize", { defaultValue: "最小化" })}
             >
-              <svg width="12" height="12" viewBox="0 0 12 12">
-                <rect x="1" y="5.5" width="10" height="1" fill="currentColor" rx="0.5" />
-              </svg>
+              <Minus size={12} />
             </button>
             <button
               onClick={handleMaximize}

--- a/src/components/NotePad.tsx
+++ b/src/components/NotePad.tsx
@@ -1,3 +1,4 @@
+import { ExternalLink, Pin, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { MouseEvent } from "react";
 import { useMemo } from "react";
@@ -588,17 +589,7 @@ export function NotePad({
             onClick={() => void handleClose()}
             className="absolute top-2 right-2 z-10 w-6 h-6 flex items-center justify-center rounded-full text-ink-ghost/70 hover:text-red-400 hover:bg-danger-bg/80 transition-colors cursor-pointer"
           >
-            <svg
-              width="12"
-              height="12"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2.5"
-              strokeLinecap="round"
-            >
-              <path d="M18 6L6 18M6 6l12 12" />
-            </svg>
+            <X size={12} />
           </button>
           <SurfaceResizeHandles />
         </Tile>
@@ -644,19 +635,7 @@ export function NotePad({
                   className="group w-7 h-7 flex items-center justify-center rounded-lg transition-all duration-200 cursor-pointer text-ink-ghost hover:text-ink-faint hover:bg-paper-warm"
                   title={t("notepad.tooltip.pinToTile", { defaultValue: "转为磁贴" })}
                 >
-                  <svg
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <path d="M12 17v5" />
-                    <path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 1 1 0 0 0 1-1V4a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v1a1 1 0 0 0 1 1 1 1 0 0 1 1 1z" />
-                  </svg>
+                  <Pin size={14} />
                 </button>
 
                 <button
@@ -664,17 +643,7 @@ export function NotePad({
                   className="group w-7 h-7 flex items-center justify-center rounded-lg text-ink-ghost hover:bg-danger-bg hover:text-red-400 transition-all duration-200 cursor-pointer"
                   title={t("notepad.tooltip.close", { defaultValue: "关闭" })}
                 >
-                  <svg
-                    width="13"
-                    height="13"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2.5"
-                    strokeLinecap="round"
-                  >
-                    <path d="M18 6L6 18M6 6l12 12" />
-                  </svg>
+                  <X size={13} />
                 </button>
               </div>
             </div>
@@ -779,20 +748,7 @@ export function NotePad({
                               defaultValue: "在编辑器中打开",
                             })}
                           >
-                            <svg
-                              width="13"
-                              height="13"
-                              viewBox="0 0 24 24"
-                              fill="none"
-                              stroke="currentColor"
-                              strokeWidth="2"
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                            >
-                              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-                              <polyline points="15 3 21 3 21 9" />
-                              <line x1="10" y1="14" x2="21" y2="3" />
-                            </svg>
+                            <ExternalLink size={13} />
                           </button>
                           <span className="text-[11px] text-ink-ghost font-mono tabular-nums">
                             {formatShortDate(note.updatedAt)}

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,3 +1,4 @@
+import { X } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -100,17 +101,7 @@ export function SettingsPanel({ config, onChange, onChooseNotesDir, onClose }: S
           className="w-7 h-7 flex items-center justify-center rounded-lg text-ink-ghost hover:text-ink-soft hover:bg-paper-warm transition-colors cursor-pointer"
           title={t("settings.closeTitle", { defaultValue: "关闭设置" })}
         >
-          <svg
-            width="12"
-            height="12"
-            viewBox="0 0 12 12"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            strokeLinecap="round"
-          >
-            <path d="M2 2l8 8M10 2l-8 8" />
-          </svg>
+          <X size={12} />
         </button>
       </div>
 

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,3 +1,4 @@
+import { CircleX, Info, TriangleAlert, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 export interface ToastItem {
@@ -16,28 +17,10 @@ export function showToast(message: string, type: ToastItem["type"] = "error") {
 const AUTO_DISMISS_MS = 5000;
 const EXIT_DURATION_MS = 200;
 
-const iconPaths: Record<NonNullable<ToastItem["type"]>, React.ReactNode> = {
-  warning: (
-    <>
-      <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
-      <line x1="12" y1="9" x2="12" y2="13" />
-      <line x1="12" y1="17" x2="12.01" y2="17" />
-    </>
-  ),
-  info: (
-    <>
-      <circle cx="12" cy="12" r="10" />
-      <line x1="12" y1="16" x2="12" y2="12" />
-      <line x1="12" y1="8" x2="12.01" y2="8" />
-    </>
-  ),
-  error: (
-    <>
-      <circle cx="12" cy="12" r="10" />
-      <line x1="15" y1="9" x2="9" y2="15" />
-      <line x1="9" y1="9" x2="15" y2="15" />
-    </>
-  ),
+const iconComponents: Record<NonNullable<ToastItem["type"]>, React.ReactNode> = {
+  warning: <TriangleAlert size={14} />,
+  info: <Info size={14} />,
+  error: <CircleX size={14} />,
 };
 
 const iconColor: Record<NonNullable<ToastItem["type"]>, string> = {
@@ -65,20 +48,7 @@ function ToastEntry({ item, onDismiss }: { item: ToastItem; onDismiss: (id: numb
   return (
     <div className={`toast-entry ${exiting ? "toast-exit" : "toast-enter"}`} role="alert">
       <div className="flex items-start gap-2.5 min-w-0">
-        <span className={`mt-px shrink-0 ${iconColor[type]}`}>
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            {iconPaths[type]}
-          </svg>
-        </span>
+        <span className={`mt-px shrink-0 ${iconColor[type]}`}>{iconComponents[type]}</span>
         <span className="text-[12.5px] leading-relaxed text-ink-soft break-words min-w-0">
           {item.message}
         </span>
@@ -87,19 +57,7 @@ function ToastEntry({ item, onDismiss }: { item: ToastItem; onDismiss: (id: numb
         onClick={dismiss}
         className="shrink-0 mt-px ml-2 p-0.5 rounded text-ink-ghost hover:text-ink-faint transition-colors cursor-pointer"
       >
-        <svg
-          width="12"
-          height="12"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <line x1="18" y1="6" x2="6" y2="18" />
-          <line x1="6" y1="6" x2="18" y2="18" />
-        </svg>
+        <X size={12} />
       </button>
     </div>
   );

--- a/src/features/markdown/MarkdownPreview.tsx
+++ b/src/features/markdown/MarkdownPreview.tsx
@@ -1,3 +1,4 @@
+import { Info, Lightbulb, MessageSquareWarning, OctagonAlert, TriangleAlert } from "lucide-react";
 import { useState, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import Markdown from "react-markdown";
@@ -94,38 +95,18 @@ const rehypePluginsWithHtml = [
 ] as Parameters<typeof Markdown>[0]["rehypePlugins"];
 
 function AlertIcon({ type }: { type: string }) {
+  const iconProps = { size: 16 };
   switch (type) {
     case "note":
-      return (
-        <svg viewBox="0 0 16 16" fill="currentColor">
-          <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z" />
-        </svg>
-      );
+      return <Info {...iconProps} />;
     case "tip":
-      return (
-        <svg viewBox="0 0 16 16" fill="currentColor">
-          <path d="M8 1.5c-2.363 0-4 1.69-4 3.75 0 .984.424 1.625.984 2.304l.214.253c.223.264.47.556.673.848.284.411.537.896.621 1.49a.75.75 0 0 1-1.484.211c-.04-.282-.163-.547-.37-.847a8.456 8.456 0 0 0-.542-.68c-.084-.1-.173-.205-.268-.32C3.201 7.75 2.5 6.766 2.5 5.25 2.5 2.31 4.863 0 8 0s5.5 2.31 5.5 5.25c0 1.516-.701 2.5-1.328 3.259-.095.115-.184.22-.268.319-.207.245-.383.453-.541.681-.208.3-.33.565-.37.847a.751.751 0 0 1-1.485-.212c.084-.593.337-1.078.621-1.489.203-.292.45-.584.673-.848.075-.088.149-.176.214-.253.56-.679.984-1.32.984-2.304 0-2.06-1.637-3.75-4-3.75ZM5.75 12h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM6 15.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Z" />
-        </svg>
-      );
+      return <Lightbulb {...iconProps} />;
     case "important":
-      return (
-        <svg viewBox="0 0 16 16" fill="currentColor">
-          <path d="M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v9.5A1.75 1.75 0 0 1 14.25 13H8.06l-2.573 2.573A1.458 1.458 0 0 1 3 14.543V13H1.75A1.75 1.75 0 0 1 0 11.25Zm1.75-.25a.25.25 0 0 0-.25.25v9.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-9.5a.25.25 0 0 0-.25-.25Zm7 2.25v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 9a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z" />
-        </svg>
-      );
+      return <MessageSquareWarning {...iconProps} />;
     case "warning":
-      return (
-        <svg viewBox="0 0 16 16" fill="currentColor">
-          <path d="M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.396A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.557ZM8.22 2.097a.25.25 0 0 0-.44 0L1.698 13.493a.25.25 0 0 0 .22.382h12.164a.25.25 0 0 0 .22-.382Z" />
-          <path d="M8.75 5.75a.75.75 0 0 0-1.5 0v2.5a.75.75 0 0 0 1.5 0v-2.5ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z" />
-        </svg>
-      );
+      return <TriangleAlert {...iconProps} />;
     case "caution":
-      return (
-        <svg viewBox="0 0 16 16" fill="currentColor">
-          <path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z" />
-        </svg>
-      );
+      return <OctagonAlert {...iconProps} />;
     default:
       return null;
   }

--- a/src/features/update/UpdateSettingsSection.tsx
+++ b/src/features/update/UpdateSettingsSection.tsx
@@ -1,3 +1,4 @@
+import { ExternalLink, Eye, EyeOff } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { message } from "@tauri-apps/plugin-dialog";
@@ -612,35 +613,7 @@ export function UpdateSettingsSection({
                         })
                   }
                 >
-                  {showCdk ? (
-                    <svg
-                      width="14"
-                      height="14"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    >
-                      <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />
-                      <line x1="1" y1="1" x2="23" y2="23" />
-                    </svg>
-                  ) : (
-                    <svg
-                      width="14"
-                      height="14"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    >
-                      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
-                      <circle cx="12" cy="12" r="3" />
-                    </svg>
-                  )}
+                  {showCdk ? <EyeOff size={14} /> : <Eye size={14} />}
                 </button>
               </div>
               <p className="text-[10px] text-ink-ghost leading-relaxed">
@@ -653,17 +626,7 @@ export function UpdateSettingsSection({
                   className="inline-flex items-center gap-0.5 text-ink-faint hover:text-bamboo cursor-pointer transition-colors"
                 >
                   Mirror酱
-                  <svg
-                    className="w-[1em] h-[1em]"
-                    viewBox="0 0 16 16"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <path d="M6 3h7v7M13 3L3 13" />
-                  </svg>
+                  <ExternalLink className="w-[1em] h-[1em]" />
                 </button>
                 {t("settings.update.mirrorChyan.noCdkHintSuffix", {
                   defaultValue: " 官网即刻获取。",


### PR DESCRIPTION
## Summary / 概要

将项目中硬编码的内联 `<svg>` JSX 元素替换为 [lucide-react](https://lucide.dev/) 组件，共替换 6 个文件 43 个图标。

| 文件 | 替换数 | 保留 |
|------|--------|------|
| `src/components/MainWindow.tsx` | 21 | 0 |
| `src/features/markdown/MarkdownPreview.tsx` | 5 | 0 |
| `src/components/NotePad.tsx` | 4 | 0 |
| `src/components/SettingsPanel.tsx` | 1 | 0 |
| `src/components/AboutPanel.tsx` | 6 | 1 (GitHub octocat) |
| `src/features/update/UpdateSettingsSection.tsx` | 3 | 0 |
| `src/components/Toast.tsx` | 4 | 0 |
| `src/components/Tile.tsx` | 0 | 1 (装饰折线) |
| **合计** | **43** | **2** |

## Related Issue / 关联 Issue

Closes #245

## Affected Platforms / 影响平台

- [x] Platform-agnostic / 平台无关

## Screenshots or Recordings / 截图或录屏

> 待补充

## Testing / 测试

1. 启动应用，检查标题栏各类按钮图标
2. 检查侧边栏搜索、新建笔记、导入、分类折叠等图标
3. 检查编辑器工具栏（撤销、重做、删除、图钉、侧边栏切换）
4. 检查 Markdown 渲染中 callout 图标
5. 检查便签窗口图标
6. 检查设置面板、关于面板图标
7. 检查 Toast 通知图标

## Checklist / 检查清单

- [x] `npx oxfmt --check`（pre-commit hook 通过）
- [x] `npx oxlint`（零错误）
- [x] `tsc --noEmit`（零错误）
- [ ] `cargo fmt --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo test`
- [x] `npm test`（20 files, 71 tests passed）
- [x] `vite build`（构建成功）