### PR TITLE
fix: 修复开机自启后显示/隐藏快捷键无法呼出主窗口

### DIFF
--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1052,6 +1052,14 @@ fn toggle_app_visibility(app: &AppHandle) {
             let _ = window.hide();
         }
     }
+
+    if labels.is_empty() {
+        if let Err(error) = show_main_window(app) {
+            eprintln!("failed to show main window from visibility toggle: {error}");
+        }
+        return;
+    }
+
     state.hide_windows(labels);
 }
 


### PR DESCRIPTION
## Summary / 概要

修复开机自启后，显示/隐藏窗口快捷键无法呼出主窗口的问题。无可见窗口时改为调用 `show_main_window`。

## Related Issue / 关联 Issue

Fixes #190

## Affected Platforms / 影响平台

- [x] Windows
- [ ] macOS
- [ ] Linux
- [x] Platform-agnostic / 平台无关

## Screenshots or Recordings / 截图或录屏

N/A

## Testing / 测试

1. 开启开机自启并重启，确认主窗口不自动弹出
2. 按显示/隐藏快捷键，确认主窗口能正常显示
3. 再次按键验证隐藏与恢复

## Checklist / 检查清单

### Code quality / 代码质量

您确认您运行并通过了：

- [x] `npx oxfmt --check`
- [x] `npx oxlint`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `npm test`