### PR TITLE
fix: 修复新建分类输入框闪烁并支持加号提交

### DIFF
--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -1891,7 +1891,14 @@ export function MainWindow({
                     : ""}
                 </span>
                 <button
-                  onClick={() => setShowCategoryInput(true)}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => {
+                    if (showCategoryInput && categoryInputValue.trim()) {
+                      void handleCreateCategory();
+                      return;
+                    }
+                    setShowCategoryInput(true);
+                  }}
                   className="text-[10px] text-ink-ghost hover:text-bamboo transition-colors cursor-pointer"
                   title={t("main.category.new", { defaultValue: "新建分类" })}
                 >


### PR DESCRIPTION
## Summary / 概要

修复主窗口侧边栏「新建分类」交互问题，优化连续创建分类时的操作体验：

- 为「+」按钮添加 `onMouseDown preventDefault`，避免输入框 `onBlur` 与按钮 `onClick` 竞态导致的重复关闭/打开闪烁
- 输入框已打开且分类名非空时，再次点击「+」即可提交创建，无需切换焦点或点击空白区域，与 Enter、失焦提交行为一致

## Related Issue / 关联 Issue

N/A

## Affected Platforms / 影响平台

- [x] Windows
- [ ] macOS
- [ ] Linux
- [x] Platform-agnostic / 平台无关

## Screenshots or Recordings / 截图或录屏

N/A

## Testing / 测试

1. 启动应用，打开主窗口侧边栏
2. 点击「+」→ 输入框稳定出现，无闪烁
3. 输入分类名后再次点击「+」→ 分类创建成功，输入框关闭
4. 空输入框再次点「+」→ 输入框保持打开
5. Enter / 失焦 / Escape 行为与改前一致

## Checklist / 检查清单

### Code quality / 代码质量

您确认您运行并通过了：

- [x] `npx oxfmt --check`
- [x] `npx oxlint`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `npm test`
