### PR TITLE
feat: 支持 Delete 键删除文档

### DIFF
--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -15,6 +15,7 @@ import {
   saveConfig,
 } from "../features/settings/api";
 import type { AppConfig, ViewMode } from "../features/settings/types";
+import { isShortcutRecordingActive } from "../features/settings/useShortcutRecorder";
 import { normalizeTileColor } from "../features/settings/tileColor";
 import { getUpdateStatus, reportInstallPreparation } from "../features/update/api";
 import {
@@ -277,6 +278,12 @@ function runEditorCommand(textarea: HTMLTextAreaElement | null, command: "undo" 
   if (!textarea || textarea.disabled) return false;
   textarea.focus();
   return document.execCommand(command);
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) return true;
+  return target.isContentEditable;
 }
 
 export function pinTileButtonTitle(isPinned: boolean): string {
@@ -1058,18 +1065,6 @@ export function MainWindow({
   }, [saveCurrentNote, t]);
 
   useEffect(() => {
-    function handleKeyDown(event: KeyboardEvent) {
-      if ((event.ctrlKey || event.metaKey) && event.key === "s") {
-        event.preventDefault();
-        void saveCurrentNote();
-      }
-    }
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [saveCurrentNote]);
-
-  useEffect(() => {
     if (!selectedId || saveState !== "dirty") return undefined;
     if (isExternal) {
       if (!settingsConfig?.externalFileAutoSave) return undefined;
@@ -1295,6 +1290,33 @@ export function MainWindow({
       showToast(getErrorMessage(error));
     }
   };
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if ((event.ctrlKey || event.metaKey) && event.key === "s") {
+        event.preventDefault();
+        void saveCurrentNote();
+        return;
+      }
+
+      if (event.key !== "Delete") return;
+      if (isEditableTarget(event.target)) return;
+      if (noteMenu || categoryMenu || isShortcutRecordingActive()) return;
+
+      const currentId = selectedIdRef.current;
+      if (!currentId) return;
+
+      event.preventDefault();
+      if (isExternalRef.current) {
+        void handleRemoveExternalFile(currentId);
+      } else {
+        void handleDeleteNote(currentId);
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [categoryMenu, handleDeleteNote, handleRemoveExternalFile, noteMenu, saveCurrentNote]);
 
   const handleOpenNoteMenu = (event: MouseEvent<HTMLElement>, noteId: string) => {
     event.preventDefault();

--- a/src/features/settings/useShortcutRecorder.ts
+++ b/src/features/settings/useShortcutRecorder.ts
@@ -23,6 +23,12 @@ interface HookKeyEvent {
 
 const MODIFIER_EVENT_KEYS = new Set(["Control", "Alt", "Shift", "Meta"]);
 
+let shortcutRecordingActive = false;
+
+export function isShortcutRecordingActive(): boolean {
+  return shortcutRecordingActive;
+}
+
 const CODE_TO_KEY: Record<string, string> = {
   BracketLeft: "[",
   BracketRight: "]",
@@ -71,12 +77,14 @@ export function useShortcutRecorder({
   const [heldKeys, setHeldKeys] = useState<string[]>([]);
 
   const finishRecording = useCallback((shortcut: string) => {
+    shortcutRecordingActive = false;
     setIsRecording(false);
     setHeldKeys([]);
     onRecordRef.current(shortcut);
   }, []);
 
   const cancelRecording = useCallback(() => {
+    shortcutRecordingActive = false;
     setIsRecording(false);
     setHeldKeys([]);
   }, []);
@@ -191,7 +199,10 @@ export function useShortcutRecorder({
     };
   }, [isRecording]);
 
-  const startRecording = useCallback(() => setIsRecording(true), []);
+  const startRecording = useCallback(() => {
+    shortcutRecordingActive = true;
+    setIsRecording(true);
+  }, []);
 
   return { isRecording, heldKeys, startRecording, cancelRecording };
 }


### PR DESCRIPTION
## Summary / 概要

- 主窗口新增 `Delete` 键快捷键：选中笔记时直接删除（移入回收站），选中外部文件时从列表移除（**不删除磁盘原文件**）
- 焦点在标题/正文等可编辑控件时不拦截，避免误删
- 设置面板打开时仍可使用 Delete；仅在快捷键录制进行中屏蔽，避免与「按 Delete 清空快捷键」冲突

## Related Issue / 关联 Issue

N/A

## Affected Platforms / 影响平台

- [x] Windows
- [ ] macOS
- [ ] Linux
- [x] Platform-agnostic / 平台无关

## Screenshots or Recordings / 截图或录屏

N/A

## Testing / 测试

1. 侧边栏选中笔记，焦点不在输入框，按 `Delete` → 笔记立即删除
2. 编辑标题或正文时按 `Delete` → 仅删除字符，不删文档
3. 选中外部文件按 `Delete` → 从列表移除，磁盘文件仍在
4. 打开设置面板（未录制快捷键）按 `Delete` → 仍可删除文档
5. 设置内点击「录制快捷键」后按 `Delete` → 清空快捷键，不删除文档
6. 打开笔记/分类右键菜单时按 `Delete` → 不触发删除

## Checklist / 检查清单

### Code quality / 代码质量

您确认您运行并通过了：

- [x] `npx oxfmt --check`（PR 变更源文件）
- [x] `npx oxlint`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `npm test`