### PR TITLE
fix: 修复主窗口标题栏双击无法最大化/还原

### DIFF
--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -1570,18 +1570,18 @@ export function MainWindow({
 
   const selectedTilePinned = selectedId ? pinnedTileIds.has(selectedId) : false;
 
-  const handleTitleBarDrag = (event: MouseEvent<HTMLDivElement>) => {
-    if ((event.target as HTMLElement).closest("button")) return;
-    void startCurrentWindowDrag().catch(() => undefined);
-  };
-
   const toggleMaximize = () => {
     void toggleMaximizeCurrentWindow().then(() => isCurrentWindowMaximized().then(setIsMaximized));
   };
 
-  const handleTitleBarDoubleClick = (event: MouseEvent<HTMLDivElement>) => {
+  const handleTitleBarMouseDown = (event: MouseEvent<HTMLDivElement>) => {
     if ((event.target as HTMLElement).closest("button")) return;
-    toggleMaximize();
+    if (event.button !== 0) return;
+    if (event.detail === 2) {
+      toggleMaximize();
+      return;
+    }
+    void startCurrentWindowDrag().catch(() => undefined);
   };
 
   const handleMinimize = () => {
@@ -1609,8 +1609,7 @@ export function MainWindow({
           className={`relative z-10 flex items-center justify-between h-11 bg-paper/55 backdrop-blur-[1px] border-b border-paper-deep/30 shrink-0 select-none cursor-default ${
             isMacOS ? "pl-20 pr-5" : "pl-5 pr-0"
           }`}
-          onMouseDown={handleTitleBarDrag}
-          onDoubleClick={handleTitleBarDoubleClick}
+          onMouseDown={handleTitleBarMouseDown}
         >
           <div className="flex items-center gap-3 min-w-0">
             <span className="text-[15px] font-serif font-medium text-ink-soft tracking-wide leading-none">


### PR DESCRIPTION
## Summary / 概要

主窗口是无边框模式（`decorations: false`），标题栏由前端自定义，拖拽需要调用 `startDragging()`。之前的实现是，拖拽绑在 `mousedown`（直接调用 `startDragging()`），双击单独用 `onDoubleClick`。在 Windows 上，第一次点击就会进入拖拽并捕获鼠标，所以 WebView 收不到 `dblclick` 事件，导致双击标题栏无法最大化/还原（见 [tauri-apps/tauri#1839](https://github.com/tauri-apps/tauri/issues/1839)）。

现在把两个逻辑合并到同一个 `mousedown` 处理器里：`event.detail === 2` 时切换最大化，否则才拖拽。这也是官方推荐做法。

## Related Issue / 关联 Issue

Fixes #211

## Affected Platforms / 影响平台

- [x] Windows
- [ ] macOS
- [ ] Linux
- [ ] Platform-agnostic / 平台无关

## Screenshots or Recordings / 截图或录屏

N/A

## Testing / 测试

1. `npm run tauri dev` 启动桌面应用
2. 双击主窗口顶部标题栏文字区域（「花笺」或笔记标题），窗口应最大化
3. 再次双击同一区域，窗口应还原
4. 单击拖拽标题栏，窗口应正常移动
5. 点击标题栏内按钮（设置、最大化等），不应触发拖拽或最大化

## Checklist / 检查清单

### Code quality / 代码质量

您确认您运行并通过了：

- [x] `npx oxfmt --check`（PR 变更文件通过；全量检查因本地未跟踪 `.cursor/`、`.doc/`、`.plan/` 失败，未纳入 commit）
- [x] `npx oxlint`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `npm test`

Made with [Cursor](https://cursor.com)