### PR TITLE
fix: 修复删除确认时的黑框与返回时的红线闪烁

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -536,6 +536,22 @@ input::placeholder {
   pointer-events: none;
 }
 
+.popup-menu button {
+  outline: none;
+}
+.popup-menu button:focus-visible {
+  outline: none;
+}
+.popup-menu[data-hover-suppressed] button:hover {
+  background-color: transparent !important;
+}
+.popup-menu[data-hover-suppressed] button.text-red-400:hover {
+  color: rgb(248 113 113) !important;
+}
+.popup-menu[data-hover-suppressed] button.text-ink-soft:hover {
+  color: var(--color-ink-soft) !important;
+}
+
 /* Save status crossfade */
 @keyframes status-fade {
   from {

--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -347,6 +347,7 @@ export function MainWindow({
   const [categoryMenu, setCategoryMenu] = useState<CategoryMenuState | null>(null);
   const [categoryMenuClosing, setCategoryMenuClosing] = useState(false);
   const [categoryMenuConfirmDelete, setCategoryMenuConfirmDelete] = useState(false);
+  const [categoryMenuHoverSuppressed, setCategoryMenuHoverSuppressed] = useState(false);
   const contentRef = useRef<HTMLTextAreaElement>(null);
   const windowLabelRef = useRef("main");
   const externalFileMtimeRef = useRef<number>(0);
@@ -971,9 +972,27 @@ export function MainWindow({
       setCategoryMenu(null);
       setCategoryMenuClosing(false);
       setCategoryMenuConfirmDelete(false);
+      setCategoryMenuHoverSuppressed(false);
     }, 150);
     return () => window.clearTimeout(timer);
   }, [categoryMenuClosing, categoryMenu]);
+
+  useEffect(() => {
+    if (!categoryMenuHoverSuppressed || !categoryMenu) return;
+    const releaseHover = () => setCategoryMenuHoverSuppressed(false);
+    window.addEventListener("mousemove", releaseHover, { once: true });
+    window.addEventListener("mousedown", releaseHover, { once: true });
+    return () => {
+      window.removeEventListener("mousemove", releaseHover);
+      window.removeEventListener("mousedown", releaseHover);
+    };
+  }, [categoryMenuHoverSuppressed, categoryMenu]);
+
+  const switchCategoryMenuPanel = useCallback((confirmDelete: boolean) => {
+    setCategoryMenuHoverSuppressed(true);
+    setCategoryMenuConfirmDelete(confirmDelete);
+    (document.activeElement as HTMLElement | null)?.blur();
+  }, []);
 
   const saveCurrentNote = useCallback(async () => {
     if (!selectedId) return null;
@@ -2445,6 +2464,7 @@ export function MainWindow({
                       {t("main.editor.confirmDelete", { defaultValue: "确认删除？" })}
                     </span>
                     <button
+                      onMouseDown={(event) => event.preventDefault()}
                       onClick={() => {
                         setDeleteExiting(true);
                         setTimeout(() => {
@@ -2453,11 +2473,12 @@ export function MainWindow({
                           void handleDeleteNote();
                         }, 150);
                       }}
-                      className="px-2 h-6 rounded-md text-[11px] text-cloud bg-red-400 hover:bg-red-500 transition-colors cursor-pointer whitespace-nowrap"
+                      className="px-2 h-6 rounded-md text-[11px] text-cloud bg-red-400 hover:bg-red-500 transition-colors cursor-pointer whitespace-nowrap outline-none"
                     >
                       {t("common.delete", { defaultValue: "删除" })}
                     </button>
                     <button
+                      onMouseDown={(event) => event.preventDefault()}
                       onClick={() => {
                         setDeleteExiting(true);
                         setTimeout(() => {
@@ -2465,7 +2486,7 @@ export function MainWindow({
                           setDeleteConfirm(false);
                         }, 150);
                       }}
-                      className="px-2 h-6 rounded-md text-[11px] text-ink-faint hover:text-ink-soft hover:bg-paper-warm transition-colors cursor-pointer"
+                      className="px-2 h-6 rounded-md text-[11px] text-ink-faint hover:text-ink-soft hover:bg-paper-warm transition-colors cursor-pointer outline-none"
                     >
                       {t("common.cancel", { defaultValue: "取消" })}
                     </button>
@@ -2750,7 +2771,7 @@ export function MainWindow({
       </div>
       {noteMenu && noteMenuTarget && (
         <div
-          className={`fixed z-[9999] min-w-[168px] py-1.5 bg-cloud/95 backdrop-blur-sm border border-paper-deep/50 rounded-lg overflow-hidden select-none ${noteMenuClosing ? "animate-menu-exit" : "animate-menu-enter"}`}
+          className={`popup-menu fixed z-[9999] min-w-[168px] py-1.5 bg-cloud/95 backdrop-blur-sm border border-paper-deep/50 rounded-lg overflow-hidden select-none ${noteMenuClosing ? "animate-menu-exit" : "animate-menu-enter"}`}
           style={{ left: noteMenu.x, top: noteMenu.y }}
           onMouseDown={(event) => event.stopPropagation()}
         >
@@ -2812,12 +2833,13 @@ export function MainWindow({
 
       {categoryMenu && (
         <div
-          className={`fixed z-[9999] min-w-[140px] py-1.5 bg-cloud/95 backdrop-blur-sm border border-paper-deep/50 rounded-lg overflow-hidden select-none ${categoryMenuClosing ? "animate-menu-exit" : "animate-menu-enter"}`}
+          className={`popup-menu fixed z-[9999] min-w-[140px] py-1.5 bg-cloud/95 backdrop-blur-sm border border-paper-deep/50 rounded-lg overflow-hidden select-none ${categoryMenuClosing ? "animate-menu-exit" : "animate-menu-enter"}`}
+          data-hover-suppressed={categoryMenuHoverSuppressed ? "" : undefined}
           style={{ left: categoryMenu.x, top: categoryMenu.y }}
           onMouseDown={(event) => event.stopPropagation()}
         >
           {categoryMenuConfirmDelete ? (
-            <div className="animate-menu-slide-left">
+            <div key="category-confirm" className="animate-menu-slide-left">
               <div className="px-3 py-1.5 text-[11px] font-body text-ink-faint border-b border-paper-deep/20">
                 {t("main.category.confirmDelete", {
                   category: categoryMenu.category,
@@ -2825,23 +2847,25 @@ export function MainWindow({
                 })}
               </div>
               <button
+                onMouseDown={(event) => event.preventDefault()}
                 onClick={() => {
                   void handleDeleteCategory(categoryMenu.category);
                   setCategoryMenuClosing(true);
                 }}
-                className="w-full text-left px-3 py-1.5 text-[12px] font-body text-red-400 hover:bg-danger-bg hover:text-red-500 transition-colors cursor-pointer"
+                className="w-full text-left px-3 py-1.5 text-[12px] font-body text-red-400 hover:bg-danger-bg hover:text-red-500 transition-colors cursor-pointer outline-none"
               >
                 {t("main.category.confirmDeleteAction", { defaultValue: "确认删除" })}
               </button>
               <button
-                onClick={() => setCategoryMenuConfirmDelete(false)}
-                className="w-full text-left px-3 py-1.5 text-[12px] font-body text-ink-soft hover:bg-bamboo-mist/60 hover:text-bamboo transition-colors cursor-pointer"
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => switchCategoryMenuPanel(false)}
+                className="w-full text-left px-3 py-1.5 text-[12px] font-body text-ink-soft hover:bg-bamboo-mist/60 hover:text-bamboo transition-colors cursor-pointer outline-none"
               >
                 {t("common.cancel", { defaultValue: "取消" })}
               </button>
             </div>
           ) : (
-            <div className="animate-menu-slide-right">
+            <div key="category-main" className="animate-menu-slide-right">
               <button
                 onClick={() => {
                   setCategoryMenuClosing(true);
@@ -2853,8 +2877,9 @@ export function MainWindow({
                 {t("main.category.rename", { defaultValue: "重命名" })}
               </button>
               <button
-                onClick={() => setCategoryMenuConfirmDelete(true)}
-                className="w-full text-left px-3 py-1.5 text-[12px] font-body text-red-400 hover:bg-danger-bg hover:text-red-500 transition-colors cursor-pointer border-t border-paper-deep/20"
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => switchCategoryMenuPanel(true)}
+                className="w-full text-left px-3 py-1.5 text-[12px] font-body text-red-400 hover:bg-danger-bg hover:text-red-500 transition-colors cursor-pointer border-t border-paper-deep/20 outline-none"
               >
                 {t("main.category.delete", { defaultValue: "删除分类" })}
               </button>


### PR DESCRIPTION
## Summary / 概要

修复删除确认 UI 的两个问题：
- 分类菜单删除确认按钮，按上下键时出现焦点黑框
- 分类删除确认页点「取消」返回时，触发红色边界闪烁


## Related Issue / 关联 Issue

N/A

## Affected Platforms / 影响平台

- [x] Windows
- [ ] macOS
- [ ] Linux
- [x] Platform-agnostic / 平台无关

## Screenshots or Recordings / 截图或录屏

https://github.com/user-attachments/assets/46e1ac12-9a75-4338-9039-c8489de14c05

## Testing / 测试

1. `npm run tauri dev` 启动应用
2. 右键分类 →「删除分类」→ 进入确认页，确认「确认删除」按钮无黑框
3. 点「取消」返回，确认无红色边界闪烁
4. 删除笔记 → 确认删除流程无焦点黑框

## Checklist / 检查清单

### Code quality / 代码质量

您确认您运行并通过了：

- [x] `npx oxfmt --check`
- [x] `npx oxlint`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `npm test`