### PR TITLE
feat: add font size zoom shortcuts (Ctrl+= / Ctrl+-)

### DIFF
--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -1197,6 +1197,39 @@ export function MainWindow({
     [persistSettings],
   );
 
+  // 备注：Ctrl+= / Ctrl+- 缩放编辑器字号，和浏览器缩放行为保持一致。
+  useEffect(() => {
+    const MIN_FONT_SIZE = 8;
+    const MAX_FONT_SIZE = 32;
+
+    function handleFontSizeShortcut(event: KeyboardEvent) {
+      if (!event.ctrlKey && !event.metaKey) return;
+
+      const isPlus = event.key === "=" || event.key === "+";
+      const isMinus = event.key === "-";
+      if (!isPlus && !isMinus) return;
+
+      event.preventDefault();
+
+      setSettingsConfig((prev) => {
+        if (!prev) return prev;
+        const currentSize = prev.fontSize ?? 14;
+        const nextSize = isPlus
+          ? Math.min(currentSize + 1, MAX_FONT_SIZE)
+          : Math.max(currentSize - 1, MIN_FONT_SIZE);
+        if (nextSize === currentSize) return prev;
+
+        const nextConfig = { ...prev, fontSize: nextSize };
+        void emit("config-changed", nextConfig);
+        persistSettings(nextConfig);
+        return nextConfig;
+      });
+    }
+
+    document.addEventListener("keydown", handleFontSizeShortcut);
+    return () => document.removeEventListener("keydown", handleFontSizeShortcut);
+  }, [persistSettings]);
+
   const handleCloseSettings = useCallback(() => {
     setSettingsOpen(false);
   }, []);

--- a/src/components/NotePad.tsx
+++ b/src/components/NotePad.tsx
@@ -10,7 +10,7 @@ import type { UpdateInstallPrepareRequest } from "../features/update/types";
 import { showToast } from "./Toast";
 import type { Note, NoteMetadata } from "../features/notes/types";
 import { countNoteChars, metadataFromNote } from "../features/notes/noteUtils";
-import { listen } from "@tauri-apps/api/event";
+import { emit, listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
   animateCurrentWindowBounds,
@@ -23,7 +23,7 @@ import {
   startCurrentWindowResize,
 } from "../features/windows/controls";
 import type { ResizeDirection } from "../features/windows/controls";
-import { getConfig } from "../features/settings/api";
+import { getConfig, saveConfig } from "../features/settings/api";
 import {
   DEFAULT_TILE_COLOR,
   normalizeTileColor,
@@ -450,6 +450,37 @@ export function NotePad({
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [handleSave]);
+
+  // 备注：Ctrl+= / Ctrl+- 缩放便签字号
+  useEffect(() => {
+    const MIN_FONT_SIZE = 8;
+    const MAX_FONT_SIZE = 32;
+
+    async function handleFontSizeShortcut(event: KeyboardEvent) {
+      if (!event.ctrlKey && !event.metaKey) return;
+
+      const isPlus = event.key === "=" || event.key === "+";
+      const isMinus = event.key === "-";
+      if (!isPlus && !isMinus) return;
+
+      event.preventDefault();
+
+      const currentConfig = await getConfig();
+      const currentSize = currentConfig.surfaceFontSize ?? 14;
+      const nextSize = isPlus
+        ? Math.min(currentSize + 1, MAX_FONT_SIZE)
+        : Math.max(currentSize - 1, MIN_FONT_SIZE);
+      if (nextSize === currentSize) return;
+
+      setSurfaceFontSize(nextSize);
+      const nextConfig = { ...currentConfig, surfaceFontSize: nextSize };
+      void emit("config-changed", nextConfig);
+      await saveConfig(nextConfig);
+    }
+
+    document.addEventListener("keydown", handleFontSizeShortcut);
+    return () => document.removeEventListener("keydown", handleFontSizeShortcut);
+  }, []);
 
   const handleOpenNote = async (noteId: string) => {
     try {


### PR DESCRIPTION

## 概述

本 PR 为主编辑器和快捷便签编辑器添加了字号缩放快捷键。

已实现快捷键：

- `Ctrl+=` / `Ctrl+Shift+=`：字号增大 1px
- `Ctrl+-`：字号缩小 1px

行为说明：

- 字号范围限制在 8px 到 32px 之间。
- 主编辑器修改 `fontSize`，快捷便签修改 `surfaceFontSize`。
- 修改后自动保存到配置文件，重启后生效。
- 快捷键仅在应用内生效，不会注册为系统全局快捷键。

## 备注

- 在关键实现路径附近添加了中文备注，方便维护者审阅。

## 测试

- `npm test`
- `npm run lint`

Closes #198

---

## Summary

This PR adds font size zoom shortcuts for both the main editor and the quick note editor.

Implemented shortcuts:

- `Ctrl+=` or `Ctrl+Shift+=`: increase font size by 1
- `Ctrl+-`: decrease font size by 1

Behavior details:

- Font size is clamped between 8px and 32px.
- Main editor adjusts `fontSize`, quick note adjusts `surfaceFontSize`.
- Changes are auto-saved to config and persist across restarts.
- Shortcuts are local to the app and are not registered as global system shortcuts.

## Notes

- Added Chinese comments near the key implementation paths to make review easier.

## Tests

- `npm test`
- `npm run lint`

Closes #198
```
