### PR TITLE
fix: 拉动代码块的滚动条，右上角的复制会跟着移动

### DIFF
--- a/src/features/markdown/MarkdownPreview.test.tsx
+++ b/src/features/markdown/MarkdownPreview.test.tsx
@@ -15,4 +15,18 @@ describe("MarkdownPreview", () => {
     expect(markup).toContain("花笺");
     expect(markup).toContain("正文");
   });
+
+  test("keeps code block controls outside the horizontally scrollable pre", () => {
+    const markup = renderToStaticMarkup(
+      <MarkdownPreview content={"```text\nvery long code line\n```"} />,
+    );
+
+    const preCloseIndex = markup.indexOf("</pre>");
+    const buttonIndex = markup.indexOf("<button");
+
+    expect(markup).toContain("markdown-code-block");
+    expect(markup).toContain("markdown-code-scroll");
+    expect(preCloseIndex).toBeGreaterThan(-1);
+    expect(buttonIndex).toBeGreaterThan(preCloseIndex);
+  });
 });

--- a/src/features/markdown/MarkdownPreview.tsx
+++ b/src/features/markdown/MarkdownPreview.tsx
@@ -26,11 +26,14 @@ function CodeBlock({ children, language }: { children: React.ReactNode; language
   }, [children]);
 
   return (
-    <pre
-      className={`my-3 px-4 rounded bg-paper-warm/80 overflow-x-auto relative group ${
-        language ? "pt-8 pb-3" : "py-3"
-      }`}
-    >
+    <div className="markdown-code-block my-3 relative group">
+      <pre
+        className={`markdown-code-scroll m-0 px-4 rounded bg-paper-warm/80 overflow-x-auto ${
+          language ? "pt-8 pb-3" : "py-3"
+        }`}
+      >
+        {children}
+      </pre>
       {language && (
         <span className="absolute top-2 left-3 text-[10px] font-mono text-ink-faint/70 uppercase tracking-wider select-none">
           {language}
@@ -45,8 +48,7 @@ function CodeBlock({ children, language }: { children: React.ReactNode; language
           ? t("markdown.copied", { defaultValue: "已复制" })
           : t("markdown.copy", { defaultValue: "复制" })}
       </button>
-      {children}
-    </pre>
+    </div>
   );
 }
 


### PR DESCRIPTION
<!--
  提交 PR 前请逐项勾选确认。Please check all boxes before submitting.
  选择性填写，没有就不写。Fill in what's relevant; leave blank if not applicable.
-->

## Summary / 概要

<!-- 简要描述此 PR 做了什么。Briefly describe what this PR does. -->
修复了一个问题，当代码块内代码长度很长时，拉动滚动条会导致复制按钮跟着一起移动，正常下应该是固定在右上角。调整后的代码引入外层div负责relative/group和按钮定位，内层pre只负责代码区域和横向滚动。这样滚动条只移动代码文本，右上角复制按钮保持固定。

## Related Issue / 关联 Issue

Fixes #299 

## Affected Platforms / 影响平台

<!-- 勾选受影响或已验证的平台。Check platforms affected or verified. -->

- [x] Windows
- [ ] macOS
- [ ] Linux
- [ ] Platform-agnostic / 平台无关

## Screenshots or Recordings / 截图或录屏

<!-- 前端变更请附截图或录屏。Attach screenshots or recordings for frontend changes. -->

修复后，现在拉动滚动条，复制按钮都会固定在右上角

<img width="1319" height="354" alt="f1" src="https://github.com/user-attachments/assets/65b31708-d54e-4a75-8bc6-13a7cceceee4" />
<img width="1320" height="299" alt="f2" src="https://github.com/user-attachments/assets/3e9fdc72-c417-4020-a8c0-c25b27aa27ac" />

## Testing / 测试

<!-- 提供复现和验证步骤。Provide steps to verify the change. -->

1. 未修复版本，提供一个很长的代码内容，包裹在代码块内。点击预览，拉动滚动条，随后可以看见复制按钮位置发生变动
2. 修复后的版本现在固定在右上角不会发生移动，具体见截图或录屏部分的截图

## Checklist / 检查清单

### Code quality / 代码质量

您确认您运行并通过了：

- [x] `npx oxfmt --check`
- [x] `npx oxlint`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `npm test`

<!-- 感谢你对花笺 Floral Notepaper 的贡献！Thank you for your contribution! -->
