### PR TITLE
fix: 点击更新设置的toggle button会发生设置页面挤压

### DIFF
--- a/src/features/update/UpdateSettingsSection.test.tsx
+++ b/src/features/update/UpdateSettingsSection.test.tsx
@@ -83,6 +83,21 @@ describe("UpdateSettingsSection", () => {
     expect(markup).not.toContain("待更新版本：1.0.5");
   });
 
+  test("renders update toggles without hidden checkbox focus targets", () => {
+    const markup = renderToStaticMarkup(
+      <UpdateSettingsSection
+        initialSettings={settings}
+        initialStatus={status}
+        mode="settingsOnly"
+      />,
+    );
+
+    expect(markup).toContain('role="switch"');
+    expect(markup).toContain("w-full");
+    expect(markup).not.toContain('type="checkbox"');
+    expect(markup).not.toContain("sr-only");
+  });
+
   test("preserves non-standard check interval values in the settings UI", () => {
     const markup = renderToStaticMarkup(
       <UpdateSettingsSection

--- a/src/features/update/UpdateSettingsSection.tsx
+++ b/src/features/update/UpdateSettingsSection.tsx
@@ -867,19 +867,20 @@ interface UpdateToggleRowProps {
 
 function UpdateToggleRow({ label, checked, disabled = false, onChange }: UpdateToggleRowProps) {
   return (
-    <label
-      className={`flex items-center justify-between h-9 rounded-lg px-2.5 bg-paper-warm/45 border border-paper-deep/25 ${
-        disabled ? "opacity-60 cursor-not-allowed" : "cursor-pointer"
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-disabled={disabled || undefined}
+      onClick={() => {
+        if (disabled) return;
+        onChange(!checked);
+      }}
+      className={`flex w-full appearance-none items-center justify-between h-9 rounded-lg px-2.5 bg-paper-warm/45 border border-paper-deep/25 text-left font-body ${
+        disabled ? "cursor-not-allowed" : "cursor-pointer"
       }`}
     >
       <span className="text-[12px] text-ink-soft">{label}</span>
-      <input
-        type="checkbox"
-        checked={checked}
-        disabled={disabled}
-        onChange={(event) => onChange(event.target.checked)}
-        className="sr-only"
-      />
       <div
         className={`relative w-8 h-[18px] rounded-full transition-colors duration-250 ease-[cubic-bezier(0.22,1,0.36,1)] ${
           checked ? "bg-bamboo" : "bg-paper-deep/50"
@@ -891,7 +892,7 @@ function UpdateToggleRow({ label, checked, disabled = false, onChange }: UpdateT
           }`}
         />
       </div>
-    </label>
+    </button>
   );
 }
 


### PR DESCRIPTION
<!--
  提交 PR 前请逐项勾选确认。Please check all boxes before submitting.
  选择性填写，没有就不写。Fill in what's relevant; leave blank if not applicable.
-->

## Summary / 概要

<!-- 简要描述此 PR 做了什么。Briefly describe what this PR does. -->
当点击更新设置的任意一个toggle button，设置页面在视觉上会发生异常挤压，当窗口高度不足时，整个设置页面无法被看到。PR修改了UpdateSettingsSection.tsx，将checkbox修改为button来解决此问题。此外，修复了点击toggle button时，条目会在视觉上出现闪烁的问题。


## Related Issue / 关联 Issue

<!-- Fixes #123, Closes #456, or related to #789 -->
Fixes #292 

## Affected Platforms / 影响平台

<!-- 勾选受影响或已验证的平台。Check platforms affected or verified. -->

- [X] Windows
- [ ] macOS
- [ ] Linux
- [ ] Platform-agnostic / 平台无关

## Screenshots or Recordings / 截图或录屏

<!-- 前端变更请附截图或录屏。Attach screenshots or recordings for frontend changes. -->
修复前，点击任意更新设置toggle button开关，会发生“挤压”
<img width="2560" height="1528" alt="Q1" src="https://github.com/user-attachments/assets/0f7a620e-f7ae-4e01-91fb-ed4058460e9e" />

<img width="2560" height="1528" alt="Q2" src="https://github.com/user-attachments/assets/79daa210-bef6-4d74-962b-0fe499360b9e" />

修复后，点击toggle button不再发生“挤压”问题
<img width="2560" height="1528" alt="f1" src="https://github.com/user-attachments/assets/1d9ff8a5-d764-4254-bb59-3150b222b0f8" />

<img width="2560" height="1528" alt="f2" src="https://github.com/user-attachments/assets/a11bed63-dae5-4815-8ea3-89f8c7555b53" />

## Testing / 测试

<!-- 提供复现和验证步骤。Provide steps to verify the change. -->

1. 更新代码前，使用v1.1.0版本打开设置页面，点击更新设置的任意一个toggle button，会发生“挤压”，参考截图第一张和第二章
2. 更新代码后，重新构建版本，点击更新设置的任意一个toggle button，不会发生“挤压”，参考截图第三张和第四张

## Checklist / 检查清单

### Code quality / 代码质量

您确认您运行并通过了：

- [X] `npx oxfmt --check`
- [X] `npx oxlint`
- [X] `cargo fmt --check`
- [X] `cargo clippy --all-targets -- -D warnings`
- [X] `cargo test`
- [X] `npm test`

<!-- 感谢你对花笺 Floral Notepaper 的贡献！Thank you for your contribution! -->
