### PR TITLE
fix(notepad): 修复便签池 prewarm WebView 泄漏

### DIFF
--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -568,6 +568,7 @@ enum ShortcutAction {
 #[derive(Default)]
 struct NotepadPool {
     available: Mutex<Vec<String>>,
+    replenish_pending: AtomicBool,
 }
 
 impl NotepadPool {
@@ -590,6 +591,14 @@ impl NotepadPool {
             .lock()
             .map(|a| a.len() < NOTEPAD_POOL_CAPACITY)
             .unwrap_or(false)
+    }
+
+    fn try_begin_replenish(&self) -> bool {
+        !self.replenish_pending.swap(true, Ordering::SeqCst)
+    }
+
+    fn finish_replenish(&self) {
+        self.replenish_pending.store(false, Ordering::SeqCst);
     }
 }
 
@@ -1534,13 +1543,20 @@ fn should_save_surface_size_before_close(label: &str) -> bool {
 }
 
 fn schedule_notepad_prewarm(app: &AppHandle) {
-    for i in 0..NOTEPAD_POOL_CAPACITY {
-        let delay = 800 + i as u64 * 400;
-        schedule_notepad_replenish(app, delay);
-    }
+    schedule_notepad_replenish(app, 800);
 }
 
 fn schedule_notepad_replenish(app: &AppHandle, delay_ms: u64) {
+    let Some(pool) = app.try_state::<NotepadPool>() else {
+        return;
+    };
+    if !pool.is_below_capacity() {
+        return;
+    }
+    if !pool.try_begin_replenish() {
+        return;
+    }
+
     let handle = app.clone();
     std::thread::spawn(move || {
         std::thread::sleep(std::time::Duration::from_millis(delay_ms));
@@ -1548,6 +1564,9 @@ fn schedule_notepad_replenish(app: &AppHandle, delay_ms: u64) {
         let _ = handle.run_on_main_thread(move || {
             if let Err(error) = prewarm_notepad(&handle_inner) {
                 eprintln!("failed to replenish notepad pool: {error}");
+            }
+            if let Some(pool) = handle_inner.try_state::<NotepadPool>() {
+                pool.finish_replenish();
             }
         });
     });
@@ -1587,7 +1606,18 @@ fn prewarm_notepad(app: &AppHandle) -> Result<(), AppError> {
     .focused(false)
     .build()?;
 
-    pool.put(label);
+    if !pool.is_below_capacity() {
+        if let Some(window) = app.get_webview_window(&label) {
+            let _ = window.close();
+        }
+        return Ok(());
+    }
+
+    if !pool.put(label.clone()) {
+        if let Some(window) = app.get_webview_window(&label) {
+            let _ = window.close();
+        }
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary / 概要

修复便签池 prewarm 在以下场景产生的 **隐藏 WebView 泄漏**：

- `pool.put()` 失败（池已满）时未关闭已 `build()` 的待机窗口
- 启动时并行调度多次 replenish，重叠 prewarm 导致多余隐藏窗无法入池

## Related Issue / 关联 Issue

N/A

## Affected Platforms / 影响平台

- [x] Windows
- [ ] macOS
- [ ] Linux
- [ ] Platform-agnostic / 平台无关

## Screenshots or Recordings / 截图或录屏

N/A

## Testing / 测试

1. 多次 Ctrl+空格快速开空白便签，观察任务管理器 / 进程内 WebView 数量：隐藏 standby 不应随连按无限增长
2. 关闭便签后，池应能正常 replenish（下次开便签仍较快）

## Checklist / 检查清单

### Code quality / 代码质量

您确认您运行并通过了：

- [x] `npx oxfmt --check`
- [x] `npx oxlint`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `npm test`
