### PR TITLE
fix: 快捷键删除后仍生效 & 新建笔记不自动跳转

### DIFF
--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -2360,9 +2360,20 @@ pub fn stop_shortcut_recording(app: &AppHandle) -> Result<(), Box<dyn Error>> {
     #[cfg(target_os = "windows")]
     keyboard_hook::stop();
 
-    let config = load_config()?;
-    if let Err(e) = install_global_shortcut_bindings(app, &config, false) {
-        eprintln!("failed to re-register global shortcuts after recording: {e}");
+    // 从 RuntimeState 重新注册快捷键，避免读取磁盘配置导致的竞态条件：
+    // config_save 可能在 stop_shortcut_recording 之后/同时运行，
+    // 如果 stop 时从磁盘读取了旧配置，会重新注册已被用户清除的快捷键。
+    if let Some(state) = app.try_state::<RuntimeState>() {
+        if let Ok(guard) = state.shortcut_bindings.lock() {
+            let bindings = guard.clone();
+            drop(guard);
+            if let Some(s) = &bindings.open_notepad {
+                let _ = app.global_shortcut().register(*s);
+            }
+            if let Some(s) = &bindings.toggle_visibility {
+                let _ = app.global_shortcut().register(*s);
+            }
+        }
     }
 
     Ok(())

--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -1223,13 +1223,20 @@ export function MainWindow({
   ]);
 
   const handleNewNote = async () => {
+    setIsLoading(true);
     await saveCurrentNote();
     try {
       const note = await createNote({ title: "", content: "", category: activeCategory });
       replaceNoteMetadata(note);
       applyNote(note);
+      // 切换到新笔记时重置预览区滚动位置
+      if (previewScrollRef.current) {
+        previewScrollRef.current.scrollTop = 0;
+      }
     } catch (error) {
       showToast(getErrorMessage(error));
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -2867,7 +2874,7 @@ export function MainWindow({
             </div>
 
             <div
-              key={viewMode}
+              key={`${viewMode}-${selectedId ?? "none"}`}
               ref={splitContainerRef}
               className="flex-1 flex min-h-0 animate-view-fade"
             >

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -632,9 +632,10 @@ function ShortcutRecorder({ value, onChange }: ShortcutRecorderProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
   const clearShortcut = () => {
-    // 显式清除会保存为空值，后端据此注销旧的全局快捷键绑定。
-    recorder.cancelRecording();
+    // 先更新配置再停止录制，避免 stop_shortcut_recording
+    // 从旧状态重新注册已被清除的快捷键。
     onChange("");
+    recorder.cancelRecording();
     markShortcutCleared();
   };
 


### PR DESCRIPTION
<!--
  提交 PR 前请逐项勾选确认。Please check all boxes before submitting.
  选择性填写，没有就不写。Fill in what's relevant; leave blank if not applicable.
-->

## Summary / 概要

修复两个问题：

1. 快捷键清除后仍生效：`stop_shortcut_recording` 从磁盘读取旧配置重新注册快捷键，与 `config_save` 存在竞态条件，导致用户在设置中清除的快捷键被重新注册。改为从内存 `RuntimeState` 读取状态。
2. 新建笔记后编辑器不自动跳转：编辑器容器以 `viewMode` 为 key，切换笔记时不会强制重新挂载。改为 `${viewMode}-${selectedId}` 确保切换笔记时刷新组件。

## Affected Platforms / 影响平台

- [x] Windows
- [ ] macOS
- [ ] Linux
- [x] Platform-agnostic / 平台无关

## Testing / 测试

1. 打开设置 → 清除快捷键 → 按 Ctrl+Space 不应弹出快速便签
2. 录制新快捷键后按 Escape 取消 → 原快捷键仍正常工作
3. 点击"新建笔记" → 编辑器自动切换到空白新笔记
4. 新建笔记后能正常输入标题和内容

## Checklist / 检查清单

- [x] `npx oxfmt --check`
- [x] `npx oxlint`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `npm test`


<!-- 感谢你对花笺 Floral Notepaper 的贡献！Thank you for your contribution! -->
