### PR TITLE
feat: add font zoom shortcuts

### DIFF
--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -20,6 +20,11 @@ import {
   normalizeViewMode,
   saveConfig,
 } from "../features/settings/api";
+import {
+  getFontZoomDirection,
+  isFontZoomEventTargetBlocked,
+  nextFontSize,
+} from "../features/settings/fontZoom";
 import type { AppConfig, ViewMode } from "../features/settings/types";
 import { normalizeTileColor } from "../features/settings/tileColor";
 import { getUpdateStatus, reportInstallPreparation } from "../features/update/api";
@@ -722,6 +727,17 @@ export function MainWindow({
   }, [applyNote, clearCurrentNote]);
 
   useEffect(() => {
+    const unlisten = listen<AppConfig>("config-changed", (event) => {
+      setSettingsConfig(event.payload);
+      setSavedDataDir(event.payload.dataDir);
+      setViewMode(normalizeViewMode(event.payload.defaultViewMode));
+    });
+    return () => {
+      void unlisten.then((fn) => fn());
+    };
+  }, []);
+
+  useEffect(() => {
     let active = true;
 
     void getUpdateStatus()
@@ -1323,6 +1339,25 @@ export function MainWindow({
     },
     [persistSettings],
   );
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      const direction = getFontZoomDirection(event);
+      if (!direction || isFontZoomEventTargetBlocked(event.target)) return;
+
+      event.preventDefault();
+      if (!settingsConfig) return;
+
+      const currentSize = settingsConfig.fontSize ?? 14;
+      const fontSize = nextFontSize(currentSize, direction);
+      if (fontSize === currentSize) return;
+
+      handleSettingsChange({ ...settingsConfig, fontSize });
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [handleSettingsChange, settingsConfig]);
 
   const handleCloseSettings = useCallback(() => {
     setSettingsOpen(false);

--- a/src/components/NotePad.tsx
+++ b/src/components/NotePad.tsx
@@ -10,7 +10,7 @@ import type { UpdateInstallPrepareRequest } from "../features/update/types";
 import { showToast } from "./Toast";
 import type { Note, NoteMetadata } from "../features/notes/types";
 import { countNoteChars, metadataFromNote } from "../features/notes/noteUtils";
-import { listen } from "@tauri-apps/api/event";
+import { emit, listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
   animateCurrentWindowBounds,
@@ -24,13 +24,18 @@ import {
   startCurrentWindowResize,
 } from "../features/windows/controls";
 import type { ResizeDirection } from "../features/windows/controls";
-import { getConfig } from "../features/settings/api";
+import { getConfig, saveConfig } from "../features/settings/api";
+import {
+  getFontZoomDirection,
+  isFontZoomEventTargetBlocked,
+  nextFontSize,
+} from "../features/settings/fontZoom";
 import {
   DEFAULT_TILE_COLOR,
   normalizeTileColor,
   resolveTileColor,
 } from "../features/settings/tileColor";
-import type { TileColorMode } from "../features/settings/types";
+import type { AppConfig, TileColorMode } from "../features/settings/types";
 import {
   shouldEnterPadFromTileOnDoubleClick,
   shouldReturnToTileAfterManualSave,
@@ -149,6 +154,8 @@ export function NotePad({
   const tileDragIntentRef = useRef<{ x: number; y: number } | null>(null);
   const windowLabelRef = useRef("");
   const statusRef = useRef<NotePadStatus>("empty");
+  const appConfigRef = useRef<AppConfig | null>(null);
+  const surfaceFontZoomSaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const contentValueRef = useRef(content);
   contentValueRef.current = content;
   const titleValueRef = useRef(title);
@@ -199,6 +206,7 @@ export function NotePad({
     async function bootstrap() {
       try {
         const [loadedConfig] = await Promise.all([getConfig(), refreshNotes()]);
+        appConfigRef.current = loadedConfig;
         if (!cancelled) {
           setNoteSurfaceAutoSave(loadedConfig.noteSurfaceAutoSave);
           setSurfaceFontSize(loadedConfig.surfaceFontSize ?? 14);
@@ -254,14 +262,8 @@ export function NotePad({
   }, []);
 
   useEffect(() => {
-    const unlisten = listen<{
-      tileColor?: string;
-      tileColorMode?: TileColorMode;
-      surfaceFontSize?: number;
-      tileRenderMarkdown?: boolean;
-      tileDoubleClickToEdit?: boolean;
-      tileSaveReturnsToPin?: boolean;
-    }>("config-changed", (event) => {
+    const unlisten = listen<AppConfig>("config-changed", (event) => {
+      appConfigRef.current = event.payload;
       const mode = event.payload.tileColorMode ?? tileColorMode;
       const raw = event.payload.tileColor ?? tileColorRaw;
       setTileColorMode(mode);
@@ -279,6 +281,14 @@ export function NotePad({
       void unlisten.then((fn) => fn());
     };
   }, [tileColorMode, tileColorRaw]);
+
+  useEffect(() => {
+    return () => {
+      if (surfaceFontZoomSaveTimer.current) {
+        clearTimeout(surfaceFontZoomSaveTimer.current);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     if (tileColorMode !== "system") return;
@@ -539,8 +549,61 @@ export function NotePad({
     [clearPendingTileDrag, switchSurfaceMode, tileDoubleClickToEdit],
   );
 
+  const queueSurfaceFontSizeConfigSave = useCallback((nextConfig: AppConfig) => {
+    if (surfaceFontZoomSaveTimer.current) {
+      clearTimeout(surfaceFontZoomSaveTimer.current);
+    }
+
+    surfaceFontZoomSaveTimer.current = setTimeout(() => {
+      const configToSave = appConfigRef.current ?? nextConfig;
+      void saveConfig(configToSave)
+        .then((savedConfig) => {
+          appConfigRef.current = savedConfig;
+        })
+        .catch((error) => showToast(getErrorMessage(error)));
+    }, 300);
+  }, []);
+
+  const applySurfaceFontZoom = useCallback(
+    (direction: ReturnType<typeof getFontZoomDirection>) => {
+      if (!direction) return;
+
+      const applyConfig = (baseConfig: AppConfig) => {
+        const currentSize = baseConfig.surfaceFontSize ?? surfaceFontSize;
+        const nextSize = nextFontSize(currentSize, direction);
+        if (nextSize === currentSize) return;
+
+        const nextConfig = { ...baseConfig, surfaceFontSize: nextSize };
+        appConfigRef.current = nextConfig;
+        setSurfaceFontSize(nextSize);
+        void emit("config-changed", nextConfig);
+        queueSurfaceFontSizeConfigSave(nextConfig);
+      };
+
+      if (appConfigRef.current) {
+        applyConfig(appConfigRef.current);
+        return;
+      }
+
+      void getConfig()
+        .then((config) => {
+          appConfigRef.current = config;
+          applyConfig(config);
+        })
+        .catch((error) => showToast(getErrorMessage(error)));
+    },
+    [queueSurfaceFontSizeConfigSave, surfaceFontSize],
+  );
+
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
+      const direction = getFontZoomDirection(event);
+      if (direction && !isFontZoomEventTargetBlocked(event.target)) {
+        event.preventDefault();
+        applySurfaceFontZoom(direction);
+        return;
+      }
+
       if ((event.ctrlKey || event.metaKey) && event.key === "s") {
         event.preventDefault();
         void handleSave();
@@ -549,7 +612,7 @@ export function NotePad({
 
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [handleSave]);
+  }, [applySurfaceFontZoom, handleSave]);
 
   const handleOpenNote = async (noteId: string) => {
     try {

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -10,10 +10,7 @@ import type {
   TileColorMode,
   ViewMode,
 } from "../features/settings/types";
-import {
-  FONT_ZOOM_MAX,
-  FONT_ZOOM_MIN,
-} from "../features/settings/fontZoom";
+import { FONT_ZOOM_MAX, FONT_ZOOM_MIN } from "../features/settings/fontZoom";
 import {
   formatHeldKeys,
   hotkeyToConfigString,

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -11,6 +11,10 @@ import type {
   ViewMode,
 } from "../features/settings/types";
 import {
+  FONT_ZOOM_MAX,
+  FONT_ZOOM_MIN,
+} from "../features/settings/fontZoom";
+import {
   formatHeldKeys,
   hotkeyToConfigString,
   isValidGlobalShortcut,
@@ -259,8 +263,8 @@ export function SettingsPanel({ config, onChange, onMigrateDataDir, onClose }: S
           <div className="flex items-center gap-3 h-9 rounded-lg px-2.5 bg-paper-warm/45 border border-paper-deep/25">
             <input
               type="range"
-              min={8}
-              max={30}
+              min={FONT_ZOOM_MIN}
+              max={FONT_ZOOM_MAX}
               step={1}
               value={config.fontSize ?? 14}
               onChange={(event) => setConfigValue("fontSize", Number(event.target.value))}
@@ -279,8 +283,8 @@ export function SettingsPanel({ config, onChange, onMigrateDataDir, onClose }: S
           <div className="flex items-center gap-3 h-9 rounded-lg px-2.5 bg-paper-warm/45 border border-paper-deep/25">
             <input
               type="range"
-              min={8}
-              max={30}
+              min={FONT_ZOOM_MIN}
+              max={FONT_ZOOM_MAX}
               step={1}
               value={config.surfaceFontSize ?? 14}
               onChange={(event) => setConfigValue("surfaceFontSize", Number(event.target.value))}
@@ -672,7 +676,11 @@ function ShortcutRecorder({ value, onChange }: ShortcutRecorderProps) {
   const isChecking = checkState === "checking";
 
   return (
-    <div ref={containerRef} className="relative space-y-1.5">
+    <div
+      ref={containerRef}
+      data-shortcut-recorder-recording={recorder.isRecording ? "true" : undefined}
+      className="relative space-y-1.5"
+    >
       <div className="flex gap-2">
         <button
           type="button"

--- a/src/features/settings/fontZoom.test.ts
+++ b/src/features/settings/fontZoom.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "vitest";
+import {
+  FONT_ZOOM_MAX,
+  FONT_ZOOM_MIN,
+  getFontZoomDirection,
+  nextFontSize,
+} from "./fontZoom";
+
+const keyEvent = (
+  overrides: Partial<Parameters<typeof getFontZoomDirection>[0]>,
+): Parameters<typeof getFontZoomDirection>[0] => ({
+  altKey: false,
+  ctrlKey: true,
+  metaKey: false,
+  key: "",
+  code: "",
+  ...overrides,
+});
+
+describe("fontZoom", () => {
+  test("detects Obsidian-style zoom-in shortcuts", () => {
+    expect(getFontZoomDirection(keyEvent({ key: "=", code: "Equal" }))).toBe("in");
+    expect(getFontZoomDirection(keyEvent({ key: "+", code: "Equal" }))).toBe("in");
+    expect(getFontZoomDirection(keyEvent({ key: "+", code: "NumpadAdd" }))).toBe("in");
+    expect(getFontZoomDirection(keyEvent({ ctrlKey: false, metaKey: true, key: "=" }))).toBe(
+      "in",
+    );
+  });
+
+  test("detects zoom-out shortcuts", () => {
+    expect(getFontZoomDirection(keyEvent({ key: "-", code: "Minus" }))).toBe("out");
+    expect(getFontZoomDirection(keyEvent({ key: "-", code: "NumpadSubtract" }))).toBe("out");
+  });
+
+  test("requires a primary modifier and ignores alt-layered shortcuts", () => {
+    expect(getFontZoomDirection(keyEvent({ ctrlKey: false, key: "=", code: "Equal" }))).toBeNull();
+    expect(getFontZoomDirection(keyEvent({ altKey: true, key: "=", code: "Equal" }))).toBeNull();
+  });
+
+  test("steps font sizes inside the configured bounds", () => {
+    expect(nextFontSize(14, "in")).toBe(15);
+    expect(nextFontSize(14, "out")).toBe(13);
+    expect(nextFontSize(FONT_ZOOM_MAX, "in")).toBe(FONT_ZOOM_MAX);
+    expect(nextFontSize(FONT_ZOOM_MIN, "out")).toBe(FONT_ZOOM_MIN);
+  });
+});

--- a/src/features/settings/fontZoom.test.ts
+++ b/src/features/settings/fontZoom.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, test } from "vitest";
-import {
-  FONT_ZOOM_MAX,
-  FONT_ZOOM_MIN,
-  getFontZoomDirection,
-  nextFontSize,
-} from "./fontZoom";
+import { FONT_ZOOM_MAX, FONT_ZOOM_MIN, getFontZoomDirection, nextFontSize } from "./fontZoom";
 
 const keyEvent = (
   overrides: Partial<Parameters<typeof getFontZoomDirection>[0]>,
@@ -22,9 +17,7 @@ describe("fontZoom", () => {
     expect(getFontZoomDirection(keyEvent({ key: "=", code: "Equal" }))).toBe("in");
     expect(getFontZoomDirection(keyEvent({ key: "+", code: "Equal" }))).toBe("in");
     expect(getFontZoomDirection(keyEvent({ key: "+", code: "NumpadAdd" }))).toBe("in");
-    expect(getFontZoomDirection(keyEvent({ ctrlKey: false, metaKey: true, key: "=" }))).toBe(
-      "in",
-    );
+    expect(getFontZoomDirection(keyEvent({ ctrlKey: false, metaKey: true, key: "=" }))).toBe("in");
   });
 
   test("detects zoom-out shortcuts", () => {

--- a/src/features/settings/fontZoom.ts
+++ b/src/features/settings/fontZoom.ts
@@ -1,0 +1,47 @@
+export type FontZoomDirection = "in" | "out";
+
+export const FONT_ZOOM_MIN = 8;
+export const FONT_ZOOM_MAX = 30;
+export const FONT_ZOOM_STEP = 1;
+export const FONT_ZOOM_DEFAULT = 14;
+
+interface FontZoomKeyboardEvent {
+  altKey: boolean;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  key: string;
+  code: string;
+}
+
+const ZOOM_IN_KEYS = new Set(["=", "+", "Add"]);
+const ZOOM_IN_CODES = new Set(["Equal", "NumpadAdd"]);
+const ZOOM_OUT_KEYS = new Set(["-", "Subtract"]);
+const ZOOM_OUT_CODES = new Set(["Minus", "NumpadSubtract"]);
+
+export function getFontZoomDirection(event: FontZoomKeyboardEvent): FontZoomDirection | null {
+  if (!(event.ctrlKey || event.metaKey)) return null;
+  if (event.altKey) return null;
+
+  if (ZOOM_IN_KEYS.has(event.key) || ZOOM_IN_CODES.has(event.code)) return "in";
+  if (ZOOM_OUT_KEYS.has(event.key) || ZOOM_OUT_CODES.has(event.code)) return "out";
+
+  return null;
+}
+
+export function clampFontSize(value: number): number {
+  if (!Number.isFinite(value)) return FONT_ZOOM_DEFAULT;
+  return Math.min(FONT_ZOOM_MAX, Math.max(FONT_ZOOM_MIN, Math.round(value)));
+}
+
+export function nextFontSize(current: number, direction: FontZoomDirection): number {
+  const baseSize = clampFontSize(current);
+  const delta = direction === "in" ? FONT_ZOOM_STEP : -FONT_ZOOM_STEP;
+  return clampFontSize(baseSize + delta);
+}
+
+export function isFontZoomEventTargetBlocked(target: EventTarget | null): boolean {
+  return (
+    target instanceof HTMLElement &&
+    Boolean(target.closest('[data-shortcut-recorder-recording="true"]'))
+  );
+}


### PR DESCRIPTION
## Summary / 概要

- 添加类似 Obsidian 的字号缩放快捷键：`Ctrl+=` 放大，`Ctrl+-` 缩小。
- 复用已有的编辑器字号 `fontSize` 和小窗/磁贴字号 `surfaceFontSize` 配置。
- 支持主窗口编辑区、预览区，以及小窗/磁贴的字号缩放。
- 新增共享的字号缩放工具，并补充快捷键识别和字号边界测试。

## Related Issue / 关联 Issue

N/A

## Affected Platforms / 影响平台

- [x] Windows
- [ ] macOS
- [ ] Linux
- [x] Platform-agnostic / 平台无关

## Screenshots or Recordings / 截图或录屏

N/A

## Testing / 测试

1. `npm test -- --run src/features/settings/fontZoom.test.ts`
2. `npm test`
3. `npm run lint`
4. `npm run build`

## Checklist / 检查清单

### Code quality / 代码质量

- [ ] `npx oxfmt --check`
- [x] `npx oxlint`
- [ ] `cargo fmt --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo test`
- [x] `npm test`