### PR TITLE
feat: 撤销/重做时自动滚动到光标位置

### DIFF
--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -1619,9 +1619,44 @@ export function MainWindow({
   const handleUndo = () => {
     if (!selectedId) return;
     const textarea = contentRef.current;
-    if (runEditorCommand(textarea, "undo")) {
+    const undoResult = runEditorCommand(textarea, "undo");
+
+    if (undoResult) {
       setContent(textarea?.value ?? content);
       markDirty();
+
+      // 撤销成功后，自动滚动到光标位置
+      if (textarea) {
+        requestAnimationFrame(() => {
+          const cursorPos = textarea.selectionStart;
+          const textLines = textarea.value.substring(0, cursorPos).split("\n");
+          const currentLine = textLines.length;
+
+          // 获取行高
+          const style = window.getComputedStyle(textarea);
+          const lineHeight = parseFloat(style.lineHeight) || parseFloat(style.fontSize) * 1.5 || 20;
+
+          // 计算目标滚动位置（让光标位置居中显示）
+          const cursorTop = (currentLine - 1) * lineHeight;
+          const viewportHeight = textarea.clientHeight;
+          const targetScrollTop = cursorTop - viewportHeight / 2 + lineHeight / 2;
+
+          // 标记为编辑器主动滚动，避免同步滚动干扰
+          scrollSource.current = "editor";
+
+          // 滚动到目标位置
+          const finalScrollTop = Math.max(
+            0,
+            Math.min(targetScrollTop, textarea.scrollHeight - viewportHeight),
+          );
+          textarea.scrollTop = finalScrollTop;
+
+          // 150ms 后清除标记
+          setTimeout(() => {
+            scrollSource.current = null;
+          }, 150);
+        });
+      }
     }
   };
 
@@ -1631,8 +1666,68 @@ export function MainWindow({
     if (runEditorCommand(textarea, "redo")) {
       setContent(textarea?.value ?? content);
       markDirty();
+
+      // 重做成功后，自动滚动到光标位置
+      if (textarea) {
+        requestAnimationFrame(() => {
+          const cursorPos = textarea.selectionStart;
+          const textLines = textarea.value.substring(0, cursorPos).split("\n");
+          const currentLine = textLines.length;
+
+          // 获取行高
+          const style = window.getComputedStyle(textarea);
+          const lineHeight = parseFloat(style.lineHeight) || parseFloat(style.fontSize) * 1.5 || 20;
+
+          // 计算目标滚动位置（让光标位置居中显示）
+          const cursorTop = (currentLine - 1) * lineHeight;
+          const viewportHeight = textarea.clientHeight;
+          const targetScrollTop = cursorTop - viewportHeight / 2 + lineHeight / 2;
+
+          // 标记为编辑器主动滚动，避免同步滚动干扰
+          scrollSource.current = "editor";
+
+          // 滚动到目标位置
+          textarea.scrollTop = Math.max(
+            0,
+            Math.min(targetScrollTop, textarea.scrollHeight - viewportHeight),
+          );
+
+          // 150ms 后清除标记
+          setTimeout(() => {
+            scrollSource.current = null;
+          }, 150);
+        });
+      }
     }
   };
+
+  // 监听 Ctrl+Z 和 Ctrl+Y 快捷键
+  useEffect(() => {
+    function handleUndoRedoKeys(event: KeyboardEvent) {
+      // 如果没有选中笔记，不处理
+      if (!selectedId) return;
+
+      // 如果焦点不在 textarea 上，不处理（避免在其他输入框中拦截）
+      if (document.activeElement !== contentRef.current) return;
+
+      // Ctrl+Z 或 Cmd+Z（撤销）
+      if ((event.ctrlKey || event.metaKey) && event.key === "z" && !event.shiftKey) {
+        event.preventDefault();
+        handleUndo();
+      }
+      // Ctrl+Y 或 Cmd+Shift+Z（重做）
+      else if (
+        ((event.ctrlKey || event.metaKey) && event.key === "y") ||
+        ((event.ctrlKey || event.metaKey) && event.shiftKey && event.key === "z")
+      ) {
+        event.preventDefault();
+        handleRedo();
+      }
+    }
+
+    document.addEventListener("keydown", handleUndoRedoKeys);
+    return () => document.removeEventListener("keydown", handleUndoRedoKeys);
+  }, [selectedId, handleUndo, handleRedo]);
 
   const handleOpenNotepad = async () => {
     try {


### PR DESCRIPTION
<!--
  提交 PR 前请逐项勾选确认。Please check all boxes before submitting.
  选择性填写，没有就不写。Fill in what's relevant; leave blank if not applicable.
-->

## Summary / 概要

 添加撤销/重做时自动滚动到光标位置的功能。
 当用户执行撤销（Ctrl+Z）或重做（Ctrl+Y/Ctrl+Shift+Z）操作后，编辑器视口会自动滚动并居中显示光标位置。

## Related Issue / 关联 Issue

N/A

## Affected Platforms / 影响平台

<!-- 勾选受影响或已验证的平台。Check platforms affected or verified. -->

- [x] Windows
- [ ] macOS
- [ ] Linux
- [x] Platform-agnostic / 平台无关

## Screenshots or Recordings / 截图或录屏

N/A

## Testing / 测试

 1. 打开一个笔记，输入多行内容（超过一屏）
 2. 滚动到页面顶部或底部，使光标位置不在可见区域
 3. 按 Ctrl+Z 或点击撤销按钮
 4. 验证视口自动滚动到光标位置并居中显示
 5. 按 Ctrl+Y 或 Ctrl+Shift+Z 测试重做功能

## Checklist / 检查清单

### Code quality / 代码质量

您确认您运行并通过了：

- [x] `npx oxfmt --check`
- [x] `npx oxlint`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `npm test`

<!-- 感谢你对花笺 Floral Notepaper 的贡献！Thank you for your contribution! -->
