### PR TITLE
feat: 添加了PDF导出功能

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -98,6 +98,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ar_archive_writer"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4087686b4b0a3427190bae57a1d9a478dbb2d40c5dc1bd6e2b6d797913bdd348"
+dependencies = [
+ "object",
+]
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,6 +135,18 @@ dependencies = [
  "wl-clipboard-rs",
  "x11rb",
 ]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "async-broadcast"
@@ -296,6 +326,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "az"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,6 +342,29 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "biblatex"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591eba69b7c085632e22ca03606f0bbea68d53bbe26c8962e2d549af20c6a561"
+dependencies = [
+ "paste",
+ "roman-numerals-rs",
+ "strum",
+ "unic-langid",
+ "unicode-normalization",
+ "unscanny",
+]
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bit-set"
@@ -405,10 +464,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "byteorder"
@@ -548,6 +627,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chinese-number"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e964125508474a83c95eb935697abbeb446ff4e9d62c71ce880e3986d1c606b"
+dependencies = [
+ "chinese-variant",
+ "enum-ordinalize",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "chinese-variant"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d1275808335c5583ea45a4141d631dafcb36b79fa8a5e10b00e356b6af3e08a"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,6 +656,44 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "citationberg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756ff1e3d43a9ecc8183932fb4d9fd3971236f3ce4acb62fe51d1cd43297547d"
+dependencies = [
+ "quick-xml 0.38.4",
+ "serde",
+ "serde_path_to_error",
 ]
 
 [[package]]
@@ -598,6 +733,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "codex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0732ab1a27b4ea05e6f9f60a5122c9924dd5123defde0d8e907f58cf643d40e6"
+dependencies = [
+ "chinese-number",
+]
+
+[[package]]
+name = "color"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ec7c5eb7a16992b1904d76c517d170ab353b0e0b3d5a0c81a8a0cd1037893cf"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,6 +779,30 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "comemo"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c963350b2b08aa4b725d7802593245380ab53dacfedcaa971385fc33306c0d4"
+dependencies = [
+ "comemo-macros",
+ "parking_lot",
+ "rustc-hash",
+ "siphasher",
+ "slab",
+]
+
+[[package]]
+name = "comemo-macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3c400139ba1389ef9e20ad2d87cda68b437a66483aa0da616bdf2cea7413853"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -683,6 +875,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,6 +906,25 @@ name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -752,6 +972,27 @@ checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -803,6 +1044,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "dbus"
@@ -1016,6 +1263,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecow"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78e4f79b296fbaab6ce2e22d52cb4c7f010fe0ebe7a32e34fa25885fd797bd02"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,6 +1302,26 @@ name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "enumflags2"
@@ -1096,6 +1378,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,6 +1408,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,6 +1444,12 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "fearless_simd"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97b65636e5b9ef369943878ac74335ba1c55c1cb6adbf1e2c293c624248d693"
 
 [[package]]
 name = "field-offset"
@@ -1167,6 +1481,16 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1176,6 +1500,7 @@ dependencies = [
  "block2",
  "chrono",
  "dirs 6.0.0",
+ "fontdb",
  "keyring",
  "libc",
  "objc2",
@@ -1198,6 +1523,8 @@ dependencies = [
  "tauri-plugin-single-instance",
  "tokio",
  "trash",
+ "typst",
+ "typst-pdf",
  "uuid",
  "windows-sys 0.59.0",
 ]
@@ -1219,6 +1546,38 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "font-types"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree 0.20.0",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
 
 [[package]]
 name = "foreign-types"
@@ -1501,6 +1860,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1577,6 +1946,29 @@ checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
 dependencies = [
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "glidesort"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2e102e6eb644d3e0b186fc161e4460417880a0a0b87d235f2e5b8fb30f2e9e0"
+
+[[package]]
+name = "glifo"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d99fc21d493812643aae86d53b7bbd02f376434a90317e8a790bc209fdd6605e"
+dependencies = [
+ "bytemuck",
+ "foldhash 0.2.0",
+ "hashbrown 0.17.1",
+ "log",
+ "peniko",
+ "png 0.18.1",
+ "skrifa",
+ "smallvec",
+ "vello_common 0.0.9",
 ]
 
 [[package]]
@@ -1667,6 +2059,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "guillotiere"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b17e70c989c36bad147b27a58d148c0741c51448aa5653436547323e524d0ab"
+dependencies = [
+ "euclid",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1697,6 +2098,146 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hayagriva"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b6c185c5c72546d50b25b70187f01ab9a1a2fa21c4db8691e2426fa5fce805c"
+dependencies = [
+ "biblatex",
+ "ciborium",
+ "citationberg",
+ "icu_collator",
+ "icu_locale",
+ "indexmap 2.14.0",
+ "paste",
+ "roman-numerals-rs",
+ "serde",
+ "serde_yaml",
+ "thiserror 2.0.18",
+ "unic-langid",
+ "unicode-segmentation",
+ "unscanny",
+ "url",
+]
+
+[[package]]
+name = "hayro"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4caa128ab87fd48ffb7490617cf93f77f606820dffbc9fd9ef6ab0ed077f56d"
+dependencies = [
+ "bytemuck",
+ "hayro-interpret",
+ "image",
+ "kurbo",
+ "pic-scale",
+ "vello_cpu",
+]
+
+[[package]]
+name = "hayro-ccitt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f4d0e94ddd48749f06bbe4e5389fb9799a0c45bcaf00495042076ef05e3241a"
+
+[[package]]
+name = "hayro-cmap"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d285dc30731c8485de5fa732fbdf2b3affdf01e4da7c2135022ca6fa664bf6"
+dependencies = [
+ "hayro-postscript",
+]
+
+[[package]]
+name = "hayro-interpret"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2613d0406898995042d0794c4245b2f2fba1246490c8ac593769bba6551129d"
+dependencies = [
+ "bitflags 2.11.1",
+ "hayro-cmap",
+ "hayro-syntax",
+ "kurbo",
+ "moxcms",
+ "phf",
+ "rustc-hash",
+ "siphasher",
+ "skrifa",
+ "smallvec",
+ "yoke",
+]
+
+[[package]]
+name = "hayro-jbig2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69374b3668dd45aeb3d3145cda68f2c7b4f223aaa2511e67d076f1c7d741388d"
+dependencies = [
+ "fearless_simd",
+ "hayro-ccitt",
+]
+
+[[package]]
+name = "hayro-jpeg2000"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ab947623ef4ccaa7acf0579edf7cbb5a73838e3839a7be73335e522f433a1"
+dependencies = [
+ "fearless_simd",
+]
+
+[[package]]
+name = "hayro-postscript"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "885c5ef0654933139a9b9546fc2c69e18d37f38aa2520f079092b1be18f1fcaa"
+
+[[package]]
+name = "hayro-svg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7434c89e920d84e077214a29e69b462a6518754610f732f1124af3948410cb8c"
+dependencies = [
+ "base64 0.22.1",
+ "hayro-interpret",
+ "image",
+ "kurbo",
+ "siphasher",
+ "xmlwriter",
+]
+
+[[package]]
+name = "hayro-syntax"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edeafd70aa2db743de8ede8637d07ec87db05efe69cde371d03f1b185fcef27"
+dependencies = [
+ "flate2",
+ "hayro-ccitt",
+ "hayro-jbig2",
+ "hayro-jpeg2000",
+ "memchr",
+ "rustc-hash",
+ "smallvec",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "hayro-write"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b3db92c4917aad24ff30d61413a9a7509ae88b27aee1ae34eff881e1d2723a"
+dependencies = [
+ "flate2",
+ "hayro-syntax",
+ "pdf-writer",
+]
 
 [[package]]
 name = "heck"
@@ -1837,6 +2378,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hypher"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef68590049bab63a464eee1a1158ac04c6f6613a546d8d90f78636b8b94f171"
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1871,6 +2418,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collator"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bbdf98e5e0aa827770acee171ebb568aaab975a36b56afdb5fd0e2f525750bb"
+dependencies = [
+ "icu_collator_data",
+ "icu_collections",
+ "icu_locale",
+ "icu_locale_core",
+ "icu_normalizer",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_collator_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038ed8e5817f2059c2f3efb0945ba78d060d3d25e8f1a1bea5139f821a21a2f0"
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1878,9 +2450,25 @@ checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "serde",
  "utf8_iter",
  "yoke",
  "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_locale_data",
+ "icu_provider",
+ "potential_utf",
+ "tinystr",
  "zerovec",
 ]
 
@@ -1892,10 +2480,17 @@ checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
+ "serde",
  "tinystr",
  "writeable",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_locale_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
 
 [[package]]
 name = "icu_normalizer"
@@ -1908,6 +2503,9 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
  "zerovec",
 ]
 
@@ -1927,6 +2525,7 @@ dependencies = [
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
+ "serde",
  "zerotrie",
  "zerovec",
 ]
@@ -1945,12 +2544,52 @@ checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
+ "postcard",
+ "serde",
+ "stable_deref_trait",
  "writeable",
  "yoke",
  "zerofrom",
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_provider_blob"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99a43c4436b6c9a37c27a822ff05238bbad134bcdf6176732208acfae46a3f"
+dependencies = [
+ "icu_provider",
+ "postcard",
+ "serde",
+ "writeable",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_segmenter"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0794db0b1a86193ac9c48768d0e6c52c54448e0870ad87907d456ee0dac964"
+dependencies = [
+ "core_maths",
+ "icu_collections",
+ "icu_locale",
+ "icu_provider",
+ "icu_segmenter_data",
+ "potential_utf",
+ "serde",
+ "utf8_iter",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_segmenter_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a2c462a4d927d512f5f882a033ddd62f33a05bb9f230d98f736ac3dc85938f"
 
 [[package]]
 name = "id-arena"
@@ -1993,11 +2632,32 @@ checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "color_quant",
+ "gif",
+ "image-webp",
  "moxcms",
  "num-traits",
  "png 0.18.1",
  "tiff",
+ "zune-core",
+ "zune-jpeg",
 ]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imagesize"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
 
 [[package]]
 name = "indexmap"
@@ -2018,6 +2678,7 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "rayon",
  "serde",
  "serde_core",
 ]
@@ -2170,6 +2831,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kamadak-exif"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1130d80c7374efad55a117d715a3af9368f0fa7a2c54573afc15a188cd984837"
+dependencies = [
+ "mutate_once",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2193,6 +2863,65 @@ dependencies = [
  "security-framework 3.7.0",
  "windows-sys 0.60.2",
  "zeroize",
+]
+
+[[package]]
+name = "krilla"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27da593198b20eeba65caeb73c2bbeec3e53ab08fa549898312ce81c4fce5e33"
+dependencies = [
+ "base64 0.22.1",
+ "bumpalo",
+ "comemo",
+ "flate2",
+ "float-cmp",
+ "gif",
+ "hayro-write",
+ "image-webp",
+ "imagesize",
+ "indexmap 2.14.0",
+ "pdf-writer",
+ "png 0.18.1",
+ "rayon",
+ "rustc-hash",
+ "rustybuzz",
+ "siphasher",
+ "skrifa",
+ "smallvec",
+ "subsetter",
+ "tiny-skia-path",
+ "xmp-writer",
+ "yoke",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "krilla-svg"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1237d7c37b16ca9fbc2e72dde13a10d321f9a44aceee35c062bc0a43bfc7ce16"
+dependencies = [
+ "flate2",
+ "fontdb",
+ "krilla",
+ "resvg",
+ "skrifa",
+ "smallvec",
+ "tiny-skia",
+ "usvg",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "polycool",
+ "smallvec",
 ]
 
 [[package]]
@@ -2251,6 +2980,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2258,6 +2993,18 @@ checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "linebender_resource_handle"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-keyutils"
@@ -2276,10 +3023,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "lipsum"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "636860251af8963cc40f6b4baadee105f02e21b28131d76eba8e40ce84ab8064"
+dependencies = [
+ "rand 0.8.7",
+ "rand_chacha 0.3.1",
+]
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "lock_api"
@@ -2318,6 +3078,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -2387,6 +3156,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mutate_once"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2426,10 +3201,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2681,6 +3475,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2728,6 +3531,30 @@ checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2785,10 +3612,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pdf-writer"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e456864a7a304047bff84977dc6fb162bd956475d40ba50b2dcecaada7f753"
+dependencies = [
+ "bitflags 2.11.1",
+ "itoa",
+ "memchr",
+ "ryu",
+]
+
+[[package]]
+name = "peniko"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "839c8299360d2e998bdb106dc0a6cd71dcc5f4df51df1b620361bf50e283cca6"
+dependencies = [
+ "bytemuck",
+ "color",
+ "kurbo",
+ "linebender_resource_handle",
+ "smallvec",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2861,6 +3719,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pic-scale"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "694e82ac1a7d35d78dc5fdc6763ffa7c0025a65d4fea3e53ba24fc89f216fc06"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2891,7 +3765,7 @@ checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.39.4",
  "serde",
  "time",
 ]
@@ -2937,11 +3811,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "polycool"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
+ "serde_core",
+ "writeable",
  "zerovec",
 ]
 
@@ -3030,12 +3931,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
 ]
 
 [[package]]
@@ -3049,6 +3966,16 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "quick-xml"
@@ -3088,7 +4015,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3137,12 +4064,31 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3152,8 +4098,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -3169,6 +4121,36 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
+dependencies = [
+ "bytemuck",
+ "font-types",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -3325,6 +4307,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "resvg"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be183ad6a216aa96f33e4c8033b0988b8b3ea6fd2359d19af5bac4643fd8e81"
+dependencies = [
+ "gif",
+ "image-webp",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "rfd"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3349,6 +4348,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3360,6 +4368,37 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "roman-numerals-rs"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85cd47a33a4510b1424fe796498e174c6a9cf94e606460ef022a19f3e4ff85e"
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "roxmltree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
+dependencies = [
+ "arrayvec",
+ "num-traits",
 ]
 
 [[package]]
@@ -3430,6 +4469,24 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustybuzz"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytemuck",
+ "core_maths",
+ "log",
+ "smallvec",
+ "ttf-parser",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
 
 [[package]]
 name = "ryu"
@@ -3635,6 +4692,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3708,6 +4776,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serialize-to-javascript"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3772,16 +4853,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
+name = "skrifa"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
+dependencies = [
+ "bytemuck",
+ "read-fonts",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"
@@ -3848,10 +4957,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stacker"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
 
 [[package]]
 name = "string_cache"
@@ -3884,10 +5021,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "subsetter"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38803281d1c23166c5ebcb455439a5d2afe711cc909cf88af72448c297756ad6"
+dependencies = [
+ "kurbo",
+ "rustc-hash",
+ "skrifa",
+ "write-fonts",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "svgtypes"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695b5790b3131dafa99b3bbfd25a216edb3d216dad9ca208d4657bfb8f2abc3d"
+dependencies = [
+ "kurbo",
+ "siphasher",
+]
 
 [[package]]
 name = "swift-rs"
@@ -3939,6 +5119,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "fancy-regex",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror 2.0.18",
+ "walkdir",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -4403,6 +5604,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "thin-vec"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4488,12 +5695,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-skia"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47ffee5eaaf5527f630fb0e356b90ebdec84d5d18d937c5e440350f88c5a91ea"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png 0.18.1",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca365c3faccca67d06593c5980fa6c57687de727a03131735bb85f01fdeeb9"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -4803,6 +6037,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
+
+[[package]]
+name = "two-face"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e51b6e60e545cfdae5a4639ff423818f52372211a8d9a3e892b4b0761f76b2"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "syntect",
+]
+
+[[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4813,6 +6073,317 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "typst"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8bf2a5a9d58cc542764a88dd43c8a679b683db4ae23e36267219339ab36b01"
+dependencies = [
+ "arrayvec",
+ "comemo",
+ "ecow",
+ "rustc-hash",
+ "typst-eval",
+ "typst-html",
+ "typst-layout",
+ "typst-library",
+ "typst-macros",
+ "typst-realize",
+ "typst-syntax",
+ "typst-timing",
+ "typst-utils",
+]
+
+[[package]]
+name = "typst-assets"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da9b236d339dce0ec443dc44afe4ba4c6d76b8917bd4b1ae80158d2111f6637b"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "typst-eval"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d064876305073ab75d5af039ae5e8dcb32c4cac4aa9f43d0f5aae347baef7c3"
+dependencies = [
+ "comemo",
+ "ecow",
+ "indexmap 2.14.0",
+ "rustc-hash",
+ "stacker",
+ "toml 0.8.2",
+ "typst-library",
+ "typst-macros",
+ "typst-syntax",
+ "typst-timing",
+ "typst-utils",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "typst-html"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d442f92bae44087735efc8b83508b259c573bbccf027e098ac68c8f4ca879f76"
+dependencies = [
+ "az",
+ "bumpalo",
+ "comemo",
+ "ecow",
+ "palette",
+ "rustc-hash",
+ "time",
+ "typst-assets",
+ "typst-library",
+ "typst-macros",
+ "typst-svg",
+ "typst-syntax",
+ "typst-timing",
+ "typst-utils",
+ "unicode-math-class",
+]
+
+[[package]]
+name = "typst-layout"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae5af3949efc6d02e3d55e79430c9096415fcf68166414c3a0e5fed1c3325d5f"
+dependencies = [
+ "az",
+ "bumpalo",
+ "codex",
+ "comemo",
+ "ecow",
+ "either",
+ "hypher",
+ "icu_properties",
+ "icu_provider",
+ "icu_provider_blob",
+ "icu_segmenter",
+ "kurbo",
+ "libm",
+ "memchr",
+ "rustc-hash",
+ "rustybuzz",
+ "smallvec",
+ "ttf-parser",
+ "typst-assets",
+ "typst-library",
+ "typst-macros",
+ "typst-syntax",
+ "typst-timing",
+ "typst-utils",
+ "unicode-bidi",
+ "unicode-math-class",
+ "unicode-script",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "typst-library"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9550a33d0f4e1965fd7d69abcf10135e965a4ad3a3aee24573b52dda9234e491"
+dependencies = [
+ "arrayvec",
+ "az",
+ "bitflags 2.11.1",
+ "bumpalo",
+ "ciborium",
+ "codex",
+ "comemo",
+ "csv",
+ "ecow",
+ "either",
+ "flate2",
+ "fontdb",
+ "glidesort",
+ "hayagriva",
+ "hayro-syntax",
+ "icu_properties",
+ "image",
+ "indexmap 2.14.0",
+ "kamadak-exif",
+ "kurbo",
+ "libm",
+ "lipsum",
+ "memchr",
+ "moxcms",
+ "palette",
+ "percent-encoding",
+ "phf",
+ "png 0.18.1",
+ "rayon",
+ "regex",
+ "regex-syntax",
+ "roxmltree 0.21.1",
+ "rust_decimal",
+ "rustc-hash",
+ "rustybuzz",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "siphasher",
+ "smallvec",
+ "syntect",
+ "time",
+ "toml 0.8.2",
+ "ttf-parser",
+ "two-face",
+ "typed-arena",
+ "typst-assets",
+ "typst-macros",
+ "typst-syntax",
+ "typst-timing",
+ "typst-utils",
+ "unicode-math-class",
+ "unicode-normalization",
+ "unicode-segmentation",
+ "unscanny",
+ "usvg",
+ "utf8_iter",
+ "wasmi",
+ "xmlwriter",
+]
+
+[[package]]
+name = "typst-macros"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "500e2873a544ca161f98183eea7ddb00030d16f4585b5ffa9e9c8e24f53148e1"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "typst-pdf"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7b33bcabc3357480768f6c78dda99a838d621c71b4738b25e09ac30ac063c9"
+dependencies = [
+ "az",
+ "bytemuck",
+ "codex",
+ "comemo",
+ "ecow",
+ "flate2",
+ "image",
+ "indexmap 2.14.0",
+ "infer",
+ "krilla",
+ "krilla-svg",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "typst-assets",
+ "typst-layout",
+ "typst-library",
+ "typst-macros",
+ "typst-syntax",
+ "typst-timing",
+ "typst-utils",
+]
+
+[[package]]
+name = "typst-realize"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "917e09614771258b13409b9a8d4f3915b2a2f7f28ca987701695f82fc6a7c0b9"
+dependencies = [
+ "arrayvec",
+ "bumpalo",
+ "comemo",
+ "ecow",
+ "regex",
+ "typst-html",
+ "typst-library",
+ "typst-macros",
+ "typst-syntax",
+ "typst-timing",
+ "typst-utils",
+]
+
+[[package]]
+name = "typst-svg"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "878b6e1293c2bea77a8be50670d1cbca4e676af96480313a105cba539da51d1c"
+dependencies = [
+ "base64 0.22.1",
+ "comemo",
+ "ecow",
+ "flate2",
+ "hayro",
+ "hayro-svg",
+ "image",
+ "indexmap 2.14.0",
+ "itoa",
+ "rustc-hash",
+ "ryu",
+ "ttf-parser",
+ "typst-assets",
+ "typst-layout",
+ "typst-library",
+ "typst-macros",
+ "typst-timing",
+ "typst-utils",
+ "xmlwriter",
+]
+
+[[package]]
+name = "typst-syntax"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22bf7f87450e5841debd4986b0f912b0f7a2251e600c08aca406305ff52c67b4"
+dependencies = [
+ "ecow",
+ "rustc-hash",
+ "serde",
+ "toml 0.8.2",
+ "typst-timing",
+ "typst-utils",
+ "unicode-ident",
+ "unicode-math-class",
+ "unicode-script",
+ "unicode-segmentation",
+ "unscanny",
+]
+
+[[package]]
+name = "typst-timing"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cc0c78ece2ade6ef73d00a13f9c474e02efc3bcfdb770e16d7c4d24e7492773"
+dependencies = [
+ "parking_lot",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "typst-utils"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40215eb2541102ecfb4cf3bef29da53033a82e22dbc2308c43bdb855701bf8d2"
+dependencies = [
+ "libm",
+ "once_cell",
+ "portable-atomic",
+ "rayon",
+ "rustc-hash",
+ "semver",
+ "siphasher",
+ "smallvec",
+ "thin-vec",
+ "unicode-math-class",
+]
 
 [[package]]
 name = "uds_windows"
@@ -4847,6 +6418,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc"
 
 [[package]]
+name = "unic-langid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ba52c9b05311f4f6e62d5d9d46f094bd6e84cb8df7b3ef952748d752a7d05"
+dependencies = [
+ "unic-langid-impl",
+ "unic-langid-macros",
+]
+
+[[package]]
+name = "unic-langid-impl"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658"
+dependencies = [
+ "serde",
+ "tinystr",
+]
+
+[[package]]
+name = "unic-langid-macros"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5957eb82e346d7add14182a3315a7e298f04e1ba4baac36f7f0dbfedba5fc25"
+dependencies = [
+ "proc-macro-hack",
+ "tinystr",
+ "unic-langid-impl",
+ "unic-langid-macros-impl",
+]
+
+[[package]]
+name = "unic-langid-macros-impl"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1249a628de3ad34b821ecb1001355bca3940bcb2f88558f1a8bd82e977f75b5"
+dependencies = [
+ "proc-macro-hack",
+ "quote",
+ "syn 2.0.117",
+ "unic-langid-impl",
+]
+
+[[package]]
 name = "unic-ucd-ident"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4867,10 +6482,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-math-class"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d246cf599d5fae3c8d56e04b20eb519adb89a8af8d0b0fbcded369aa3647d65"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
 
 [[package]]
 name = "unicode-segmentation"
@@ -4879,10 +6539,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "unscanny"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9df2af067a7953e9c3831320f35c1cc0600c30d44d9f7a12b01db1cd88d6b47"
 
 [[package]]
 name = "untrusted"
@@ -4922,10 +6600,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "usvg"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de"
+dependencies = [
+ "base64 0.22.1",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize",
+ "kurbo",
+ "log",
+ "pico-args",
+ "roxmltree 0.21.1",
+ "rustybuzz",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "ttf-parser",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
+]
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -4949,6 +6661,53 @@ dependencies = [
  "js-sys",
  "serde_core",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "vello_common"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3361bff7f7d82c0c496b92048db83846691f0e844cc28dee92b1c824291b55ee"
+dependencies = [
+ "bytemuck",
+ "fearless_simd",
+ "guillotiere",
+ "hashbrown 0.17.1",
+ "log",
+ "peniko",
+ "png 0.18.1",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "vello_common"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d672facaa2d697285a786cd9d44d614cd2ce54cdc022504bf339f8fff3b750"
+dependencies = [
+ "bytemuck",
+ "fearless_simd",
+ "guillotiere",
+ "hashbrown 0.17.1",
+ "log",
+ "peniko",
+ "png 0.18.1",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "vello_cpu"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d8ded630e8316bb94a55881256506d1f3b9947b5f66db8a7d32ca7ba02decd0"
+dependencies = [
+ "bytemuck",
+ "glifo",
+ "hashbrown 0.17.1",
+ "png 0.18.1",
+ "vello_common 0.0.8",
 ]
 
 [[package]]
@@ -5088,7 +6847,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
  "leb128fmt",
- "wasmparser",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -5100,7 +6859,7 @@ dependencies = [
  "anyhow",
  "indexmap 2.14.0",
  "wasm-encoder",
- "wasmparser",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -5114,6 +6873,52 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmi"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2300d0f78cba12f14e29e8dd157ea64050c0a688179aefdb2050105805594a0c"
+dependencies = [
+ "spin",
+ "wasmi_collections",
+ "wasmi_core",
+ "wasmi_ir",
+ "wasmparser 0.239.0",
+]
+
+[[package]]
+name = "wasmi_collections"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a8c42a2a76148d43097b1d7cc2a5bf33d5c23bd4dd69015fc887e311767884"
+
+[[package]]
+name = "wasmi_core"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9013136083d988725953390bf668b64b7a218fabf26f8b913bbc59546b97ee27"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "wasmi_ir"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1fa003f79156f406d62ef0e1464dc03e11ace37170e9fa7524299a75ad8f68"
+dependencies = [
+ "wasmi_core",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9d90bb93e764f6beabf1d02028c70a2156a6583e63ac4218dd07ef733368b0"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -5185,7 +6990,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
- "quick-xml",
+ "quick-xml 0.39.4",
  "quote",
 ]
 
@@ -5927,7 +7732,7 @@ dependencies = [
  "serde_json",
  "wasm-encoder",
  "wasm-metadata",
- "wasmparser",
+ "wasmparser 0.244.0",
  "wit-parser",
 ]
 
@@ -5946,7 +7751,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -5966,6 +7771,25 @@ dependencies = [
  "wayland-protocols",
  "wayland-protocols-wlr",
 ]
+
+[[package]]
+name = "write-fonts"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb731d4c4d93eacc69a1ad2f270f905788a98e4a3438267bcafbe08d3431c8d8"
+dependencies = [
+ "font-types",
+ "indexmap 2.14.0",
+ "kurbo",
+ "log",
+ "read-fonts",
+]
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
 
 [[package]]
 name = "writeable"
@@ -6060,6 +7884,27 @@ name = "xkeysym"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
+name = "xmp-writer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9440ea3e5aeabb0ac63af70daf835274065238cdd0cec83418f417eae38bacee"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "yoke"
@@ -6199,8 +8044,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
+ "litemap",
+ "serde_core",
  "yoke",
  "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
@@ -6209,6 +8057,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",
@@ -6224,6 +8073,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
 
 [[package]]
 name = "zmij"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,6 +39,9 @@ semver = "1"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 sha2 = "0.10"
 dirs = "6"
+typst = { version = "0.15", default-features = false }
+typst-pdf = "0.15"
+fontdb = "0.23"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -2562,6 +2562,9 @@ mod tests {
             toggle_visibility_shortcut: toggle_visibility_shortcut.into(),
             notes_dir: None,
             last_known_base_dir: None,
+            export_page_size: "a4".into(),
+            export_font_family: "HarmonyOS Sans".into(),
+            export_font_size: 14,
         }
     }
 
@@ -2647,6 +2650,9 @@ mod tests {
             toggle_visibility_shortcut: String::new(),
             notes_dir: None,
             last_known_base_dir: None,
+            export_page_size: "a4".into(),
+            export_font_family: "HarmonyOS Sans".into(),
+            export_font_size: 14,
         };
         let next = AppConfig {
             locale: "en-US".into(),
@@ -2684,6 +2690,9 @@ mod tests {
             toggle_visibility_shortcut: "Ctrl+Shift+H".into(),
             notes_dir: None,
             last_known_base_dir: None,
+            export_page_size: "a4".into(),
+            export_font_family: "HarmonyOS Sans".into(),
+            export_font_size: 14,
         };
 
         assert_eq!(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -64,6 +64,11 @@ fn notes_export_markdown(id: String, path: String) -> Result<(), AppError> {
 }
 
 #[tauri::command]
+fn notes_export_pdf(id: String, path: String) -> Result<(), AppError> {
+    default_store()?.export_pdf_file(&id, &PathBuf::from(path))
+}
+
+#[tauri::command]
 fn read_external_file(path: String) -> Result<String, AppError> {
     std::fs::read_to_string(&path).map_err(|e| AppError {
         code: "io".into(),
@@ -449,6 +454,7 @@ pub fn run() {
             notes_delete,
             notes_import_markdown,
             notes_export_markdown,
+            notes_export_pdf,
             notes_move_category,
             read_external_file,
             save_external_file,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 pub mod desktop;
 pub mod json_io;
 pub mod locales;
@@ -64,8 +66,12 @@ fn notes_export_markdown(id: String, path: String) -> Result<(), AppError> {
 }
 
 #[tauri::command]
-fn notes_export_pdf(id: String, path: String) -> Result<(), AppError> {
-    default_store()?.export_pdf_file(&id, &PathBuf::from(path))
+fn notes_export_pdf(
+    id: String,
+    path: String,
+    admonition_labels: HashMap<String, String>,
+) -> Result<(), AppError> {
+    default_store()?.export_pdf_file(&id, &PathBuf::from(path), admonition_labels)
 }
 
 #[tauri::command]

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -1,1 +1,2 @@
 pub mod notes;
+pub mod pdf;

--- a/src-tauri/src/services/notes.rs
+++ b/src-tauri/src/services/notes.rs
@@ -1,4 +1,5 @@
 use crate::json_io::write_json_atomic;
+use crate::services::pdf;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -88,6 +89,13 @@ pub struct AppConfig {
     pub toggle_visibility_shortcut: String,
     #[serde(default = "default_open_at_cursor")]
     pub open_at_cursor: bool,
+    // Export settings
+    #[serde(default = "default_export_page_size")]
+    pub export_page_size: String,
+    #[serde(default = "default_export_font_family")]
+    pub export_font_family: String,
+    #[serde(default = "default_export_font_size")]
+    pub export_font_size: u32,
     // Legacy fields — read from old config, never written back
     #[serde(default, skip_serializing)]
     pub notes_dir: Option<String>,
@@ -896,6 +904,21 @@ impl NoteStore {
         Ok(())
     }
 
+    pub fn export_pdf_file(&self, id: &str, path: &Path) -> Result<(), AppError> {
+        let note = self.read_note(id)?;
+        let config = self.load_config()?;
+        let options = pdf::PdfExportOptions {
+            page_size: config.export_page_size,
+            font_family: config.export_font_family,
+            font_size: config.export_font_size,
+        };
+        pdf::export_markdown_to_pdf(&note.content, path, &options).map_err(|msg| AppError {
+            code: "exportPdf".into(),
+            message: msg,
+            details: Default::default(),
+        })
+    }
+
     pub fn list_categories(&self) -> Result<Vec<String>, AppError> {
         let notes_dir = self.notes_dir();
         fs::create_dir_all(&notes_dir)?;
@@ -1083,6 +1106,9 @@ impl NoteStore {
             surface_height: None,
             toggle_visibility_shortcut: default_toggle_visibility_shortcut(),
             open_at_cursor: default_open_at_cursor(),
+            export_page_size: default_export_page_size(),
+            export_font_family: default_export_font_family(),
+            export_font_size: default_export_font_size(),
             notes_dir: None,
             last_known_base_dir: None,
         }
@@ -1663,6 +1689,18 @@ fn default_locale() -> String {
     "zh-CN".into()
 }
 
+fn default_export_page_size() -> String {
+    "a4".into()
+}
+
+fn default_export_font_family() -> String {
+    "HarmonyOS Sans".into()
+}
+
+fn default_export_font_size() -> u32 {
+    14
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1832,6 +1870,9 @@ mod tests {
             notes_dir: None,
             last_known_base_dir: None,
             open_at_cursor: true,
+            export_page_size: "a4".into(),
+            export_font_family: "HarmonyOS Sans".into(),
+            export_font_size: 14,
         };
 
         store.save_config(saved.clone()).expect("save config");
@@ -2353,5 +2394,105 @@ mod tests {
             fs::read_to_string(export_path).expect("read exported markdown"),
             content
         );
+    }
+
+    #[test]
+    fn exports_pdf_with_typst_basic_markdown() {
+        let root = test_root("export-pdf");
+        let store_path = root.join("store");
+        let store = NoteStore::new(store_path.clone(), store_path);
+        let content = "\
+# 标题
+**粗体** *斜体* ~~删除线~~
+## 二级标题
+- 列表项1
+- 列表项2
+```rs
+fn main() {}
+```
+一段普通文本，包含 #hash 和 $dollar 符号。";
+        let note = store
+            .create_note(SaveNoteRequest {
+                title: "PDF 测试".into(),
+                content: content.into(),
+                category: String::new(),
+            })
+            .expect("create note");
+
+        let export_dir = root.join("exports");
+        let export_path = export_dir.join("test.pdf");
+
+        store
+            .export_pdf_file(&note.id, &export_path)
+            .expect("export PDF");
+
+        assert!(export_path.exists(), "PDF file should exist");
+        assert!(
+            export_path.metadata().expect("read metadata").len() > 100,
+            "PDF file should be non-empty"
+        );
+
+        // Verify PDF magic bytes: %PDF
+        let header = fs::read(&export_path).expect("read PDF");
+        assert_eq!(&header[..4], b"%PDF", "should be a valid PDF");
+    }
+
+    #[test]
+    fn exports_pdf_respects_custom_page_size() {
+        let root = test_root("export-pdf-custom");
+        let store_path = root.join("store");
+        let store = NoteStore::new(store_path.clone(), store_path);
+        let note = store
+            .create_note(SaveNoteRequest {
+                title: "Custom Size".into(),
+                content: "Hello World".into(),
+                category: String::new(),
+            })
+            .expect("create note");
+
+        let export_path = root.join("exports").join("letter.pdf");
+
+        // Set letter page size and export
+        let mut config = store.load_config().expect("load config");
+        config.export_page_size = "us-letter".into();
+        store.save_config(config).expect("save config");
+
+        store
+            .export_pdf_file(&note.id, &export_path)
+            .expect("export PDF with custom size");
+
+        assert!(export_path.exists());
+        let header = fs::read(&export_path).expect("read PDF");
+        assert_eq!(&header[..4], b"%PDF");
+    }
+
+    #[test]
+    fn exports_pdf_with_special_characters() {
+        let root = test_root("export-pdf-special");
+        let store_path = root.join("store");
+        let store = NoteStore::new(store_path.clone(), store_path);
+        let content = "\
+# 公式示例
+Einstein: $E = mc^2$
+C# 代码: `Console.WriteLine();`
+路径: C:\\Users\\test\\file.txt
+使用 #tag 标签";
+        let note = store
+            .create_note(SaveNoteRequest {
+                title: "Special Chars".into(),
+                content: content.into(),
+                category: String::new(),
+            })
+            .expect("create note");
+
+        let export_path = root.join("exports").join("special.pdf");
+
+        store
+            .export_pdf_file(&note.id, &export_path)
+            .expect("export PDF with special chars");
+
+        assert!(export_path.exists());
+        let header = fs::read(&export_path).expect("read PDF");
+        assert_eq!(&header[..4], b"%PDF");
     }
 }

--- a/src-tauri/src/services/notes.rs
+++ b/src-tauri/src/services/notes.rs
@@ -3,7 +3,7 @@ use crate::services::pdf;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashMap},
     env, fmt, fs, io,
     path::{Component, Path, PathBuf},
 };
@@ -904,13 +904,19 @@ impl NoteStore {
         Ok(())
     }
 
-    pub fn export_pdf_file(&self, id: &str, path: &Path) -> Result<(), AppError> {
+    pub fn export_pdf_file(
+        &self,
+        id: &str,
+        path: &Path,
+        admonition_labels: HashMap<String, String>,
+    ) -> Result<(), AppError> {
         let note = self.read_note(id)?;
         let config = self.load_config()?;
         let options = pdf::PdfExportOptions {
             page_size: config.export_page_size,
             font_family: config.export_font_family,
             font_size: config.export_font_size,
+            admonition_labels,
         };
         pdf::export_markdown_to_pdf(&note.content, path, &options).map_err(|msg| AppError {
             code: "exportPdf".into(),
@@ -2396,6 +2402,16 @@ mod tests {
         );
     }
 
+    fn default_labels() -> HashMap<String, String> {
+        HashMap::from([
+            ("note".into(), "Note".into()),
+            ("tip".into(), "Tip".into()),
+            ("important".into(), "Important".into()),
+            ("warning".into(), "Warning".into()),
+            ("caution".into(), "Caution".into()),
+        ])
+    }
+
     #[test]
     fn exports_pdf_with_typst_basic_markdown() {
         let root = test_root("export-pdf");
@@ -2423,7 +2439,7 @@ fn main() {}
         let export_path = export_dir.join("test.pdf");
 
         store
-            .export_pdf_file(&note.id, &export_path)
+            .export_pdf_file(&note.id, &export_path, default_labels())
             .expect("export PDF");
 
         assert!(export_path.exists(), "PDF file should exist");
@@ -2458,7 +2474,7 @@ fn main() {}
         store.save_config(config).expect("save config");
 
         store
-            .export_pdf_file(&note.id, &export_path)
+            .export_pdf_file(&note.id, &export_path, default_labels())
             .expect("export PDF with custom size");
 
         assert!(export_path.exists());
@@ -2488,7 +2504,7 @@ C# 代码: `Console.WriteLine();`
         let export_path = root.join("exports").join("special.pdf");
 
         store
-            .export_pdf_file(&note.id, &export_path)
+            .export_pdf_file(&note.id, &export_path, default_labels())
             .expect("export PDF with special chars");
 
         assert!(export_path.exists());
@@ -2536,7 +2552,7 @@ C# 代码: `Console.WriteLine();`
         let export_path = root.join("exports").join("admonition.pdf");
 
         store
-            .export_pdf_file(&note.id, &export_path)
+            .export_pdf_file(&note.id, &export_path, default_labels())
             .expect("export PDF with admonitions");
 
         assert!(export_path.exists());

--- a/src-tauri/src/services/notes.rs
+++ b/src-tauri/src/services/notes.rs
@@ -2495,4 +2495,52 @@ C# 代码: `Console.WriteLine();`
         let header = fs::read(&export_path).expect("read PDF");
         assert_eq!(&header[..4], b"%PDF");
     }
+
+    #[test]
+    fn exports_pdf_with_admonition_blocks() {
+        let root = test_root("export-pdf-admonition");
+        let store_path = root.join("store");
+        let store = NoteStore::new(store_path.clone(), store_path);
+        let content = "\
+# 注意提醒
+
+> [!NOTE]
+> 这是一个普通提示信息。
+
+> [!TIP]
+> 这是一个小技巧。
+
+> [!WARNING]
+> 请谨慎操作。
+
+> [!CAUTION]
+> 这个操作有风险。
+
+> [!IMPORTANT]
+> 这条信息非常重要。
+
+包含 **粗体** 和 `代码` 的 [!NOTE] 注意块：
+> [!NOTE] 标题行也有内容
+> 第二行内容
+>
+> 新的段落";
+
+        let note = store
+            .create_note(SaveNoteRequest {
+                title: "Admonition Test".into(),
+                content: content.into(),
+                category: String::new(),
+            })
+            .expect("create note");
+
+        let export_path = root.join("exports").join("admonition.pdf");
+
+        store
+            .export_pdf_file(&note.id, &export_path)
+            .expect("export PDF with admonitions");
+
+        assert!(export_path.exists());
+        let header = fs::read(&export_path).expect("read PDF");
+        assert_eq!(&header[..4], b"%PDF");
+    }
 }

--- a/src-tauri/src/services/pdf.rs
+++ b/src-tauri/src/services/pdf.rs
@@ -78,24 +78,24 @@ fn markdown_to_typst(md: &str) -> String {
             continue;
         }
 
-        if line.starts_with("###### ") {
+        if let Some(rest) = line.strip_prefix("###### ") {
             out.push_str("====== ");
-            out.push_str(&line[7..]);
-        } else if line.starts_with("##### ") {
+            out.push_str(rest);
+        } else if let Some(rest) = line.strip_prefix("##### ") {
             out.push_str("===== ");
-            out.push_str(&line[6..]);
-        } else if line.starts_with("#### ") {
+            out.push_str(rest);
+        } else if let Some(rest) = line.strip_prefix("#### ") {
             out.push_str("==== ");
-            out.push_str(&line[5..]);
-        } else if line.starts_with("### ") {
+            out.push_str(rest);
+        } else if let Some(rest) = line.strip_prefix("### ") {
             out.push_str("=== ");
-            out.push_str(&line[4..]);
-        } else if line.starts_with("## ") {
+            out.push_str(rest);
+        } else if let Some(rest) = line.strip_prefix("## ") {
             out.push_str("== ");
-            out.push_str(&line[3..]);
-        } else if line.starts_with("# ") {
+            out.push_str(rest);
+        } else if let Some(rest) = line.strip_prefix("# ") {
             out.push_str("= ");
-            out.push_str(&line[2..]);
+            out.push_str(rest);
         } else {
             let converted = convert_inline(line);
             out.push_str(&converted);
@@ -251,7 +251,7 @@ fn create_world(source: &str) -> Result<ExportWorld, String> {
     let mut fonts = Vec::new();
 
     for face in fontdb.faces() {
-        let id = face.id.clone();
+        let id = face.id;
         let index = face.index;
         if let Some(Some(font)) = fontdb.with_face_data(id, move |data: &[u8], _: u32| {
             Font::new(Bytes::new(data.to_vec()), index)

--- a/src-tauri/src/services/pdf.rs
+++ b/src-tauri/src/services/pdf.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::Path;
 use typst::diag::{FileError, FileResult, Warned};
 use typst::foundations::{Bytes, Datetime, Duration};
@@ -12,14 +13,22 @@ pub struct PdfExportOptions {
     pub page_size: String,
     pub font_family: String,
     pub font_size: u32,
+    pub admonition_labels: HashMap<String, String>,
 }
 
 impl Default for PdfExportOptions {
     fn default() -> Self {
+        let mut admonition_labels = HashMap::new();
+        admonition_labels.insert("note".into(), "Note".into());
+        admonition_labels.insert("tip".into(), "Tip".into());
+        admonition_labels.insert("important".into(), "Important".into());
+        admonition_labels.insert("warning".into(), "Warning".into());
+        admonition_labels.insert("caution".into(), "Caution".into());
         Self {
-            page_size: "A4".into(),
+            page_size: "a4".into(),
             font_family: "HarmonyOS Sans".into(),
             font_size: 14,
+            admonition_labels,
         }
     }
 }
@@ -61,7 +70,58 @@ impl World for ExportWorld {
     }
 }
 
-fn markdown_to_typst(md: &str) -> String {
+fn admonition_icon(type_name: &str) -> String {
+    match type_name.to_uppercase().as_str() {
+        "NOTE" => r#"#box(
+  fill: rgb(9, 105, 218),
+  width: 1.2em,
+  height: 1.2em,
+  radius: 50%,
+  inset: 0pt,
+  align(center + horizon, text(fill: white, size: 0.8em, weight: "bold", "i"))
+)"#
+        .to_string(),
+        "TIP" => r#"#box(
+  fill: rgb(26, 127, 55),
+  width: 1.2em,
+  height: 1.2em,
+  radius: 50%,
+  inset: 0pt,
+  align(center + horizon, text(fill: white, size: 0.8em, "★"))
+)"#
+        .to_string(),
+        "WARNING" => r#"#box(
+  fill: rgb(154, 103, 0),
+  width: 1.2em,
+  height: 1.2em,
+  radius: 50%,
+  inset: 0pt,
+  align(center + horizon, text(fill: white, size: 0.8em, "!"))
+)"#
+        .to_string(),
+        "CAUTION" => r#"#box(
+  fill: rgb(207, 34, 46),
+  width: 1.2em,
+  height: 1.2em,
+  radius: 50%,
+  inset: 0pt,
+  align(center + horizon, text(fill: white, size: 0.8em, weight: "bold", "!"))
+)"#
+        .to_string(),
+        "IMPORTANT" => r#"#box(
+  fill: rgb(130, 80, 223),
+  width: 1.2em,
+  height: 1.2em,
+  radius: 50%,
+  inset: 0pt,
+  align(center + horizon, text(fill: white, size: 0.8em, "◆"))
+)"#
+        .to_string(),
+        _ => "".to_string(),
+    }
+}
+
+fn markdown_to_typst(md: &str, labels: &HashMap<String, String>) -> String {
     let mut out = String::with_capacity(md.len());
     let mut in_code_block = false;
 
@@ -89,24 +149,32 @@ fn markdown_to_typst(md: &str) -> String {
         // > [!TYPE] [optional content]
         if let Some(rest) = line.strip_prefix("> [!") {
             if let Some(end) = rest.find(']') {
-                let type_name = &rest[..end];
+                let type_name = &rest[..end].to_lowercase();
                 let inline_rest = rest[end + 1..].trim();
-                let (label, accent, bg) = match type_name.to_uppercase().as_str() {
-                    "NOTE" => ("NOTE", "rgb(9, 105, 218)", "rgb(212, 231, 250)"),
-                    "TIP" => ("TIP", "rgb(26, 127, 55)", "rgb(210, 240, 218)"),
-                    "WARNING" => ("WARNING", "rgb(154, 103, 0)", "rgb(250, 236, 210)"),
-                    "CAUTION" => ("CAUTION", "rgb(207, 34, 46)", "rgb(253, 220, 222)"),
-                    "IMPORTANT" => ("IMPORTANT", "rgb(130, 80, 223)", "rgb(230, 220, 250)"),
-                    _ => ("NOTE", "rgb(9, 105, 218)", "rgb(212, 231, 250)"),
+                let kind = type_name.as_str();
+                let (accent, bg) = match kind {
+                    "note" => ("rgb(9, 105, 218)", "rgb(212, 231, 250)"),
+                    "tip" => ("rgb(26, 127, 55)", "rgb(210, 240, 218)"),
+                    "warning" => ("rgb(154, 103, 0)", "rgb(250, 236, 210)"),
+                    "caution" => ("rgb(207, 34, 46)", "rgb(253, 220, 222)"),
+                    "important" => ("rgb(130, 80, 223)", "rgb(230, 220, 250)"),
+                    _ => ("rgb(9, 105, 218)", "rgb(212, 231, 250)"),
                 };
+                let label = labels.get(kind).map(|s| s.as_str()).unwrap_or(kind);
+                let icon = admonition_icon(kind);
                 out.push_str(&format!(
                     "#block(fill: {bg}, stroke: (left: 4pt + {accent}), \
-                     inset: (x: 1em, y: 0.75em), radius: 4pt, width: 100%, breakable: true)["
+             inset: (x: 1em, y: 0.75em), radius: 4pt, width: 100%, breakable: true)["
                 ));
+                if !icon.is_empty() {
+                    out.push_str(&format!("{}", icon));
+                    out.push('\n');
+                }
                 out.push_str(&format!("*{}:*", label));
+                out.push('\n');
                 if !inline_rest.is_empty() {
-                    out.push(' ');
                     out.push_str(&convert_inline(inline_rest));
+                    out.push('\n');
                 }
 
                 i += 1;
@@ -120,8 +188,6 @@ fn markdown_to_typst(md: &str) -> String {
                             out.push_str(&convert_inline(content));
                         }
                         i += 1;
-                    } else if aline.trim().is_empty() {
-                        break;
                     } else {
                         break;
                     }
@@ -255,7 +321,7 @@ fn build_typst_source(content: &str, options: &PdfExportOptions) -> String {
     let size = options.page_size.to_lowercase();
     let font = &options.font_family;
     let size_pt = options.font_size;
-    let converted = markdown_to_typst(content);
+    let converted = markdown_to_typst(content, &options.admonition_labels);
 
     format!(
         "#set page(paper: \"{size}\", margin: 2.5cm)\n\

--- a/src-tauri/src/services/pdf.rs
+++ b/src-tauri/src/services/pdf.rs
@@ -121,16 +121,7 @@ fn markdown_to_typst(md: &str) -> String {
                         }
                         i += 1;
                     } else if aline.trim().is_empty() {
-                        let mut j = i + 1;
-                        while j < len && lines[j].trim().is_empty() {
-                            j += 1;
-                        }
-                        if j < len && lines[j].starts_with("> ") {
-                            out.push_str("\n\n");
-                            i += 1;
-                        } else {
-                            break;
-                        }
+                        break;
                     } else {
                         break;
                     }

--- a/src-tauri/src/services/pdf.rs
+++ b/src-tauri/src/services/pdf.rs
@@ -1,0 +1,270 @@
+use std::path::Path;
+use typst::diag::{FileError, FileResult, Warned};
+use typst::foundations::{Bytes, Datetime, Duration};
+use typst::syntax::{FileId, RootedPath, Source, VirtualPath, VirtualRoot};
+use typst::text::{Font, FontBook};
+use typst::utils::LazyHash;
+use typst::World;
+use typst::{Library, LibraryExt};
+
+#[derive(Debug, Clone)]
+pub struct PdfExportOptions {
+    pub page_size: String,
+    pub font_family: String,
+    pub font_size: u32,
+}
+
+impl Default for PdfExportOptions {
+    fn default() -> Self {
+        Self {
+            page_size: "A4".into(),
+            font_family: "HarmonyOS Sans".into(),
+            font_size: 14,
+        }
+    }
+}
+
+struct ExportWorld {
+    source: Source,
+    book: LazyHash<FontBook>,
+    fonts: Vec<Font>,
+    library: LazyHash<Library>,
+}
+
+impl World for ExportWorld {
+    fn source(&self, _id: FileId) -> FileResult<Source> {
+        Ok(self.source.clone())
+    }
+
+    fn book(&self) -> &LazyHash<FontBook> {
+        &self.book
+    }
+
+    fn main(&self) -> FileId {
+        self.source.id()
+    }
+
+    fn library(&self) -> &LazyHash<Library> {
+        &self.library
+    }
+
+    fn font(&self, index: usize) -> Option<Font> {
+        self.fonts.get(index).cloned()
+    }
+
+    fn file(&self, _id: FileId) -> FileResult<Bytes> {
+        Err(FileError::Other(None))
+    }
+
+    fn today(&self, _offset: Option<Duration>) -> Option<Datetime> {
+        Datetime::from_ymd(2026, 7, 12)
+    }
+}
+
+fn markdown_to_typst(md: &str) -> String {
+    let mut out = String::with_capacity(md.len());
+    let mut in_code_block = false;
+
+    for line in md.lines() {
+        if line.trim_start().starts_with("```") {
+            in_code_block = !in_code_block;
+            out.push_str(line);
+            out.push('\n');
+            continue;
+        }
+        if in_code_block {
+            out.push_str(line);
+            out.push('\n');
+            continue;
+        }
+
+        if line.starts_with("###### ") {
+            out.push_str("====== ");
+            out.push_str(&line[7..]);
+        } else if line.starts_with("##### ") {
+            out.push_str("===== ");
+            out.push_str(&line[6..]);
+        } else if line.starts_with("#### ") {
+            out.push_str("==== ");
+            out.push_str(&line[5..]);
+        } else if line.starts_with("### ") {
+            out.push_str("=== ");
+            out.push_str(&line[4..]);
+        } else if line.starts_with("## ") {
+            out.push_str("== ");
+            out.push_str(&line[3..]);
+        } else if line.starts_with("# ") {
+            out.push_str("= ");
+            out.push_str(&line[2..]);
+        } else {
+            let converted = convert_inline(line);
+            out.push_str(&converted);
+        }
+        out.push('\n');
+    }
+    out
+}
+
+fn convert_inline(s: &str) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    let n = chars.len();
+    let mut result = String::with_capacity(s.len());
+    let mut i = 0;
+    while i < n {
+        // *** — markdown bold+italic → typst _*text*_
+        if i + 2 < n && chars[i] == '*' && chars[i + 1] == '*' && chars[i + 2] == '*' {
+            result.push_str("_*");
+            i += 3;
+            let start = i;
+            while i + 2 < n && !(chars[i] == '*' && chars[i + 1] == '*' && chars[i + 2] == '*') {
+                i += 1;
+            }
+            if i + 2 < n {
+                for &c in &chars[start..i] {
+                    result.push(c);
+                }
+                result.push_str("*_");
+                i += 3;
+            } else {
+                for &c in &chars[start..] {
+                    result.push(c);
+                }
+                break;
+            }
+            continue;
+        }
+        // ** — markdown bold → typst _text_
+        if i + 1 < n && chars[i] == '*' && chars[i + 1] == '*' {
+            result.push('_');
+            i += 2;
+            let start = i;
+            while i + 1 < n && !(chars[i] == '*' && chars[i + 1] == '*') {
+                i += 1;
+            }
+            if i + 1 < n {
+                for &c in &chars[start..i] {
+                    result.push(c);
+                }
+                result.push('_');
+                i += 2;
+            } else {
+                for &c in &chars[start..] {
+                    result.push(c);
+                }
+                break;
+            }
+            continue;
+        }
+        // `code` — same in typst
+        if chars[i] == '`' {
+            let start = i;
+            while i < n && chars[i] != '`' {
+                i += 1;
+            }
+            if i < n {
+                for &c in &chars[start..=i] {
+                    result.push(c);
+                }
+                i += 1;
+            } else {
+                for &c in &chars[start..] {
+                    result.push(c);
+                }
+                break;
+            }
+            continue;
+        }
+        // 这里跳过特殊字符，避免转义错误
+        if chars[i] == '\\' {
+            result.push_str("\\\\");
+            i += 1;
+            continue;
+        }
+        if chars[i] == '#' {
+            result.push_str("\\#");
+            i += 1;
+            continue;
+        }
+        if chars[i] == '$' {
+            result.push_str("\\$");
+            i += 1;
+            continue;
+        }
+        result.push(chars[i]);
+        i += 1;
+    }
+    result
+}
+
+fn build_typst_source(content: &str, options: &PdfExportOptions) -> String {
+    let size = options.page_size.to_lowercase();
+    let font = &options.font_family;
+    let size_pt = options.font_size;
+    let converted = markdown_to_typst(content);
+
+    format!(
+        "#set page(paper: \"{size}\", margin: 2.5cm)\n\
+         #set text(font: (\"{font}\", \"Noto Sans SC\", \"PingFang SC\", \"Microsoft YaHei\"), size: {size_pt}pt)\n\
+         \n\
+         {converted}\n"
+    )
+}
+
+pub fn export_markdown_to_pdf(
+    content: &str,
+    path: &Path,
+    options: &PdfExportOptions,
+) -> Result<(), String> {
+    let typst_source = build_typst_source(content, options);
+    let world = create_world(&typst_source)?;
+    let Warned {
+        output,
+        warnings: _,
+    } = typst::compile(&world);
+    let document = output.map_err(|errors| {
+        let msgs: Vec<String> = errors.iter().map(|e| e.message.to_string()).collect();
+        format!("Typst compilation failed: {}", msgs.join("; "))
+    })?;
+    let pdf_bytes =
+        typst_pdf::pdf(&document, &typst_pdf::PdfOptions::default()).map_err(|errors| {
+            let msgs: Vec<String> = errors.iter().map(|e| e.message.to_string()).collect();
+            format!("PDF export failed: {}", msgs.join("; "))
+        })?;
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("create directory: {e}"))?;
+    }
+    std::fs::write(path, &pdf_bytes).map_err(|e| format!("write PDF: {e}"))?;
+    Ok(())
+}
+
+fn create_world(source: &str) -> Result<ExportWorld, String> {
+    let vpath = VirtualPath::new("main.typ").map_err(|e| format!("invalid virtual path: {e}"))?;
+    let rooted = RootedPath::new(VirtualRoot::Project, vpath);
+    let id = FileId::new(rooted);
+    let source = Source::new(id, source.into());
+
+    let mut fontdb = fontdb::Database::new();
+    fontdb.load_system_fonts();
+
+    let mut book = FontBook::new();
+    let mut fonts = Vec::new();
+
+    for face in fontdb.faces() {
+        let id = face.id.clone();
+        let index = face.index;
+        if let Some(Some(font)) = fontdb.with_face_data(id, move |data: &[u8], _: u32| {
+            Font::new(Bytes::new(data.to_vec()), index)
+        }) {
+            book.push(font.info().clone());
+            fonts.push(font);
+        }
+    }
+
+    Ok(ExportWorld {
+        source,
+        book: LazyHash::new(book),
+        fonts,
+        library: LazyHash::new(Library::builder().build()),
+    })
+}

--- a/src-tauri/src/services/pdf.rs
+++ b/src-tauri/src/services/pdf.rs
@@ -32,8 +32,8 @@ struct ExportWorld {
 }
 
 impl World for ExportWorld {
-    fn source(&self, _id: FileId) -> FileResult<Source> {
-        Ok(self.source.clone())
+    fn library(&self) -> &LazyHash<Library> {
+        &self.library
     }
 
     fn book(&self) -> &LazyHash<FontBook> {
@@ -44,16 +44,16 @@ impl World for ExportWorld {
         self.source.id()
     }
 
-    fn library(&self) -> &LazyHash<Library> {
-        &self.library
-    }
-
-    fn font(&self, index: usize) -> Option<Font> {
-        self.fonts.get(index).cloned()
+    fn source(&self, _id: FileId) -> FileResult<Source> {
+        Ok(self.source.clone())
     }
 
     fn file(&self, _id: FileId) -> FileResult<Bytes> {
         Err(FileError::Other(None))
+    }
+
+    fn font(&self, index: usize) -> Option<Font> {
+        self.fonts.get(index).cloned()
     }
 
     fn today(&self, _offset: Option<Duration>) -> Option<Datetime> {
@@ -65,17 +65,79 @@ fn markdown_to_typst(md: &str) -> String {
     let mut out = String::with_capacity(md.len());
     let mut in_code_block = false;
 
-    for line in md.lines() {
+    let lines: Vec<&str> = md.lines().collect();
+    let len = lines.len();
+    let mut i = 0;
+
+    while i < len {
+        let line = lines[i];
+
         if line.trim_start().starts_with("```") {
             in_code_block = !in_code_block;
             out.push_str(line);
             out.push('\n');
+            i += 1;
             continue;
         }
         if in_code_block {
             out.push_str(line);
             out.push('\n');
+            i += 1;
             continue;
+        }
+
+        // > [!TYPE] [optional content]
+        if let Some(rest) = line.strip_prefix("> [!") {
+            if let Some(end) = rest.find(']') {
+                let type_name = &rest[..end];
+                let inline_rest = rest[end + 1..].trim();
+                let (label, accent, bg) = match type_name.to_uppercase().as_str() {
+                    "NOTE" => ("NOTE", "rgb(9, 105, 218)", "rgb(212, 231, 250)"),
+                    "TIP" => ("TIP", "rgb(26, 127, 55)", "rgb(210, 240, 218)"),
+                    "WARNING" => ("WARNING", "rgb(154, 103, 0)", "rgb(250, 236, 210)"),
+                    "CAUTION" => ("CAUTION", "rgb(207, 34, 46)", "rgb(253, 220, 222)"),
+                    "IMPORTANT" => ("IMPORTANT", "rgb(130, 80, 223)", "rgb(230, 220, 250)"),
+                    _ => ("NOTE", "rgb(9, 105, 218)", "rgb(212, 231, 250)"),
+                };
+                out.push_str(&format!(
+                    "#block(fill: {bg}, stroke: (left: 4pt + {accent}), \
+                     inset: (x: 1em, y: 0.75em), radius: 4pt, width: 100%, breakable: true)["
+                ));
+                out.push_str(&format!("*{}:*", label));
+                if !inline_rest.is_empty() {
+                    out.push(' ');
+                    out.push_str(&convert_inline(inline_rest));
+                }
+
+                i += 1;
+                while i < len {
+                    let aline = lines[i];
+                    if let Some(content) = aline.strip_prefix("> ") {
+                        if content.trim().is_empty() {
+                            out.push_str("\n\n");
+                        } else {
+                            out.push(' ');
+                            out.push_str(&convert_inline(content));
+                        }
+                        i += 1;
+                    } else if aline.trim().is_empty() {
+                        let mut j = i + 1;
+                        while j < len && lines[j].trim().is_empty() {
+                            j += 1;
+                        }
+                        if j < len && lines[j].starts_with("> ") {
+                            out.push_str("\n\n");
+                            i += 1;
+                        } else {
+                            break;
+                        }
+                    } else {
+                        break;
+                    }
+                }
+                out.push_str("]\n\n");
+                continue;
+            }
         }
 
         if let Some(rest) = line.strip_prefix("###### ") {
@@ -101,7 +163,9 @@ fn markdown_to_typst(md: &str) -> String {
             out.push_str(&converted);
         }
         out.push('\n');
+        i += 1;
     }
+
     out
 }
 

--- a/src-tauri/src/services/pdf.rs
+++ b/src-tauri/src/services/pdf.rs
@@ -167,7 +167,7 @@ fn markdown_to_typst(md: &str, labels: &HashMap<String, String>) -> String {
              inset: (x: 1em, y: 0.75em), radius: 4pt, width: 100%, breakable: true)["
                 ));
                 if !icon.is_empty() {
-                    out.push_str(&format!("{}", icon));
+                    out.push_str(icon.as_str());
                     out.push('\n');
                 }
                 out.push_str(&format!("*{}:*", label));

--- a/src-tauri/src/updater/helper.rs
+++ b/src-tauri/src/updater/helper.rs
@@ -2084,7 +2084,12 @@ fn available_disk_space(path: &Path) -> Option<u64> {
         return None;
     }
     let stat = unsafe { stat.assume_init() };
-    Some((stat.f_bavail as u64).saturating_mul(stat.f_frsize))
+
+    fn cast_u64<T: Into<u64>>(val: T) -> u64 {
+        val.into()
+    }
+
+    Some(cast_u64(stat.f_bavail).saturating_mul(cast_u64(stat.f_frsize)))
 }
 
 #[cfg(not(any(unix, target_os = "windows")))]

--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -5,7 +5,11 @@ import { useTranslation } from "react-i18next";
 import { emit, listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { AboutPanel } from "./AboutPanel";
-import { exportMarkdownNote, importMarkdownNote } from "../features/importExport/api";
+import {
+  exportMarkdownNote,
+  exportMarkdownPDF,
+  importMarkdownNote,
+} from "../features/importExport/api";
 import { MarkdownPreview } from "../features/markdown/MarkdownPreview";
 import { showToast } from "./Toast";
 import {
@@ -1479,6 +1483,22 @@ export function MainWindow({
     }
   };
 
+  const handleExportMarkdownPDF = async (note: NoteMetadata) => {
+    try {
+      if (note.id === selectedId) {
+        const saved = await saveCurrentNote();
+        if (!saved) return;
+      }
+
+      await exportMarkdownPDF({
+        id: note.id,
+        title: note.id === selectedId ? title : note.title,
+      });
+    } catch (error) {
+      showToast(getErrorMessage(error));
+    }
+  };
+
   const handleNoteMenuAction = (action: NoteContextMenuAction) => {
     const note = noteMenuTarget;
     if (!note) return;
@@ -1486,6 +1506,10 @@ export function MainWindow({
     if (action === "export") {
       setNoteMenuClosing(true);
       void handleExportNote(note);
+      return;
+    } else if (action === "exportPDF") {
+      setNoteMenuClosing(true);
+      void handleExportMarkdownPDF(note);
       return;
     }
 

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -457,6 +457,57 @@ export function SettingsPanel({ config, onChange, onMigrateDataDir, onClose }: S
           />
         </section>
 
+        <section className="space-y-2">
+          <h3 className="text-[11px] font-body text-ink-faint">
+            {t("settings.export.label", { defaultValue: "PDF 导出" })}
+          </h3>
+          <div className="space-y-1.5">
+            <label className="block text-[11px] text-ink-faint/70 px-0.5">
+              {t("settings.export.pageSize", { defaultValue: "纸张大小" })}
+            </label>
+            <input
+              type="text"
+              value={config.exportPageSize}
+              onChange={(event) => setConfigValue("exportPageSize", event.target.value)}
+              placeholder="A4"
+              spellCheck={false}
+              className="w-full h-8 px-2.5 rounded-lg bg-paper-warm/70 border border-paper-deep/40 text-[12px] font-mono text-ink-soft outline-none"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <label className="block text-[11px] text-ink-faint/70 px-0.5">
+              {t("settings.export.fontFamily", { defaultValue: "字体" })}
+            </label>
+            <input
+              type="text"
+              value={config.exportFontFamily}
+              onChange={(event) => setConfigValue("exportFontFamily", event.target.value)}
+              placeholder="HarmonyOS Sans"
+              spellCheck={false}
+              className="w-full h-8 px-2.5 rounded-lg bg-paper-warm/70 border border-paper-deep/40 text-[12px] font-mono text-ink-soft outline-none"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <label className="block text-[11px] text-ink-faint/70 px-0.5">
+              {t("settings.export.fontSize", { defaultValue: "字号" })}
+            </label>
+            <div className="flex items-center gap-3 h-9 rounded-lg px-2.5 bg-paper-warm/45 border border-paper-deep/25">
+              <input
+                type="range"
+                min={8}
+                max={30}
+                step={1}
+                value={config.exportFontSize ?? 14}
+                onChange={(event) => setConfigValue("exportFontSize", Number(event.target.value))}
+                className="flex-1 h-1 accent-bamboo cursor-pointer appearance-none bg-transparent [&::-webkit-slider-runnable-track]:h-[3px] [&::-webkit-slider-runnable-track]:rounded-full [&::-webkit-slider-runnable-track]:bg-paper-deep/50 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-bamboo [&::-webkit-slider-thumb]:-mt-[4.5px] [&::-webkit-slider-thumb]:shadow-[0_1px_3px_rgba(0,0,0,0.15)]"
+              />
+              <span className="text-[12px] font-mono text-ink-soft tabular-nums w-8 text-right">
+                {config.exportFontSize ?? 14}px
+              </span>
+            </div>
+          </div>
+        </section>
+
         <UpdateSettingsSection mode="settingsOnly" />
 
         <section className="pt-2 border-t border-paper-deep/25">

--- a/src/features/importExport/api.ts
+++ b/src/features/importExport/api.ts
@@ -48,7 +48,15 @@ export async function exportMarkdownPDF(note: ExportableNote): Promise<boolean> 
     return false;
   }
 
-  await invoke("notes_export_pdf", { id: note.id, path });
+  const admonitionLabels = {
+    note: t("markdown.alert.note"),
+    tip: t("markdown.alert.tip"),
+    important: t("markdown.alert.important"),
+    warning: t("markdown.alert.warning"),
+    caution: t("markdown.alert.caution"),
+  };
+
+  await invoke("notes_export_pdf", { id: note.id, path, admonitionLabels });
   return true;
 }
 

--- a/src/features/importExport/api.ts
+++ b/src/features/importExport/api.ts
@@ -38,10 +38,30 @@ export async function exportMarkdownNote(note: ExportableNote): Promise<boolean>
   return true;
 }
 
+export async function exportMarkdownPDF(note: ExportableNote): Promise<boolean> {
+  const path = await save({
+    defaultPath: pdfFileName(note.title),
+    filters: [{ name: "PDF", extensions: ["pdf"] }],
+  });
+
+  if (typeof path !== "string") {
+    return false;
+  }
+
+  await invoke("notes_export_pdf", { id: note.id, path });
+  return true;
+}
+
 function markdownFileName(title: string, translate: TFunction = t): string {
   const safeTitle =
     safeFileStem(title) || translate("common.untitledNote", { defaultValue: "无标题笔记" });
   return `${safeTitle}.md`;
+}
+
+function pdfFileName(title: string, translate: TFunction = t): string {
+  const safeTitle =
+    safeFileStem(title) || translate("common.untitledNote", { defaultValue: "无标题笔记" });
+  return `${safeTitle}.pdf`;
 }
 
 function safeFileStem(value: string): string {

--- a/src/features/notes/noteContextMenu.ts
+++ b/src/features/notes/noteContextMenu.ts
@@ -1,6 +1,6 @@
 import { t, type TFunction } from "i18next";
 
-export type NoteContextMenuAction = "export" | "move" | "delete";
+export type NoteContextMenuAction = "export" | "exportPDF" | "move" | "delete";
 
 export interface NoteContextMenuItem {
   action: NoteContextMenuAction;
@@ -13,6 +13,10 @@ export function getNoteContextMenuItems(translate: TFunction = t): NoteContextMe
     {
       action: "export",
       label: translate("noteMenu.export", { defaultValue: "导出 Markdown" }),
+    },
+    {
+      action: "exportPDF",
+      label: translate("noteMenu.exportPDF", { defaultValue: "导出 PDF" }),
     },
     {
       action: "move",

--- a/src/features/settings/api.test.ts
+++ b/src/features/settings/api.test.ts
@@ -53,6 +53,9 @@ describe("settings api", () => {
       renderHtmlMarkdown: false,
       splitScrollSync: true,
       openAtCursor: true,
+      exportPageSize: "a4",
+      exportFontFamily: "HarmonyOS Sans",
+      exportFontSize: 14,
     };
     mockedInvoke.mockResolvedValue(config);
 
@@ -87,6 +90,9 @@ describe("settings api", () => {
       renderHtmlMarkdown: false,
       splitScrollSync: true,
       openAtCursor: true,
+      exportPageSize: "a4",
+      exportFontFamily: "HarmonyOS Sans",
+      exportFontSize: 14,
     };
     mockedInvoke.mockResolvedValue(config);
 

--- a/src/features/settings/types.ts
+++ b/src/features/settings/types.ts
@@ -39,4 +39,7 @@ export interface AppConfig {
   backgroundScale?: number;
   backgroundPositionX?: number;
   backgroundPositionY?: number;
+  exportPageSize: string;
+  exportFontFamily: string;
+  exportFontSize: number;
 }

--- a/src/locales/en-US/translation.json
+++ b/src/locales/en-US/translation.json
@@ -163,6 +163,7 @@
   "noteMenu": {
     "delete": "Delete Note",
     "export": "Export Markdown",
+    "exportPDF": "Export PDF",
     "moveToCategory": "Move to category…"
   },
   "notepad": {
@@ -419,6 +420,12 @@
       "title": "Updates"
     },
     "visibilityShortcut": "Show/Hide window shortcut",
+    "export": {
+      "label": "PDF Export",
+      "pageSize": "Paper size",
+      "fontFamily": "Font family",
+      "fontSize": "Font size"
+    },
     "background": {
       "label": "Background image",
       "default": "Default background",

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -163,6 +163,7 @@
   "noteMenu": {
     "delete": "删除笔记",
     "export": "导出 Markdown",
+    "exportPDF": "导出 PDF",
     "moveToCategory": "移动到分类…"
   },
   "notepad": {
@@ -419,6 +420,12 @@
       "title": "更新"
     },
     "visibilityShortcut": "显示/隐藏窗口快捷键",
+    "export": {
+      "label": "PDF 导出",
+      "pageSize": "纸张大小",
+      "fontFamily": "字体",
+      "fontSize": "字号"
+    },
     "background": {
       "label": "背景图片",
       "default": "默认背景",

--- a/src/locales/zh-HK/translation.json
+++ b/src/locales/zh-HK/translation.json
@@ -163,6 +163,7 @@
   "noteMenu": {
     "delete": "刪除筆記",
     "export": "匯出 Markdown",
+    "exportPDF": "匯出 PDF",
     "moveToCategory": "移至分類…"
   },
   "notepad": {
@@ -400,6 +401,12 @@
       "title": "更新"
     },
     "visibilityShortcut": "顯示／隱藏視窗快捷鍵",
+    "export": {
+      "label": "PDF 匯出",
+      "pageSize": "紙張大小",
+      "fontFamily": "字型",
+      "fontSize": "字級"
+    },
     "background": {
       "label": "背景圖片",
       "default": "預設背景",


### PR DESCRIPTION
## Summary / 概要

该项PR进行了如下改动：

1. 添加了typst、typst-pdf、fontdb作为新的依赖项
2. 使用了上述依赖制作了PDF导出功能
3. 额外修复了位于src-tauri/src/updater/helper.rs文件中函数available_disk_space在Linux中可能导致的clippy报错
4. 添加了导出PDF入口选项在右键笔记菜单项
5. 添加了PDF导出选项位于应用设置，提供纸张大小设置和字体以及字体大小设置
6. 在翻译文件中引入了相关的文本翻译

## Related Issue / 关联 Issue

相关Issue: #340 

## Affected Platforms / 影响平台

- [ ] Windows
- [x] macOS
- [x] Linux
- [ ] Platform-agnostic / 平台无关

## Screenshots or Recordings / 截图或录屏

新增的右键菜单项：

<img width="1450" height="1014" alt="image" src="https://github.com/user-attachments/assets/382f4b10-77f0-4d62-b1f7-88a4874626ee" />

新增设置选项：

<img width="347" height="959" alt="image" src="https://github.com/user-attachments/assets/54ccbbe2-66ca-42e8-90c4-5bff9b28c18d" />

生成的PDF：

<img width="1882" height="1101" alt="image" src="https://github.com/user-attachments/assets/7d6f4157-9957-4db0-ad98-6e78b40d7fb5" />

## Testing / 测试

1.  打开或创建一个笔记
7.  编辑完成之后，右键左边列表对应的笔记
8. 点击 导出PDF 并选择保存路径完成保存
9. （可选）点击设置，翻到下方有PDF导出选项，设置字号、字体、纸张大小
10. 前往保存路径查看生成的PDF产物

## Checklist / 检查清单

### Code quality / 代码质量

您确认您运行并通过了：

- [x ] `npx oxfmt --check`
- [x] `npx oxlint`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `npm test`