### PR TITLE
ci: 为 Windows 发布接入 SignPath 签名

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,15 +2,18 @@ name: Release
 
 on:
   push:
-    branches:
-      - "ci/windows-artifact-sign"
     tags:
       - "v*"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions: {}
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  RUST_TOOLCHAIN: "1.96.1"
 
 jobs:
   validate-release:
@@ -19,7 +22,7 @@ jobs:
     permissions:
       contents: read
     outputs:
-      mode: ${{ steps.release.outputs.mode }}
+      commit: ${{ steps.release.outputs.commit }}
       version: ${{ steps.release.outputs.version }}
       tag: ${{ steps.release.outputs.tag }}
     steps:
@@ -27,6 +30,7 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
+          fetch-depth: 0
 
       - name: Validate source, versions, and signing scope
         id: release
@@ -38,20 +42,44 @@ jobs:
           tauri_version="$(jq -r '.version' src-tauri/tauri.conf.json)"
           cargo_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' src-tauri/Cargo.toml | head -n 1)"
 
-          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
-            mode="release"
-            tag="$GITHUB_REF_NAME"
-            if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo "Release tags must use the stable SemVer form vMAJOR.MINOR.PATCH: $tag" >&2
-              exit 1
-            fi
-            version="${tag#v}"
-          elif [[ "$GITHUB_REF_TYPE" == "branch" && "$GITHUB_REF_NAME" == "ci/windows-artifact-sign" ]]; then
-            mode="test"
-            tag=""
-            version="$package_version"
-          else
+          if [[ "$GITHUB_REF_TYPE" != "tag" ]]; then
             echo "Unsupported release source: $GITHUB_REF_TYPE $GITHUB_REF_NAME" >&2
+            exit 1
+          fi
+          tag="$GITHUB_REF_NAME"
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release tags must use the stable SemVer form vMAJOR.MINOR.PATCH: $tag" >&2
+            exit 1
+          fi
+          version="${tag#v}"
+          release_commit="$(git rev-parse "${GITHUB_SHA}^{commit}")"
+
+          git fetch --no-tags origin \
+            '+refs/heads/main:refs/remotes/origin/main'
+          if ! git merge-base --is-ancestor "$release_commit" refs/remotes/origin/main; then
+            echo "Release tag $tag must point to a commit contained in main." >&2
+            exit 1
+          fi
+
+          remote_tag_commit="$(
+            git ls-remote origin \
+              "refs/tags/${tag}" \
+              "refs/tags/${tag}^{}" |
+              awk '
+                $2 ~ /\^\{\}$/ { peeled = $1 }
+                $2 !~ /\^\{\}$/ { direct = $1 }
+                END {
+                  if (peeled != "") print peeled
+                  else print direct
+                }
+              '
+          )"
+          if [[ -z "$remote_tag_commit" ]]; then
+            echo "Release tag no longer exists on origin: $tag" >&2
+            exit 1
+          fi
+          if [[ "$remote_tag_commit" != "$release_commit" ]]; then
+            echo "Release tag $tag moved: expected $release_commit, got $remote_tag_commit." >&2
             exit 1
           fi
 
@@ -106,7 +134,13 @@ jobs:
             exit 1
           fi
 
-          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+          install_mode="$(jq -r '.bundle.windows.nsis.installMode // "currentUser"' src-tauri/tauri.conf.json)"
+          if [[ "$install_mode" != "both" ]]; then
+            echo "The release workflow tests Current User and All Users installs, but installMode is $install_mode." >&2
+            exit 1
+          fi
+
+          echo "commit=$release_commit" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
@@ -132,6 +166,8 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
 
       - name: Install dependencies
         run: npm ci
@@ -245,13 +281,52 @@ jobs:
       actions: read
       contents: read
     steps:
+      - name: Checkout release source
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Revalidate release tag before signing
+        shell: bash
+        env:
+          RELEASE_COMMIT: ${{ needs.validate-release.outputs.commit }}
+          RELEASE_TAG: ${{ needs.validate-release.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          git fetch --no-tags origin \
+            '+refs/heads/main:refs/remotes/origin/main'
+          if ! git merge-base --is-ancestor "$RELEASE_COMMIT" refs/remotes/origin/main; then
+            echo "Release commit $RELEASE_COMMIT is no longer contained in main." >&2
+            exit 1
+          fi
+
+          remote_tag_commit="$(
+            git ls-remote origin \
+              "refs/tags/${RELEASE_TAG}" \
+              "refs/tags/${RELEASE_TAG}^{}" |
+              awk '
+                $2 ~ /\^\{\}$/ { peeled = $1 }
+                $2 !~ /\^\{\}$/ { direct = $1 }
+                END {
+                  if (peeled != "") print peeled
+                  else print direct
+                }
+              '
+          )"
+          if [[ -z "$remote_tag_commit" || "$remote_tag_commit" != "$RELEASE_COMMIT" ]]; then
+            echo "Release tag $RELEASE_TAG was deleted or moved before binary signing." >&2
+            echo "Expected $RELEASE_COMMIT, got ${remote_tag_commit:-<missing>}." >&2
+            exit 1
+          fi
+
       - name: Submit binary signing request
         uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2
         with:
-          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          api-token: ${{ secrets.SIGNPATH_RELEASE_API_TOKEN }}
           organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
           project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
-          signing-policy-slug: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
+          signing-policy-slug: release-signing
           artifact-configuration-slug: ${{ vars.SIGNPATH_WINDOWS_BINARY_ARTIFACT_CONFIGURATION_SLUG }}
           github-artifact-id: ${{ needs.build-windows-binary.outputs.unsigned_artifact_id }}
           wait-for-completion: true
@@ -263,11 +338,10 @@ jobs:
       - name: Verify signed executable
         shell: pwsh
         env:
-          SIGNING_MODE: ${{ needs.validate-release.outputs.mode }}
           RELEASE_VERSION: ${{ needs.validate-release.outputs.version }}
-          EXPECTED_CERTIFICATE_SUBJECT: ${{ vars.SIGNPATH_CERTIFICATE_SUBJECT }}
-          EXPECTED_CERTIFICATE_ISSUER: ${{ vars.SIGNPATH_CERTIFICATE_ISSUER }}
-          EXPECTED_CERTIFICATE_SHA1: ${{ vars.SIGNPATH_CERTIFICATE_SHA1 }}
+          EXPECTED_CERTIFICATE_SUBJECT: ${{ vars.SIGNPATH_RELEASE_CERTIFICATE_SUBJECT }}
+          EXPECTED_CERTIFICATE_ISSUER: ${{ vars.SIGNPATH_RELEASE_CERTIFICATE_ISSUER }}
+          EXPECTED_CERTIFICATE_SHA1: ${{ vars.SIGNPATH_RELEASE_CERTIFICATE_SHA1 }}
         run: |
           $ErrorActionPreference = 'Stop'
 
@@ -292,15 +366,15 @@ jobs:
             param([Parameter(Mandatory = $true)][string]$Path)
 
             if ([string]::IsNullOrWhiteSpace($env:EXPECTED_CERTIFICATE_SUBJECT)) {
-              throw 'SIGNPATH_CERTIFICATE_SUBJECT is not configured.'
+              throw 'SIGNPATH_RELEASE_CERTIFICATE_SUBJECT is not configured.'
             }
             if ([string]::IsNullOrWhiteSpace($env:EXPECTED_CERTIFICATE_ISSUER)) {
-              throw 'SIGNPATH_CERTIFICATE_ISSUER is not configured.'
+              throw 'SIGNPATH_RELEASE_CERTIFICATE_ISSUER is not configured.'
             }
 
             $expectedThumbprint = ($env:EXPECTED_CERTIFICATE_SHA1 -replace '\s', '').ToUpperInvariant()
             if ($expectedThumbprint -notmatch '^[0-9A-F]{40}$') {
-              throw 'SIGNPATH_CERTIFICATE_SHA1 must contain a 40-character SHA-1 certificate thumbprint.'
+              throw 'SIGNPATH_RELEASE_CERTIFICATE_SHA1 must contain a 40-character SHA-1 certificate thumbprint.'
             }
 
             $signature = Get-AuthenticodeSignature -LiteralPath $Path
@@ -330,11 +404,7 @@ jobs:
               throw "Signed file was not found: $Path"
             }
 
-            if ($env:SIGNING_MODE -notin @('test', 'release')) {
-              throw "Unsupported signing mode: $($env:SIGNING_MODE)"
-            }
-
-            $certificate = Get-PinnedSignerCertificate -Path $Path
+            Get-PinnedSignerCertificate -Path $Path | Out-Null
 
             $signature = Get-AuthenticodeSignature -LiteralPath $Path
             $signature | Format-List Status, StatusMessage, SignerCertificate, TimeStamperCertificate
@@ -342,28 +412,15 @@ jobs:
               throw "The signature does not contain a trusted timestamp: $Path"
             }
 
-            if ($signature.Status -eq 'Valid') {
-              $signTool = Get-SignToolPath
-              & $signTool verify /pa /all /v $Path
-              if ($LASTEXITCODE -ne 0) {
-                throw "signtool verification failed for $Path with exit code $LASTEXITCODE."
-              }
-              return
-            }
-
-            $untrustedRootPattern = '(?i)(0x800B0109|untrusted root|root certificate.+not trusted)'
-            $isExpectedTestTrustFailure =
-              $env:SIGNING_MODE -eq 'test' -and
-              $signature.Status -in @('UnknownError', 'NotTrusted') -and
-              $signature.StatusMessage -match $untrustedRootPattern
-            if (-not $isExpectedTestTrustFailure) {
+            if ($signature.Status -ne 'Valid') {
               throw "Authenticode signature is not valid for ${Path}: $($signature.Status): $($signature.StatusMessage)"
             }
-            if ($certificate.Subject -ne $certificate.Issuer) {
-              throw 'The pinned test certificate must be self-signed.'
-            }
 
-            Write-Host 'Accepted the pinned SignPath test certificate; only the expected untrusted-root status was ignored.'
+            $signTool = Get-SignToolPath
+            & $signTool verify /pa /all /v $Path
+            if ($LASTEXITCODE -ne 0) {
+              throw "signtool verification failed for $Path with exit code $LASTEXITCODE."
+            }
           }
 
           $mainBinary = "signed-windows-binary/floral-notepaper_$($env:RELEASE_VERSION).exe"
@@ -423,6 +480,8 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
 
       - name: Install dependencies
         run: npm ci
@@ -437,23 +496,17 @@ jobs:
         id: restore
         shell: pwsh
         env:
-          SIGNING_MODE: ${{ needs.validate-release.outputs.mode }}
           RELEASE_VERSION: ${{ needs.validate-release.outputs.version }}
-          EXPECTED_CERTIFICATE_SUBJECT: ${{ vars.SIGNPATH_CERTIFICATE_SUBJECT }}
-          EXPECTED_CERTIFICATE_ISSUER: ${{ vars.SIGNPATH_CERTIFICATE_ISSUER }}
-          EXPECTED_CERTIFICATE_SHA1: ${{ vars.SIGNPATH_CERTIFICATE_SHA1 }}
+          EXPECTED_CERTIFICATE_SUBJECT: ${{ vars.SIGNPATH_RELEASE_CERTIFICATE_SUBJECT }}
+          EXPECTED_CERTIFICATE_ISSUER: ${{ vars.SIGNPATH_RELEASE_CERTIFICATE_ISSUER }}
+          EXPECTED_CERTIFICATE_SHA1: ${{ vars.SIGNPATH_RELEASE_CERTIFICATE_SHA1 }}
         run: |
           $ErrorActionPreference = 'Stop'
 
-          if ($env:SIGNING_MODE -notin @('test', 'release')) {
-            throw "Unsupported signing mode: $($env:SIGNING_MODE)"
-          }
           $expectedThumbprint = ($env:EXPECTED_CERTIFICATE_SHA1 -replace '\s', '').ToUpperInvariant()
           if ($expectedThumbprint -notmatch '^[0-9A-F]{40}$') {
-            throw 'SIGNPATH_CERTIFICATE_SHA1 must contain a 40-character SHA-1 certificate thumbprint.'
+            throw 'SIGNPATH_RELEASE_CERTIFICATE_SHA1 must contain a 40-character SHA-1 certificate thumbprint.'
           }
-          $untrustedRootPattern = '(?i)(0x800B0109|untrusted root|root certificate.+not trusted)'
-
           $targetDir = 'src-tauri/target/release'
           New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
           $binaries = @(
@@ -486,11 +539,7 @@ jobs:
               throw "The restored executable does not contain a trusted timestamp: $($binary.Source)"
             }
 
-            $isExpectedTestTrustFailure =
-              $env:SIGNING_MODE -eq 'test' -and
-              $signature.Status -in @('UnknownError', 'NotTrusted') -and
-              $signature.StatusMessage -match $untrustedRootPattern
-            if ($signature.Status -ne 'Valid' -and -not $isExpectedTestTrustFailure) {
+            if ($signature.Status -ne 'Valid') {
               throw "The restored executable is not validly signed: $($binary.Source): $($signature.Status): $($signature.StatusMessage)"
             }
 
@@ -677,13 +726,52 @@ jobs:
       actions: read
       contents: read
     steps:
+      - name: Checkout release source
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Revalidate release tag before signing
+        shell: bash
+        env:
+          RELEASE_COMMIT: ${{ needs.validate-release.outputs.commit }}
+          RELEASE_TAG: ${{ needs.validate-release.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          git fetch --no-tags origin \
+            '+refs/heads/main:refs/remotes/origin/main'
+          if ! git merge-base --is-ancestor "$RELEASE_COMMIT" refs/remotes/origin/main; then
+            echo "Release commit $RELEASE_COMMIT is no longer contained in main." >&2
+            exit 1
+          fi
+
+          remote_tag_commit="$(
+            git ls-remote origin \
+              "refs/tags/${RELEASE_TAG}" \
+              "refs/tags/${RELEASE_TAG}^{}" |
+              awk '
+                $2 ~ /\^\{\}$/ { peeled = $1 }
+                $2 !~ /\^\{\}$/ { direct = $1 }
+                END {
+                  if (peeled != "") print peeled
+                  else print direct
+                }
+              '
+          )"
+          if [[ -z "$remote_tag_commit" || "$remote_tag_commit" != "$RELEASE_COMMIT" ]]; then
+            echo "Release tag $RELEASE_TAG was deleted or moved before installer signing." >&2
+            echo "Expected $RELEASE_COMMIT, got ${remote_tag_commit:-<missing>}." >&2
+            exit 1
+          fi
+
       - name: Submit installer signing request
         uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2
         with:
-          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          api-token: ${{ secrets.SIGNPATH_RELEASE_API_TOKEN }}
           organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
           project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
-          signing-policy-slug: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
+          signing-policy-slug: release-signing
           artifact-configuration-slug: ${{ vars.SIGNPATH_WINDOWS_INSTALLER_ARTIFACT_CONFIGURATION_SLUG }}
           github-artifact-id: ${{ needs.build-windows-installer.outputs.unsigned_artifact_id }}
           wait-for-completion: true
@@ -699,11 +787,10 @@ jobs:
       - name: Verify installer and installed executable
         shell: pwsh
         env:
-          SIGNING_MODE: ${{ needs.validate-release.outputs.mode }}
           RELEASE_VERSION: ${{ needs.validate-release.outputs.version }}
-          EXPECTED_CERTIFICATE_SUBJECT: ${{ vars.SIGNPATH_CERTIFICATE_SUBJECT }}
-          EXPECTED_CERTIFICATE_ISSUER: ${{ vars.SIGNPATH_CERTIFICATE_ISSUER }}
-          EXPECTED_CERTIFICATE_SHA1: ${{ vars.SIGNPATH_CERTIFICATE_SHA1 }}
+          EXPECTED_CERTIFICATE_SUBJECT: ${{ vars.SIGNPATH_RELEASE_CERTIFICATE_SUBJECT }}
+          EXPECTED_CERTIFICATE_ISSUER: ${{ vars.SIGNPATH_RELEASE_CERTIFICATE_ISSUER }}
+          EXPECTED_CERTIFICATE_SHA1: ${{ vars.SIGNPATH_RELEASE_CERTIFICATE_SHA1 }}
         run: |
           $ErrorActionPreference = 'Stop'
 
@@ -728,15 +815,15 @@ jobs:
             param([Parameter(Mandatory = $true)][string]$Path)
 
             if ([string]::IsNullOrWhiteSpace($env:EXPECTED_CERTIFICATE_SUBJECT)) {
-              throw 'SIGNPATH_CERTIFICATE_SUBJECT is not configured.'
+              throw 'SIGNPATH_RELEASE_CERTIFICATE_SUBJECT is not configured.'
             }
             if ([string]::IsNullOrWhiteSpace($env:EXPECTED_CERTIFICATE_ISSUER)) {
-              throw 'SIGNPATH_CERTIFICATE_ISSUER is not configured.'
+              throw 'SIGNPATH_RELEASE_CERTIFICATE_ISSUER is not configured.'
             }
 
             $expectedThumbprint = ($env:EXPECTED_CERTIFICATE_SHA1 -replace '\s', '').ToUpperInvariant()
             if ($expectedThumbprint -notmatch '^[0-9A-F]{40}$') {
-              throw 'SIGNPATH_CERTIFICATE_SHA1 must contain a 40-character SHA-1 certificate thumbprint.'
+              throw 'SIGNPATH_RELEASE_CERTIFICATE_SHA1 must contain a 40-character SHA-1 certificate thumbprint.'
             }
 
             $signature = Get-AuthenticodeSignature -LiteralPath $Path
@@ -766,11 +853,7 @@ jobs:
               throw "Signed file was not found: $Path"
             }
 
-            if ($env:SIGNING_MODE -notin @('test', 'release')) {
-              throw "Unsupported signing mode: $($env:SIGNING_MODE)"
-            }
-
-            $certificate = Get-PinnedSignerCertificate -Path $Path
+            Get-PinnedSignerCertificate -Path $Path | Out-Null
 
             $signature = Get-AuthenticodeSignature -LiteralPath $Path
             $signature | Format-List Status, StatusMessage, SignerCertificate, TimeStamperCertificate
@@ -778,28 +861,150 @@ jobs:
               throw "The signature does not contain a trusted timestamp: $Path"
             }
 
-            if ($signature.Status -eq 'Valid') {
-              $signTool = Get-SignToolPath
-              & $signTool verify /pa /all /v $Path
-              if ($LASTEXITCODE -ne 0) {
-                throw "signtool verification failed for $Path with exit code $LASTEXITCODE."
-              }
-              return
-            }
-
-            $untrustedRootPattern = '(?i)(0x800B0109|untrusted root|root certificate.+not trusted)'
-            $isExpectedTestTrustFailure =
-              $env:SIGNING_MODE -eq 'test' -and
-              $signature.Status -in @('UnknownError', 'NotTrusted') -and
-              $signature.StatusMessage -match $untrustedRootPattern
-            if (-not $isExpectedTestTrustFailure) {
+            if ($signature.Status -ne 'Valid') {
               throw "Authenticode signature is not valid for ${Path}: $($signature.Status): $($signature.StatusMessage)"
             }
-            if ($certificate.Subject -ne $certificate.Issuer) {
-              throw 'The pinned test certificate must be self-signed.'
+
+            $signTool = Get-SignToolPath
+            & $signTool verify /pa /all /v $Path
+            if ($LASTEXITCODE -ne 0) {
+              throw "signtool verification failed for $Path with exit code $LASTEXITCODE."
+            }
+          }
+
+          function Test-PortableExecutable {
+            param([Parameter(Mandatory = $true)][string]$Path)
+
+            $stream = [System.IO.File]::OpenRead((Resolve-Path -LiteralPath $Path).Path)
+            $reader = [System.IO.BinaryReader]::new($stream)
+            try {
+              if ($stream.Length -lt 64 -or $reader.ReadUInt16() -ne 0x5A4D) {
+                return $false
+              }
+
+              $stream.Position = 0x3C
+              $peOffset = $reader.ReadInt32()
+              if ($peOffset -lt 64 -or $peOffset -gt ($stream.Length - 4)) {
+                return $false
+              }
+
+              $stream.Position = $peOffset
+              return $reader.ReadUInt32() -eq 0x00004550
+            } finally {
+              $reader.Dispose()
+              $stream.Dispose()
+            }
+          }
+
+          function Get-InstallEntry {
+            param(
+              [Parameter(Mandatory = $true)][string]$Mode,
+              [Parameter(Mandatory = $true)][string[]]$RegistryRoots
+            )
+
+            $entries = foreach ($root in $RegistryRoots) {
+              if (-not (Test-Path -LiteralPath $root)) {
+                continue
+              }
+              Get-ChildItem -LiteralPath $root -ErrorAction SilentlyContinue |
+                ForEach-Object { Get-ItemProperty -LiteralPath $_.PSPath -ErrorAction SilentlyContinue } |
+                Where-Object { $_.DisplayName -eq '花笺' }
+            }
+            $entries = @($entries)
+            if ($entries.Count -ne 1) {
+              throw "Expected exactly one $Mode uninstall registry entry, found $($entries.Count)."
+            }
+            if ([string]::IsNullOrWhiteSpace($entries[0].InstallLocation)) {
+              throw "The $Mode uninstall registry entry has no InstallLocation."
+            }
+            return $entries[0]
+          }
+
+          function Assert-PathRemoved {
+            param(
+              [Parameter(Mandatory = $true)][string]$Description,
+              [Parameter(Mandatory = $true)][string]$Path
+            )
+
+            for ($attempt = 0; $attempt -lt 30; $attempt++) {
+              if (-not (Test-Path -LiteralPath $Path)) {
+                return
+              }
+              Start-Sleep -Milliseconds 500
+            }
+            throw "$Description remains after uninstall: $Path"
+          }
+
+          function Invoke-InstallVerification {
+            param(
+              [Parameter(Mandatory = $true)][string]$Mode,
+              [Parameter(Mandatory = $true)][string]$ModeSwitch,
+              [Parameter(Mandatory = $true)][string[]]$RegistryRoots,
+              [Parameter(Mandatory = $true)][string]$InstallerPath,
+              [Parameter(Mandatory = $true)][string]$ExpectedBinarySha256
+            )
+
+            $installProcess = Start-Process -FilePath $InstallerPath -ArgumentList @('/S', $ModeSwitch) -PassThru -Wait
+            if ($installProcess.ExitCode -ne 0) {
+              throw "The $Mode NSIS install failed with exit code $($installProcess.ExitCode)."
             }
 
-            Write-Host 'Accepted the pinned SignPath test certificate; only the expected untrusted-root status was ignored.'
+            $installEntry = Get-InstallEntry -Mode $Mode -RegistryRoots $RegistryRoots
+            $installDir = $installEntry.InstallLocation.Trim('"')
+            $installedBinary = Join-Path $installDir 'floral-notepaper.exe'
+            $uninstaller = Join-Path $installDir 'uninstall.exe'
+            Assert-AuthenticodeSignature -Path $installedBinary
+
+            $installedSha256 = (Get-FileHash -LiteralPath $installedBinary -Algorithm SHA256).Hash
+            if ($installedSha256 -ne $ExpectedBinarySha256) {
+              throw "$Mode installed executable hash mismatch. Expected $ExpectedBinarySha256, got $installedSha256."
+            }
+
+            if (-not (Test-Path -LiteralPath $uninstaller -PathType Leaf)) {
+              throw "The $Mode NSIS uninstaller was not found at $uninstaller."
+            }
+            if (-not (Test-PortableExecutable -Path $uninstaller)) {
+              throw "The $Mode NSIS uninstaller is not a valid PE file: $uninstaller"
+            }
+
+            $resolvedBinary = (Resolve-Path -LiteralPath $installedBinary).Path
+            $resolvedUninstaller = (Resolve-Path -LiteralPath $uninstaller).Path
+            $unexpectedPortableExecutables = @(
+              Get-ChildItem -LiteralPath $installDir -File -Recurse |
+                Where-Object { Test-PortableExecutable -Path $_.FullName } |
+                Where-Object {
+                  $_.FullName -ine $resolvedBinary -and
+                  $_.FullName -ine $resolvedUninstaller
+                } |
+                Select-Object -ExpandProperty FullName
+            )
+            if ($unexpectedPortableExecutables.Count -ne 0) {
+              throw "Unexpected PE files are outside the SignPath allowlist:`n$($unexpectedPortableExecutables -join "`n")"
+            }
+
+            $uninstallerSha256 = (Get-FileHash -LiteralPath $uninstaller -Algorithm SHA256).Hash
+            $uninstallerSignature = Get-AuthenticodeSignature -LiteralPath $uninstaller
+            if ($uninstallerSignature.Status -eq 'Valid') {
+              Assert-AuthenticodeSignature -Path $uninstaller
+            } elseif ($uninstallerSignature.Status -ne 'NotSigned') {
+              throw "$Mode uninstaller has an unexpected Authenticode state: $($uninstallerSignature.Status): $($uninstallerSignature.StatusMessage)"
+            }
+
+            # Tauri generates this PE during installation. Until the SignPath artifact
+            # configuration supports deep signing it, only NotSigned is accepted as
+            # an explicit exception; any invalid or unexpected signature fails closed.
+            "- ${Mode}: installed executable signature and hash verified; PE scope verified" >> $env:GITHUB_STEP_SUMMARY
+            "- ${Mode} uninstaller: SHA-256 $uninstallerSha256; Authenticode $($uninstallerSignature.Status) (unsigned is a documented release exception)" >> $env:GITHUB_STEP_SUMMARY
+
+            $uninstallRegistryPath = $installEntry.PSPath
+            $uninstallProcess = Start-Process -FilePath $uninstaller -ArgumentList @('/S', $ModeSwitch) -PassThru -Wait
+            if ($uninstallProcess.ExitCode -ne 0) {
+              throw "The $Mode NSIS uninstall failed with exit code $($uninstallProcess.ExitCode)."
+            }
+
+            Assert-PathRemoved -Description "$Mode installed executable" -Path $installedBinary
+            Assert-PathRemoved -Description "$Mode install directory" -Path $installDir
+            Assert-PathRemoved -Description "$Mode uninstall registry entry" -Path $uninstallRegistryPath
           }
 
           $installer = "signed-windows-installer/floral-notepaper_$($env:RELEASE_VERSION)_x64-setup.exe"
@@ -808,51 +1013,33 @@ jobs:
           Assert-AuthenticodeSignature -Path $portable
           $expectedBinarySha256 = (Get-FileHash -LiteralPath $portable -Algorithm SHA256).Hash
 
-          $installProcess = Start-Process -FilePath $installer -ArgumentList @('/S', '/CurrentUser') -PassThru -Wait
-          if ($installProcess.ExitCode -ne 0) {
-            throw "The NSIS installer failed with exit code $($installProcess.ExitCode)."
-          }
-
-          $uninstallRoots = @(
-            'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall',
-            'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall',
-            'HKLM:\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall'
-          )
-          $installEntry = foreach ($root in $uninstallRoots) {
-            if (-not (Test-Path $root)) {
-              continue
-            }
-            Get-ChildItem $root -ErrorAction SilentlyContinue |
-              ForEach-Object { Get-ItemProperty $_.PSPath -ErrorAction SilentlyContinue } |
-              Where-Object { $_.DisplayName -eq '花笺' }
-          }
-          $installEntry = @($installEntry) | Select-Object -First 1
-          if (-not $installEntry -or [string]::IsNullOrWhiteSpace($installEntry.InstallLocation)) {
-            throw 'The installed application could not be located through the uninstall registry.'
-          }
-
-          $installDir = $installEntry.InstallLocation.Trim('"')
-          $installedBinary = Join-Path $installDir 'floral-notepaper.exe'
-          $uninstaller = Join-Path $installDir 'uninstall.exe'
-          Assert-AuthenticodeSignature -Path $installedBinary
-
-          $installedSha256 = (Get-FileHash -LiteralPath $installedBinary -Algorithm SHA256).Hash
-          if ($installedSha256 -ne $expectedBinarySha256) {
-            throw "Installed executable hash mismatch. Expected $expectedBinarySha256, got $installedSha256."
-          }
-
-          if (-not (Test-Path -LiteralPath $uninstaller -PathType Leaf)) {
-            throw "The NSIS uninstaller was not found at $uninstaller."
-          }
-          $uninstallerSignature = Get-AuthenticodeSignature -LiteralPath $uninstaller
           "### Windows signing verification" >> $env:GITHUB_STEP_SUMMARY
           "- Installer: valid Authenticode signature and timestamp" >> $env:GITHUB_STEP_SUMMARY
-          "- Installed executable: signature valid and SHA-256 matches the signed portable executable" >> $env:GITHUB_STEP_SUMMARY
-          "- Uninstaller: $($uninstallerSignature.Status) (signing intentionally deferred)" >> $env:GITHUB_STEP_SUMMARY
 
-          $uninstallProcess = Start-Process -FilePath $uninstaller -ArgumentList @('/S', '/CurrentUser') -PassThru -Wait
-          if ($uninstallProcess.ExitCode -ne 0) {
-            throw "The NSIS uninstaller failed with exit code $($uninstallProcess.ExitCode)."
+          $installCases = @(
+            @{
+              Mode = 'Current User'
+              Switch = '/CurrentUser'
+              RegistryRoots = @(
+                'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall'
+              )
+            },
+            @{
+              Mode = 'All Users'
+              Switch = '/AllUsers'
+              RegistryRoots = @(
+                'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall',
+                'HKLM:\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall'
+              )
+            }
+          )
+          foreach ($installCase in $installCases) {
+            Invoke-InstallVerification `
+              -Mode $installCase.Mode `
+              -ModeSwitch $installCase.Switch `
+              -RegistryRoots $installCase.RegistryRoots `
+              -InstallerPath $installer `
+              -ExpectedBinarySha256 $expectedBinarySha256
           }
 
       - name: Upload verified signed installer
@@ -884,6 +1071,8 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
 
       - name: Install system dependencies
         run: |
@@ -904,27 +1093,39 @@ jobs:
           set -euo pipefail
           mkdir -p release-assets
 
-          deb_source="$(find src-tauri/target/release/bundle/deb -type f -name '*.deb' | sort | head -n 1)"
-          if [[ -n "$deb_source" ]]; then
-            cp "$deb_source" "release-assets/floral-notepaper_${RELEASE_VERSION}_amd64.deb"
-          fi
+          require_one() {
+            local description="$1"
+            shift
+            local files=("$@")
 
-          rpm_source="$(find src-tauri/target/release/bundle/rpm -type f -name '*.rpm' | sort | head -n 1)"
-          if [[ -n "$rpm_source" ]]; then
-            cp "$rpm_source" "release-assets/floral-notepaper-${RELEASE_VERSION}-1.x86_64.rpm"
-          fi
+            if [[ ${#files[@]} -ne 1 ]]; then
+              printf 'Expected exactly one %s, found %d:\n' \
+                "$description" "${#files[@]}" >&2
+              printf '%s\n' "${files[@]}" >&2
+              exit 1
+            fi
+          }
 
-          appimage_source="$(find src-tauri/target/release/bundle/appimage -type f -name '*.AppImage' | sort | head -n 1)"
-          if [[ -n "$appimage_source" ]]; then
-            cp "$appimage_source" "release-assets/floral-notepaper_${RELEASE_VERSION}_amd64.AppImage"
-          fi
+          deb_candidates=()
+          while IFS= read -r candidate; do
+            deb_candidates+=("$candidate")
+          done < <(find src-tauri/target/release/bundle/deb -type f -name '*.deb' | sort)
+          require_one 'DEB package' "${deb_candidates[@]}"
+          cp "${deb_candidates[0]}" "release-assets/floral-notepaper_${RELEASE_VERSION}_amd64.deb"
 
-          shopt -s nullglob
-          assets=(release-assets/*)
-          if [[ ${#assets[@]} -eq 0 ]]; then
-            echo 'No Linux release assets found.' >&2
-            exit 1
-          fi
+          rpm_candidates=()
+          while IFS= read -r candidate; do
+            rpm_candidates+=("$candidate")
+          done < <(find src-tauri/target/release/bundle/rpm -type f -name '*.rpm' | sort)
+          require_one 'RPM package' "${rpm_candidates[@]}"
+          cp "${rpm_candidates[0]}" "release-assets/floral-notepaper-${RELEASE_VERSION}-1.x86_64.rpm"
+
+          appimage_candidates=()
+          while IFS= read -r candidate; do
+            appimage_candidates+=("$candidate")
+          done < <(find src-tauri/target/release/bundle/appimage -type f -name '*.AppImage' | sort)
+          require_one 'AppImage' "${appimage_candidates[@]}"
+          cp "${appimage_candidates[0]}" "release-assets/floral-notepaper_${RELEASE_VERSION}_amd64.AppImage"
 
       - name: Upload Linux release assets
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -956,6 +1157,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30
         with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
           targets: x86_64-apple-darwin
 
       - name: Install dependencies
@@ -1015,6 +1217,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30
         with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
           targets: aarch64-apple-darwin
 
       - name: Install dependencies
@@ -1053,86 +1256,6 @@ jobs:
           overwrite: true
           retention-days: 7
 
-  verify-test-release-assets:
-    name: Verify test release assets without publishing
-    needs:
-      - validate-release
-      - sign-windows-binary
-      - sign-and-verify-windows-installer
-      - build-linux
-      - build-macos-x86_64
-      - build-macos-aarch64
-    if: needs.validate-release.outputs.mode == 'test'
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-    steps:
-      - name: Download signed Windows portable executable
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: signed-windows-portable
-          path: test-release-assets
-
-      - name: Download signed Windows installer
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: signed-windows-installer
-          path: test-release-assets
-
-      - name: Download Linux release assets
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: linux-release-assets
-          path: test-release-assets
-
-      - name: Download macOS Intel release asset
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: macos-x64-release-asset
-          path: test-release-assets
-
-      - name: Download macOS Apple Silicon release asset
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: macos-aarch64-release-asset
-          path: test-release-assets
-
-      - name: Validate test assets and generate checksums
-        shell: bash
-        env:
-          RELEASE_VERSION: ${{ needs.validate-release.outputs.version }}
-        run: |
-          set -euo pipefail
-
-          required_assets=(
-            "floral-notepaper_${RELEASE_VERSION}.exe"
-            "floral-notepaper_${RELEASE_VERSION}_x64-setup.exe"
-            "floral-notepaper_${RELEASE_VERSION}_x64.dmg"
-            "floral-notepaper_${RELEASE_VERSION}_aarch64.dmg"
-          )
-          for asset in "${required_assets[@]}"; do
-            if [[ ! -f "test-release-assets/$asset" ]]; then
-              echo "Required test asset is missing: $asset" >&2
-              exit 1
-            fi
-          done
-
-          find test-release-assets -maxdepth 1 -type f ! -name SHA256SUMS.txt -print0 \
-            | sort -z \
-            | xargs -0 sha256sum \
-            | sed 's#  test-release-assets/#  #' \
-            > test-release-assets/SHA256SUMS.txt
-
-      - name: Upload aggregate test release assets
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: test-release-assets
-          path: test-release-assets/*
-          if-no-files-found: error
-          overwrite: true
-          retention-days: 7
-
   publish-draft-release:
     name: Publish verified assets to draft release
     needs:
@@ -1142,7 +1265,6 @@ jobs:
       - build-linux
       - build-macos-x86_64
       - build-macos-aarch64
-    if: needs.validate-release.outputs.mode == 'release'
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -1152,6 +1274,7 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
+          fetch-depth: 0
 
       - name: Download signed Windows portable executable
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -1186,13 +1309,20 @@ jobs:
       - name: Validate release assets and generate checksums
         shell: bash
         env:
+          RELEASE_COMMIT: ${{ needs.validate-release.outputs.commit }}
+          RELEASE_TAG: ${{ needs.validate-release.outputs.tag }}
           RELEASE_VERSION: ${{ needs.validate-release.outputs.version }}
+          WORKFLOW_RUN_ATTEMPT: ${{ github.run_attempt }}
+          WORKFLOW_RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
 
           required_assets=(
             "floral-notepaper_${RELEASE_VERSION}.exe"
             "floral-notepaper_${RELEASE_VERSION}_x64-setup.exe"
+            "floral-notepaper_${RELEASE_VERSION}_amd64.deb"
+            "floral-notepaper-${RELEASE_VERSION}-1.x86_64.rpm"
+            "floral-notepaper_${RELEASE_VERSION}_amd64.AppImage"
             "floral-notepaper_${RELEASE_VERSION}_x64.dmg"
             "floral-notepaper_${RELEASE_VERSION}_aarch64.dmg"
           )
@@ -1202,6 +1332,13 @@ jobs:
               exit 1
             fi
           done
+
+          {
+            echo "tag=$RELEASE_TAG"
+            echo "commit=$RELEASE_COMMIT"
+            echo "workflow_run_id=$WORKFLOW_RUN_ID"
+            echo "workflow_run_attempt=$WORKFLOW_RUN_ATTEMPT"
+          } > release-assets/BUILD-INFO.txt
 
           find release-assets -maxdepth 1 -type f ! -name SHA256SUMS.txt -print0 \
             | sort -z \
@@ -1213,10 +1350,37 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_COMMIT: ${{ needs.validate-release.outputs.commit }}
           RELEASE_TAG: ${{ needs.validate-release.outputs.tag }}
           RELEASE_VERSION: ${{ needs.validate-release.outputs.version }}
         run: |
           set -euo pipefail
+
+          git fetch --no-tags origin \
+            '+refs/heads/main:refs/remotes/origin/main'
+          if ! git merge-base --is-ancestor "$RELEASE_COMMIT" refs/remotes/origin/main; then
+            echo "Release commit $RELEASE_COMMIT is no longer contained in main." >&2
+            exit 1
+          fi
+
+          remote_tag_commit="$(
+            git ls-remote origin \
+              "refs/tags/${RELEASE_TAG}" \
+              "refs/tags/${RELEASE_TAG}^{}" |
+              awk '
+                $2 ~ /\^\{\}$/ { peeled = $1 }
+                $2 !~ /\^\{\}$/ { direct = $1 }
+                END {
+                  if (peeled != "") print peeled
+                  else print direct
+                }
+              '
+          )"
+          if [[ -z "$remote_tag_commit" || "$remote_tag_commit" != "$RELEASE_COMMIT" ]]; then
+            echo "Release tag $RELEASE_TAG was deleted or moved before publishing." >&2
+            echo "Expected $RELEASE_COMMIT, got ${remote_tag_commit:-<missing>}." >&2
+            exit 1
+          fi
 
           release_note_file="Docs/release-note/${RELEASE_VERSION}.md"
           if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
@@ -1225,11 +1389,6 @@ jobs:
               echo "Release $RELEASE_TAG is already published and will not be overwritten." >&2
               exit 1
             fi
-
-            while IFS= read -r asset; do
-              [[ -z "$asset" ]] && continue
-              gh release delete-asset "$RELEASE_TAG" "$asset" --repo "$GITHUB_REPOSITORY" --yes
-            done < <(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name')
 
             gh release edit "$RELEASE_TAG" \
               --repo "$GITHUB_REPOSITORY" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -278,33 +278,6 @@ jobs:
             return $certificate
           }
 
-          function Add-PinnedTestCertificateToTrustStore {
-            param([Parameter(Mandatory = $true)][string]$Path)
-
-            if ($env:SIGNING_MODE -eq 'release') {
-              return
-            }
-            if ($env:SIGNING_MODE -ne 'test') {
-              throw "Unsupported signing mode: $($env:SIGNING_MODE)"
-            }
-
-            $certificate = Get-PinnedSignerCertificate -Path $Path
-            if ($certificate.Subject -ne $certificate.Issuer) {
-              throw 'The pinned test certificate must be self-signed before it can be trusted on the ephemeral runner.'
-            }
-
-            $store = [System.Security.Cryptography.X509Certificates.X509Store]::new(
-              [System.Security.Cryptography.X509Certificates.StoreName]::Root,
-              [System.Security.Cryptography.X509Certificates.StoreLocation]::CurrentUser
-            )
-            try {
-              $store.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
-              $store.Add($certificate)
-            } finally {
-              $store.Close()
-            }
-          }
-
           function Assert-AuthenticodeSignature {
             param([Parameter(Mandatory = $true)][string]$Path)
 
@@ -312,26 +285,43 @@ jobs:
               throw "Signed file was not found: $Path"
             }
 
-            $null = Get-PinnedSignerCertificate -Path $Path
+            if ($env:SIGNING_MODE -notin @('test', 'release')) {
+              throw "Unsupported signing mode: $($env:SIGNING_MODE)"
+            }
+
+            $certificate = Get-PinnedSignerCertificate -Path $Path
 
             $signature = Get-AuthenticodeSignature -LiteralPath $Path
             $signature | Format-List Status, StatusMessage, SignerCertificate, TimeStamperCertificate
-            if ($signature.Status -ne 'Valid') {
-              throw "Authenticode signature is not valid for ${Path}: $($signature.Status)"
-            }
             if (-not $signature.TimeStamperCertificate) {
               throw "The signature does not contain a trusted timestamp: $Path"
             }
 
-            $signTool = Get-SignToolPath
-            & $signTool verify /pa /all /v $Path
-            if ($LASTEXITCODE -ne 0) {
-              throw "signtool verification failed for $Path with exit code $LASTEXITCODE."
+            if ($signature.Status -eq 'Valid') {
+              $signTool = Get-SignToolPath
+              & $signTool verify /pa /all /v $Path
+              if ($LASTEXITCODE -ne 0) {
+                throw "signtool verification failed for $Path with exit code $LASTEXITCODE."
+              }
+              return
             }
+
+            $untrustedRootPattern = '(?i)(0x800B0109|untrusted root|root certificate.+not trusted)'
+            $isExpectedTestTrustFailure =
+              $env:SIGNING_MODE -eq 'test' -and
+              $signature.Status -in @('UnknownError', 'NotTrusted') -and
+              $signature.StatusMessage -match $untrustedRootPattern
+            if (-not $isExpectedTestTrustFailure) {
+              throw "Authenticode signature is not valid for ${Path}: $($signature.Status): $($signature.StatusMessage)"
+            }
+            if ($certificate.Subject -ne $certificate.Issuer) {
+              throw 'The pinned test certificate must be self-signed.'
+            }
+
+            Write-Host 'Accepted the pinned SignPath test certificate; only the expected untrusted-root status was ignored.'
           }
 
           $mainBinary = "signed-windows-binary/floral-notepaper_$($env:RELEASE_VERSION).exe"
-          Add-PinnedTestCertificateToTrustStore -Path $mainBinary
           Assert-AuthenticodeSignature -Path $mainBinary
 
       - name: Upload verified signed binaries
@@ -677,33 +667,6 @@ jobs:
             return $certificate
           }
 
-          function Add-PinnedTestCertificateToTrustStore {
-            param([Parameter(Mandatory = $true)][string]$Path)
-
-            if ($env:SIGNING_MODE -eq 'release') {
-              return
-            }
-            if ($env:SIGNING_MODE -ne 'test') {
-              throw "Unsupported signing mode: $($env:SIGNING_MODE)"
-            }
-
-            $certificate = Get-PinnedSignerCertificate -Path $Path
-            if ($certificate.Subject -ne $certificate.Issuer) {
-              throw 'The pinned test certificate must be self-signed before it can be trusted on the ephemeral runner.'
-            }
-
-            $store = [System.Security.Cryptography.X509Certificates.X509Store]::new(
-              [System.Security.Cryptography.X509Certificates.StoreName]::Root,
-              [System.Security.Cryptography.X509Certificates.StoreLocation]::CurrentUser
-            )
-            try {
-              $store.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
-              $store.Add($certificate)
-            } finally {
-              $store.Close()
-            }
-          }
-
           function Assert-AuthenticodeSignature {
             param([Parameter(Mandatory = $true)][string]$Path)
 
@@ -711,27 +674,44 @@ jobs:
               throw "Signed file was not found: $Path"
             }
 
-            $null = Get-PinnedSignerCertificate -Path $Path
+            if ($env:SIGNING_MODE -notin @('test', 'release')) {
+              throw "Unsupported signing mode: $($env:SIGNING_MODE)"
+            }
+
+            $certificate = Get-PinnedSignerCertificate -Path $Path
 
             $signature = Get-AuthenticodeSignature -LiteralPath $Path
             $signature | Format-List Status, StatusMessage, SignerCertificate, TimeStamperCertificate
-            if ($signature.Status -ne 'Valid') {
-              throw "Authenticode signature is not valid for ${Path}: $($signature.Status)"
-            }
             if (-not $signature.TimeStamperCertificate) {
               throw "The signature does not contain a trusted timestamp: $Path"
             }
 
-            $signTool = Get-SignToolPath
-            & $signTool verify /pa /all /v $Path
-            if ($LASTEXITCODE -ne 0) {
-              throw "signtool verification failed for $Path with exit code $LASTEXITCODE."
+            if ($signature.Status -eq 'Valid') {
+              $signTool = Get-SignToolPath
+              & $signTool verify /pa /all /v $Path
+              if ($LASTEXITCODE -ne 0) {
+                throw "signtool verification failed for $Path with exit code $LASTEXITCODE."
+              }
+              return
             }
+
+            $untrustedRootPattern = '(?i)(0x800B0109|untrusted root|root certificate.+not trusted)'
+            $isExpectedTestTrustFailure =
+              $env:SIGNING_MODE -eq 'test' -and
+              $signature.Status -in @('UnknownError', 'NotTrusted') -and
+              $signature.StatusMessage -match $untrustedRootPattern
+            if (-not $isExpectedTestTrustFailure) {
+              throw "Authenticode signature is not valid for ${Path}: $($signature.Status): $($signature.StatusMessage)"
+            }
+            if ($certificate.Subject -ne $certificate.Issuer) {
+              throw 'The pinned test certificate must be self-signed.'
+            }
+
+            Write-Host 'Accepted the pinned SignPath test certificate; only the expected untrusted-root status was ignored.'
           }
 
           $installer = "signed-windows-installer/floral-notepaper_$($env:RELEASE_VERSION)_x64-setup.exe"
           $portable = "signed-windows-binaries/floral-notepaper_$($env:RELEASE_VERSION).exe"
-          Add-PinnedTestCertificateToTrustStore -Path $installer
           Assert-AuthenticodeSignature -Path $installer
           Assert-AuthenticodeSignature -Path $portable
           $expectedBinarySha256 = (Get-FileHash -LiteralPath $portable -Algorithm SHA256).Hash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,13 +73,17 @@ jobs:
             exit 1
           fi
 
-          bundled_bin_sources=()
-          while IFS= read -r source; do
-            bundled_bin_sources+=("$source")
-          done < <(find src-tauri/src/bin -maxdepth 1 -type f -name '*.rs' -exec basename {} \; | sort)
-          if [[ ${#bundled_bin_sources[@]} -ne 1 || "${bundled_bin_sources[0]}" != "floral-notepaper-update-helper.rs" ]]; then
-            echo 'The expected bundled Rust helper set has changed; update the SignPath configuration before releasing:' >&2
-            printf '%s\n' "${bundled_bin_sources[@]}" >&2
+          executable_targets=()
+          while IFS= read -r target; do
+            executable_targets+=("$target")
+          done < <(
+            cargo metadata --manifest-path src-tauri/Cargo.toml --format-version 1 --no-deps |
+              jq -r '.packages[] | select(.name == "floral-notepaper") | .targets[] | select(.kind | index("bin")) | .name' |
+              sort
+          )
+          if [[ ${#executable_targets[@]} -ne 1 || "${executable_targets[0]}" != "floral-notepaper" ]]; then
+            echo 'The executable target set has changed; update the SignPath configuration before releasing:' >&2
+            printf '%s\n' "${executable_targets[@]}" >&2
             exit 1
           fi
 
@@ -148,10 +152,6 @@ jobs:
             @{
               Source = 'src-tauri/target/release/floral-notepaper.exe'
               Destination = Join-Path $releaseDir "floral-notepaper_$($env:RELEASE_VERSION).exe"
-            },
-            @{
-              Source = 'src-tauri/target/release/floral-notepaper-update-helper.exe'
-              Destination = Join-Path $releaseDir 'floral-notepaper-update-helper.exe'
             }
           )
 
@@ -331,10 +331,8 @@ jobs:
           }
 
           $mainBinary = "signed-windows-binary/floral-notepaper_$($env:RELEASE_VERSION).exe"
-          $helperBinary = 'signed-windows-binary/floral-notepaper-update-helper.exe'
           Add-PinnedTestCertificateToTrustStore -Path $mainBinary
           Assert-AuthenticodeSignature -Path $mainBinary
-          Assert-AuthenticodeSignature -Path $helperBinary
 
       - name: Upload verified signed binaries
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -401,11 +399,6 @@ jobs:
               Source = "signed-windows-binaries/floral-notepaper_$($env:RELEASE_VERSION).exe"
               Target = Join-Path $targetDir 'floral-notepaper.exe'
               Output = 'main_sha256'
-            },
-            @{
-              Source = 'signed-windows-binaries/floral-notepaper-update-helper.exe'
-              Target = Join-Path $targetDir 'floral-notepaper-update-helper.exe'
-              Output = 'helper_sha256'
             }
           )
 
@@ -540,7 +533,6 @@ jobs:
         env:
           RELEASE_VERSION: ${{ needs.validate-release.outputs.version }}
           EXPECTED_MAIN_SHA256: ${{ steps.restore.outputs.main_sha256 }}
-          EXPECTED_HELPER_SHA256: ${{ steps.restore.outputs.helper_sha256 }}
         run: |
           $ErrorActionPreference = 'Stop'
 
@@ -548,10 +540,6 @@ jobs:
             @{
               Path = 'src-tauri/target/release/floral-notepaper.exe'
               ExpectedSha256 = $env:EXPECTED_MAIN_SHA256
-            },
-            @{
-              Path = 'src-tauri/target/release/floral-notepaper-update-helper.exe'
-              ExpectedSha256 = $env:EXPECTED_HELPER_SHA256
             }
           )
           foreach ($binary in $binaries) {
@@ -743,13 +731,10 @@ jobs:
 
           $installer = "signed-windows-installer/floral-notepaper_$($env:RELEASE_VERSION)_x64-setup.exe"
           $portable = "signed-windows-binaries/floral-notepaper_$($env:RELEASE_VERSION).exe"
-          $helper = 'signed-windows-binaries/floral-notepaper-update-helper.exe'
           Add-PinnedTestCertificateToTrustStore -Path $installer
           Assert-AuthenticodeSignature -Path $installer
           Assert-AuthenticodeSignature -Path $portable
-          Assert-AuthenticodeSignature -Path $helper
           $expectedBinarySha256 = (Get-FileHash -LiteralPath $portable -Algorithm SHA256).Hash
-          $expectedHelperSha256 = (Get-FileHash -LiteralPath $helper -Algorithm SHA256).Hash
 
           $installProcess = Start-Process -FilePath $installer -ArgumentList @('/S', '/CurrentUser') -PassThru -Wait
           if ($installProcess.ExitCode -ne 0) {
@@ -776,19 +761,12 @@ jobs:
 
           $installDir = $installEntry.InstallLocation.Trim('"')
           $installedBinary = Join-Path $installDir 'floral-notepaper.exe'
-          $installedHelper = Join-Path $installDir 'floral-notepaper-update-helper.exe'
           $uninstaller = Join-Path $installDir 'uninstall.exe'
           Assert-AuthenticodeSignature -Path $installedBinary
-          Assert-AuthenticodeSignature -Path $installedHelper
 
           $installedSha256 = (Get-FileHash -LiteralPath $installedBinary -Algorithm SHA256).Hash
           if ($installedSha256 -ne $expectedBinarySha256) {
             throw "Installed executable hash mismatch. Expected $expectedBinarySha256, got $installedSha256."
-          }
-
-          $installedHelperSha256 = (Get-FileHash -LiteralPath $installedHelper -Algorithm SHA256).Hash
-          if ($installedHelperSha256 -ne $expectedHelperSha256) {
-            throw "Installed helper hash mismatch. Expected $expectedHelperSha256, got $installedHelperSha256."
           }
 
           if (-not (Test-Path -LiteralPath $uninstaller -PathType Leaf)) {
@@ -798,7 +776,6 @@ jobs:
           "### Windows signing verification" >> $env:GITHUB_STEP_SUMMARY
           "- Installer: valid Authenticode signature and timestamp" >> $env:GITHUB_STEP_SUMMARY
           "- Installed executable: signature valid and SHA-256 matches the signed portable executable" >> $env:GITHUB_STEP_SUMMARY
-          "- Installed update helper: signature valid and SHA-256 matches the signed bundled helper" >> $env:GITHUB_STEP_SUMMARY
           "- Uninstaller: $($uninstallerSignature.Status) (signing intentionally deferred)" >> $env:GITHUB_STEP_SUMMARY
 
           $uninstallProcess = Start-Process -FilePath $uninstaller -ArgumentList @('/S', '/CurrentUser') -PassThru -Wait

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,51 @@ jobs:
       - name: Build executable without bundling
         run: npm run tauri -- build --no-bundle --no-sign
 
+      - name: Mark executable for NSIS bundling
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $binaryPath = 'src-tauri/target/release/floral-notepaper.exe'
+          if (-not (Test-Path -LiteralPath $binaryPath -PathType Leaf)) {
+            throw "Windows executable was not found at $binaryPath."
+          }
+
+          $unknownMarker = '__TAURI_BUNDLE_TYPE_VAR_UNK'
+          $nsisMarker = '__TAURI_BUNDLE_TYPE_VAR_NSS'
+          if ($unknownMarker.Length -ne $nsisMarker.Length) {
+            throw 'Tauri bundle type markers must have the same length.'
+          }
+
+          $bytes = [System.IO.File]::ReadAllBytes($binaryPath)
+          $content = [System.Text.Encoding]::Latin1.GetString($bytes)
+          $markerIndex = $content.IndexOf($unknownMarker, [System.StringComparison]::Ordinal)
+          if ($markerIndex -lt 0) {
+            throw 'The Tauri unknown bundle type marker was not found.'
+          }
+          if ($content.IndexOf($unknownMarker, $markerIndex + 1, [System.StringComparison]::Ordinal) -ge 0) {
+            throw 'More than one Tauri unknown bundle type marker was found.'
+          }
+          if ($content.Contains($nsisMarker, [System.StringComparison]::Ordinal)) {
+            throw 'The executable already contains an NSIS bundle type marker.'
+          }
+
+          $nsisMarkerBytes = [System.Text.Encoding]::ASCII.GetBytes($nsisMarker)
+          [System.Array]::Copy($nsisMarkerBytes, 0, $bytes, $markerIndex, $nsisMarkerBytes.Length)
+          [System.IO.File]::WriteAllBytes($binaryPath, $bytes)
+
+          $patchedContent = [System.Text.Encoding]::Latin1.GetString(
+            [System.IO.File]::ReadAllBytes($binaryPath)
+          )
+          if (
+            $patchedContent.Contains($unknownMarker, [System.StringComparison]::Ordinal) -or
+            -not $patchedContent.Contains($nsisMarker, [System.StringComparison]::Ordinal)
+          ) {
+            throw 'Failed to apply the Tauri NSIS bundle type marker.'
+          }
+
+          Write-Host 'Marked the unsigned executable for NSIS bundling before code signing.'
+
       - name: Collect unsigned Windows binaries
         shell: pwsh
         env:
@@ -323,6 +368,20 @@ jobs:
 
           $mainBinary = "signed-windows-binary/floral-notepaper_$($env:RELEASE_VERSION).exe"
           Assert-AuthenticodeSignature -Path $mainBinary
+
+          $binaryContent = [System.Text.Encoding]::Latin1.GetString(
+            [System.IO.File]::ReadAllBytes($mainBinary)
+          )
+          $unknownMarker = '__TAURI_BUNDLE_TYPE_VAR_UNK'
+          $nsisMarker = '__TAURI_BUNDLE_TYPE_VAR_NSS'
+          $nsisMarkerIndex = $binaryContent.IndexOf($nsisMarker, [System.StringComparison]::Ordinal)
+          if (
+            $binaryContent.Contains($unknownMarker, [System.StringComparison]::Ordinal) -or
+            $nsisMarkerIndex -lt 0 -or
+            $binaryContent.IndexOf($nsisMarker, $nsisMarkerIndex + 1, [System.StringComparison]::Ordinal) -ge 0
+          ) {
+            throw 'The signed executable does not contain exactly one Tauri NSIS bundle type marker.'
+          }
 
       - name: Upload verified signed binaries
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,92 +1,359 @@
 name: Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "版本号（例如 v1.0.3）"
-        required: true
-        type: string
+  push:
+    tags:
+      - "v*"
+
+permissions: {}
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  prepare-release:
+  validate-release:
+    name: Validate release source
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     outputs:
-      created: ${{ steps.release.outputs.created }}
+      version: ${{ steps.release.outputs.version }}
+      tag: ${{ steps.release.outputs.tag }}
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
-      - name: Create or update draft release
+      - name: Validate tag, versions, and signing scope
         id: release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG_NAME: ${{ github.event.inputs.version }}
+        shell: bash
         run: |
-          ver="$(echo "$TAG_NAME" | sed 's/^v//')"
-          release_note_file="Docs/release-note/${ver}.md"
-          if [ ! -f "$release_note_file" ]; then
+          set -euo pipefail
+
+          tag="$GITHUB_REF_NAME"
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release tags must use the stable SemVer form vMAJOR.MINOR.PATCH: $tag" >&2
+            exit 1
+          fi
+
+          version="${tag#v}"
+          package_version="$(jq -r '.version' package.json)"
+          tauri_version="$(jq -r '.version' src-tauri/tauri.conf.json)"
+          cargo_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' src-tauri/Cargo.toml | head -n 1)"
+
+          for entry in \
+            "package.json:$package_version" \
+            "src-tauri/tauri.conf.json:$tauri_version" \
+            "src-tauri/Cargo.toml:$cargo_version"; do
+            file="${entry%%:*}"
+            actual="${entry#*:}"
+            if [[ "$actual" != "$version" ]]; then
+              echo "Version mismatch in $file: expected $version, got $actual" >&2
+              exit 1
+            fi
+          done
+
+          release_note_file="Docs/release-note/${version}.md"
+          if [[ ! -f "$release_note_file" ]]; then
             echo "Release note file not found: $release_note_file" >&2
             exit 1
           fi
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          empty_ref=""
-          git tag -f "$TAG_NAME" "$GITHUB_SHA"
-          git push origin "${empty_ref}:refs/tags/$TAG_NAME" || true
-          git push origin "refs/tags/$TAG_NAME"
-
-          if gh release view "$TAG_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            gh release edit "$TAG_NAME" --repo "$GITHUB_REPOSITORY" --draft --notes-file "$release_note_file"
-            echo "created=false" >> "$GITHUB_OUTPUT"
-          else
-            gh release create "$TAG_NAME" --repo "$GITHUB_REPOSITORY" --draft --title "$TAG_NAME" --notes-file "$release_note_file" --verify-tag
-            echo "created=true" >> "$GITHUB_OUTPUT"
+          bundled_bin_sources=()
+          while IFS= read -r source; do
+            bundled_bin_sources+=("$source")
+          done < <(find src-tauri/src/bin -maxdepth 1 -type f -name '*.rs' -exec basename {} \; | sort)
+          if [[ ${#bundled_bin_sources[@]} -ne 1 || "${bundled_bin_sources[0]}" != "floral-notepaper-update-helper.rs" ]]; then
+            echo 'The expected bundled Rust helper set has changed; update the SignPath configuration before releasing:' >&2
+            printf '%s\n' "${bundled_bin_sources[@]}" >&2
+            exit 1
           fi
 
-          # Remove stale auxiliary files and old sanitized asset names from older workflow versions.
-          for asset in \
-            icon.icns \
-            bundle_dmg.sh \
-            "_${ver}_aarch64.dmg" \
-            "_${ver}_x64.dmg" \
-            "_${ver}_x64-setup.exe" \
-            "花笺_${ver}_aarch64.dmg" \
-            "花笺_${ver}_x64.dmg" \
-            "花笺_${ver}_x64-setup.exe"; do
-            gh release delete-asset "$TAG_NAME" "$asset" --repo "$GITHUB_REPOSITORY" --yes >/dev/null 2>&1 || true
-          done
+          external_bins="$(jq -r '.bundle.externalBin // [] | .[]' src-tauri/tauri.conf.json)"
+          if [[ -n "$external_bins" ]]; then
+            echo "bundle.externalBin is not empty; update the SignPath signing scope before releasing:" >&2
+            printf '%s\n' "$external_bins" >&2
+            exit 1
+          fi
 
-  build-windows:
-    needs: prepare-release
+          executable_resources="$({
+            jq -r '
+              (.bundle.resources // [])
+              | if type == "array" then .[] else keys[] end
+            ' src-tauri/tauri.conf.json
+          } | grep -Ei '\.(exe|dll)(\*|$)' || true)"
+          if [[ -n "$executable_resources" ]]; then
+            echo "Executable bundle resources are not covered by the current SignPath configurations:" >&2
+            printf '%s\n' "$executable_resources" >&2
+            exit 1
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+  build-windows-binary:
+    name: Build unsigned Windows binary
+    needs: validate-release
     runs-on: windows-latest
     permissions:
-      contents: write
+      contents: read
+    outputs:
+      unsigned_artifact_id: ${{ steps.upload.outputs.artifact-id }}
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v5
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "24"
           cache: npm
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Set version
+      - name: Build executable without bundling
+        run: npm run tauri -- build --no-bundle --no-sign
+
+      - name: Collect unsigned Windows binaries
         shell: pwsh
+        env:
+          RELEASE_VERSION: ${{ needs.validate-release.outputs.version }}
         run: |
-          $ver = "${{ github.event.inputs.version }}" -replace '^v', ''
-          node scripts/set-version.mjs $ver
+          $ErrorActionPreference = 'Stop'
+
+          $releaseDir = 'unsigned-release-assets'
+          New-Item -ItemType Directory -Path $releaseDir -Force | Out-Null
+          $binaries = @(
+            @{
+              Source = 'src-tauri/target/release/floral-notepaper.exe'
+              Destination = Join-Path $releaseDir "floral-notepaper_$($env:RELEASE_VERSION).exe"
+            },
+            @{
+              Source = 'src-tauri/target/release/floral-notepaper-update-helper.exe'
+              Destination = Join-Path $releaseDir 'floral-notepaper-update-helper.exe'
+            }
+          )
+
+          foreach ($binary in $binaries) {
+            if (-not (Test-Path -LiteralPath $binary.Source -PathType Leaf)) {
+              throw "Windows executable was not found at $($binary.Source)."
+            }
+            Copy-Item -LiteralPath $binary.Source -Destination $binary.Destination -Force
+
+            $versionInfo = [System.Diagnostics.FileVersionInfo]::GetVersionInfo((Resolve-Path $binary.Destination).Path)
+            $escapedVersion = [Regex]::Escape($env:RELEASE_VERSION)
+            $expectedVersionPattern = "^$escapedVersion(?:\.0)?(?:[+ -]|$)"
+            foreach ($entry in @{
+                FileVersion = $versionInfo.FileVersion
+                ProductVersion = $versionInfo.ProductVersion
+              }.GetEnumerator()) {
+              if ([string]::IsNullOrWhiteSpace($entry.Value) -or $entry.Value -notmatch $expectedVersionPattern) {
+                throw "Unexpected PE $($entry.Key) for $($binary.Source): expected $env:RELEASE_VERSION, got $($entry.Value)."
+              }
+            }
+          }
+
+          Compress-Archive `
+            -Path (Join-Path $releaseDir '*.exe') `
+            -DestinationPath 'unsigned-windows-binaries.zip' `
+            -CompressionLevel Optimal
+
+      - name: Upload unsigned binaries for SignPath
+        id: upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          path: unsigned-windows-binaries.zip
+          archive: false
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 1
+
+  sign-windows-binary:
+    name: Sign and verify Windows binary
+    needs: [validate-release, build-windows-binary]
+    runs-on: windows-latest
+    environment:
+      name: release-signing
+      deployment: false
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Submit binary signing request
+        uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
+          artifact-configuration-slug: ${{ vars.SIGNPATH_WINDOWS_BINARY_ARTIFACT_CONFIGURATION_SLUG }}
+          github-artifact-id: ${{ needs.build-windows-binary.outputs.unsigned_artifact_id }}
+          wait-for-completion: true
+          output-artifact-directory: signed-windows-binary
+          skip-decompress: false
+          parameters: |
+            version: ${{ toJSON(needs.validate-release.outputs.version) }}
+
+      - name: Verify signed executable
+        shell: pwsh
+        env:
+          RELEASE_VERSION: ${{ needs.validate-release.outputs.version }}
+          EXPECTED_CERTIFICATE_SUBJECT: ${{ vars.SIGNPATH_CERTIFICATE_SUBJECT }}
+          EXPECTED_CERTIFICATE_ISSUER: ${{ vars.SIGNPATH_CERTIFICATE_ISSUER }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          function Get-SignToolPath {
+            $command = Get-Command signtool.exe -ErrorAction SilentlyContinue
+            if ($command) {
+              return $command.Source
+            }
+
+            $kitsRoot = Join-Path ${env:ProgramFiles(x86)} 'Windows Kits/10/bin'
+            $candidate = Get-ChildItem -Path $kitsRoot -Filter signtool.exe -File -Recurse |
+              Where-Object { $_.FullName -match '[\\/]x64[\\/]signtool\.exe$' } |
+              Sort-Object FullName -Descending |
+              Select-Object -First 1
+            if (-not $candidate) {
+              throw 'signtool.exe was not found on the runner.'
+            }
+            return $candidate.FullName
+          }
+
+          function Assert-AuthenticodeSignature {
+            param([Parameter(Mandatory = $true)][string]$Path)
+
+            if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+              throw "Signed file was not found: $Path"
+            }
+            if ([string]::IsNullOrWhiteSpace($env:EXPECTED_CERTIFICATE_SUBJECT)) {
+              throw 'SIGNPATH_CERTIFICATE_SUBJECT is not configured.'
+            }
+            if ([string]::IsNullOrWhiteSpace($env:EXPECTED_CERTIFICATE_ISSUER)) {
+              throw 'SIGNPATH_CERTIFICATE_ISSUER is not configured.'
+            }
+
+            $signature = Get-AuthenticodeSignature -LiteralPath $Path
+            $signature | Format-List Status, StatusMessage, SignerCertificate, TimeStamperCertificate
+            if ($signature.Status -ne 'Valid') {
+              throw "Authenticode signature is not valid for $Path: $($signature.Status)"
+            }
+            if ($signature.SignerCertificate.Subject -ne $env:EXPECTED_CERTIFICATE_SUBJECT) {
+              throw "Unexpected certificate subject: $($signature.SignerCertificate.Subject)"
+            }
+            if ($signature.SignerCertificate.Issuer -ne $env:EXPECTED_CERTIFICATE_ISSUER) {
+              throw "Unexpected certificate issuer: $($signature.SignerCertificate.Issuer)"
+            }
+            if (-not $signature.TimeStamperCertificate) {
+              throw "The signature does not contain a trusted timestamp: $Path"
+            }
+
+            $signTool = Get-SignToolPath
+            & $signTool verify /pa /all /v $Path
+            if ($LASTEXITCODE -ne 0) {
+              throw "signtool verification failed for $Path with exit code $LASTEXITCODE."
+            }
+          }
+
+          $mainBinary = "signed-windows-binary/floral-notepaper_$($env:RELEASE_VERSION).exe"
+          $helperBinary = 'signed-windows-binary/floral-notepaper-update-helper.exe'
+          Assert-AuthenticodeSignature -Path $mainBinary
+          Assert-AuthenticodeSignature -Path $helperBinary
+
+      - name: Upload verified signed binaries
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: signed-windows-binaries
+          path: signed-windows-binary/*.exe
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 7
+
+      - name: Upload verified signed executable
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: signed-windows-portable
+          path: signed-windows-binary/floral-notepaper_${{ needs.validate-release.outputs.version }}.exe
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 7
+
+  build-windows-installer:
+    name: Bundle unsigned Windows installer
+    needs: [validate-release, sign-windows-binary]
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    outputs:
+      unsigned_artifact_id: ${{ steps.upload.outputs.artifact-id }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: "24"
+          cache: npm
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download signed Windows binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: signed-windows-binaries
+          path: signed-windows-binaries
+
+      - name: Restore signed Windows binaries
+        id: restore
+        shell: pwsh
+        env:
+          RELEASE_VERSION: ${{ needs.validate-release.outputs.version }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $targetDir = 'src-tauri/target/release'
+          New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+          $binaries = @(
+            @{
+              Source = "signed-windows-binaries/floral-notepaper_$($env:RELEASE_VERSION).exe"
+              Target = Join-Path $targetDir 'floral-notepaper.exe'
+              Output = 'main_sha256'
+            },
+            @{
+              Source = 'signed-windows-binaries/floral-notepaper-update-helper.exe'
+              Target = Join-Path $targetDir 'floral-notepaper-update-helper.exe'
+              Output = 'helper_sha256'
+            }
+          )
+
+          foreach ($binary in $binaries) {
+            if (-not (Test-Path -LiteralPath $binary.Source -PathType Leaf)) {
+              throw "Signed executable was not found at $($binary.Source)."
+            }
+
+            $signature = Get-AuthenticodeSignature -LiteralPath $binary.Source
+            if ($signature.Status -ne 'Valid' -or -not $signature.TimeStamperCertificate) {
+              throw "The restored executable is not validly signed: $($binary.Source): $($signature.Status)"
+            }
+
+            Copy-Item -LiteralPath $binary.Source -Destination $binary.Target -Force
+            $sha256 = (Get-FileHash -LiteralPath $binary.Target -Algorithm SHA256).Hash
+            "$($binary.Output)=$sha256" >> $env:GITHUB_OUTPUT
+          }
 
       - name: Preload Tauri NSIS toolchain
         shell: pwsh
@@ -196,55 +463,256 @@ jobs:
 
           Write-Host "Tauri NSIS toolchain is ready at $nsisPath"
 
-      - name: Build
-        run: npm run tauri build
+      - name: Bundle NSIS installer without recompiling
+        run: npm run tauri -- bundle --bundles nsis --no-sign
 
-      - name: Rename portable binary
-        shell: pwsh
-        run: |
-          $ver = "${{ github.event.inputs.version }}" -replace '^v', ''
-          Copy-Item src-tauri/target/release/floral-notepaper.exe "floral-notepaper_$ver.exe"
-
-      - name: Upload release assets
+      - name: Verify binary hash and collect installer
         shell: pwsh
         env:
-          GH_TOKEN: ${{ github.token }}
-          TAG_NAME: ${{ github.event.inputs.version }}
+          RELEASE_VERSION: ${{ needs.validate-release.outputs.version }}
+          EXPECTED_MAIN_SHA256: ${{ steps.restore.outputs.main_sha256 }}
+          EXPECTED_HELPER_SHA256: ${{ steps.restore.outputs.helper_sha256 }}
         run: |
-          $ver = $env:TAG_NAME -replace '^v', ''
-          $releaseDir = 'release-assets'
-          New-Item -ItemType Directory -Path $releaseDir -Force | Out-Null
+          $ErrorActionPreference = 'Stop'
 
-          $setupSource = Get-ChildItem -Path 'src-tauri/target/release/bundle/nsis' -File -Recurse -Filter '*.exe' | Sort-Object Length -Descending | Select-Object -First 1
-          if (-not $setupSource) {
-            throw 'No Windows NSIS installer found.'
+          $binaries = @(
+            @{
+              Path = 'src-tauri/target/release/floral-notepaper.exe'
+              ExpectedSha256 = $env:EXPECTED_MAIN_SHA256
+            },
+            @{
+              Path = 'src-tauri/target/release/floral-notepaper-update-helper.exe'
+              ExpectedSha256 = $env:EXPECTED_HELPER_SHA256
+            }
+          )
+          foreach ($binary in $binaries) {
+            $actualSha256 = (Get-FileHash -LiteralPath $binary.Path -Algorithm SHA256).Hash
+            if ($actualSha256 -ne $binary.ExpectedSha256) {
+              throw "A signed executable was replaced while bundling: $($binary.Path). Expected $($binary.ExpectedSha256), got $actualSha256."
+            }
           }
 
-          $setupAsset = Join-Path $releaseDir "floral-notepaper_${ver}_x64-setup.exe"
-          $portableAsset = Join-Path $releaseDir "floral-notepaper_${ver}.exe"
-          Copy-Item $setupSource.FullName $setupAsset -Force
-          Copy-Item "floral-notepaper_$ver.exe" $portableAsset -Force
-
-          $files = @(
-            (Resolve-Path $setupAsset).Path,
-            (Resolve-Path $portableAsset).Path
+          $installers = @(
+            Get-ChildItem -Path 'src-tauri/target/release/bundle/nsis' -File -Recurse -Filter '*.exe'
           )
-          gh release upload $env:TAG_NAME $files --clobber --repo $env:GITHUB_REPOSITORY
+          if ($installers.Count -ne 1) {
+            $names = ($installers | ForEach-Object FullName) -join "`n"
+            throw "Expected exactly one NSIS installer, found $($installers.Count):`n$names"
+          }
+
+          $releaseDir = 'unsigned-release-assets'
+          New-Item -ItemType Directory -Path $releaseDir -Force | Out-Null
+          $asset = Join-Path $releaseDir "floral-notepaper_$($env:RELEASE_VERSION)_x64-setup.exe"
+          Copy-Item -LiteralPath $installers[0].FullName -Destination $asset -Force
+
+          $versionInfo = [System.Diagnostics.FileVersionInfo]::GetVersionInfo((Resolve-Path $asset).Path)
+          $escapedVersion = [Regex]::Escape($env:RELEASE_VERSION)
+          $expectedVersionPattern = "^$escapedVersion(?:\.0)?(?:[+ -]|$)"
+          foreach ($entry in @{
+              FileVersion = $versionInfo.FileVersion
+              ProductVersion = $versionInfo.ProductVersion
+            }.GetEnumerator()) {
+            if ([string]::IsNullOrWhiteSpace($entry.Value) -or $entry.Value -notmatch $expectedVersionPattern) {
+              throw "Unexpected installer $($entry.Key): expected $env:RELEASE_VERSION, got $($entry.Value)."
+            }
+          }
+
+      - name: Upload unsigned installer for SignPath
+        id: upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          path: unsigned-release-assets/floral-notepaper_${{ needs.validate-release.outputs.version }}_x64-setup.exe
+          archive: false
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 1
+
+  sign-and-verify-windows-installer:
+    name: Sign and install-test Windows installer
+    needs: [validate-release, sign-windows-binary, build-windows-installer]
+    runs-on: windows-latest
+    environment:
+      name: release-signing
+      deployment: false
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Submit installer signing request
+        uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
+          artifact-configuration-slug: ${{ vars.SIGNPATH_WINDOWS_INSTALLER_ARTIFACT_CONFIGURATION_SLUG }}
+          github-artifact-id: ${{ needs.build-windows-installer.outputs.unsigned_artifact_id }}
+          wait-for-completion: true
+          output-artifact-directory: signed-windows-installer
+          skip-decompress: true
+          parameters: |
+            version: ${{ toJSON(needs.validate-release.outputs.version) }}
+
+      - name: Download signed Windows binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: signed-windows-binaries
+          path: signed-windows-binaries
+
+      - name: Verify installer and installed executable
+        shell: pwsh
+        env:
+          RELEASE_VERSION: ${{ needs.validate-release.outputs.version }}
+          EXPECTED_CERTIFICATE_SUBJECT: ${{ vars.SIGNPATH_CERTIFICATE_SUBJECT }}
+          EXPECTED_CERTIFICATE_ISSUER: ${{ vars.SIGNPATH_CERTIFICATE_ISSUER }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          function Get-SignToolPath {
+            $command = Get-Command signtool.exe -ErrorAction SilentlyContinue
+            if ($command) {
+              return $command.Source
+            }
+
+            $kitsRoot = Join-Path ${env:ProgramFiles(x86)} 'Windows Kits/10/bin'
+            $candidate = Get-ChildItem -Path $kitsRoot -Filter signtool.exe -File -Recurse |
+              Where-Object { $_.FullName -match '[\\/]x64[\\/]signtool\.exe$' } |
+              Sort-Object FullName -Descending |
+              Select-Object -First 1
+            if (-not $candidate) {
+              throw 'signtool.exe was not found on the runner.'
+            }
+            return $candidate.FullName
+          }
+
+          function Assert-AuthenticodeSignature {
+            param([Parameter(Mandatory = $true)][string]$Path)
+
+            if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+              throw "Signed file was not found: $Path"
+            }
+            if ([string]::IsNullOrWhiteSpace($env:EXPECTED_CERTIFICATE_SUBJECT)) {
+              throw 'SIGNPATH_CERTIFICATE_SUBJECT is not configured.'
+            }
+            if ([string]::IsNullOrWhiteSpace($env:EXPECTED_CERTIFICATE_ISSUER)) {
+              throw 'SIGNPATH_CERTIFICATE_ISSUER is not configured.'
+            }
+
+            $signature = Get-AuthenticodeSignature -LiteralPath $Path
+            $signature | Format-List Status, StatusMessage, SignerCertificate, TimeStamperCertificate
+            if ($signature.Status -ne 'Valid') {
+              throw "Authenticode signature is not valid for $Path: $($signature.Status)"
+            }
+            if ($signature.SignerCertificate.Subject -ne $env:EXPECTED_CERTIFICATE_SUBJECT) {
+              throw "Unexpected certificate subject: $($signature.SignerCertificate.Subject)"
+            }
+            if ($signature.SignerCertificate.Issuer -ne $env:EXPECTED_CERTIFICATE_ISSUER) {
+              throw "Unexpected certificate issuer: $($signature.SignerCertificate.Issuer)"
+            }
+            if (-not $signature.TimeStamperCertificate) {
+              throw "The signature does not contain a trusted timestamp: $Path"
+            }
+
+            $signTool = Get-SignToolPath
+            & $signTool verify /pa /all /v $Path
+            if ($LASTEXITCODE -ne 0) {
+              throw "signtool verification failed for $Path with exit code $LASTEXITCODE."
+            }
+          }
+
+          $installer = "signed-windows-installer/floral-notepaper_$($env:RELEASE_VERSION)_x64-setup.exe"
+          $portable = "signed-windows-binaries/floral-notepaper_$($env:RELEASE_VERSION).exe"
+          $helper = 'signed-windows-binaries/floral-notepaper-update-helper.exe'
+          Assert-AuthenticodeSignature -Path $installer
+          Assert-AuthenticodeSignature -Path $portable
+          Assert-AuthenticodeSignature -Path $helper
+          $expectedBinarySha256 = (Get-FileHash -LiteralPath $portable -Algorithm SHA256).Hash
+          $expectedHelperSha256 = (Get-FileHash -LiteralPath $helper -Algorithm SHA256).Hash
+
+          $installProcess = Start-Process -FilePath $installer -ArgumentList @('/S', '/CurrentUser') -PassThru -Wait
+          if ($installProcess.ExitCode -ne 0) {
+            throw "The NSIS installer failed with exit code $($installProcess.ExitCode)."
+          }
+
+          $uninstallRoots = @(
+            'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall',
+            'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall',
+            'HKLM:\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall'
+          )
+          $installEntry = foreach ($root in $uninstallRoots) {
+            if (-not (Test-Path $root)) {
+              continue
+            }
+            Get-ChildItem $root -ErrorAction SilentlyContinue |
+              ForEach-Object { Get-ItemProperty $_.PSPath -ErrorAction SilentlyContinue } |
+              Where-Object { $_.DisplayName -eq '花笺' }
+          }
+          $installEntry = @($installEntry) | Select-Object -First 1
+          if (-not $installEntry -or [string]::IsNullOrWhiteSpace($installEntry.InstallLocation)) {
+            throw 'The installed application could not be located through the uninstall registry.'
+          }
+
+          $installDir = $installEntry.InstallLocation.Trim('"')
+          $installedBinary = Join-Path $installDir 'floral-notepaper.exe'
+          $installedHelper = Join-Path $installDir 'floral-notepaper-update-helper.exe'
+          $uninstaller = Join-Path $installDir 'uninstall.exe'
+          Assert-AuthenticodeSignature -Path $installedBinary
+          Assert-AuthenticodeSignature -Path $installedHelper
+
+          $installedSha256 = (Get-FileHash -LiteralPath $installedBinary -Algorithm SHA256).Hash
+          if ($installedSha256 -ne $expectedBinarySha256) {
+            throw "Installed executable hash mismatch. Expected $expectedBinarySha256, got $installedSha256."
+          }
+
+          $installedHelperSha256 = (Get-FileHash -LiteralPath $installedHelper -Algorithm SHA256).Hash
+          if ($installedHelperSha256 -ne $expectedHelperSha256) {
+            throw "Installed helper hash mismatch. Expected $expectedHelperSha256, got $installedHelperSha256."
+          }
+
+          if (-not (Test-Path -LiteralPath $uninstaller -PathType Leaf)) {
+            throw "The NSIS uninstaller was not found at $uninstaller."
+          }
+          $uninstallerSignature = Get-AuthenticodeSignature -LiteralPath $uninstaller
+          "### Windows signing verification" >> $env:GITHUB_STEP_SUMMARY
+          "- Installer: valid Authenticode signature and timestamp" >> $env:GITHUB_STEP_SUMMARY
+          "- Installed executable: signature valid and SHA-256 matches the signed portable executable" >> $env:GITHUB_STEP_SUMMARY
+          "- Installed update helper: signature valid and SHA-256 matches the signed bundled helper" >> $env:GITHUB_STEP_SUMMARY
+          "- Uninstaller: $($uninstallerSignature.Status) (signing intentionally deferred)" >> $env:GITHUB_STEP_SUMMARY
+
+          $uninstallProcess = Start-Process -FilePath $uninstaller -ArgumentList @('/S', '/CurrentUser') -PassThru -Wait
+          if ($uninstallProcess.ExitCode -ne 0) {
+            throw "The NSIS uninstaller failed with exit code $($uninstallProcess.ExitCode)."
+          }
+
+      - name: Upload verified signed installer
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: signed-windows-installer
+          path: signed-windows-installer/floral-notepaper_${{ needs.validate-release.outputs.version }}_x64-setup.exe
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 7
 
   build-linux:
-    needs: prepare-release
+    name: Build Linux release assets
+    needs: validate-release
     runs-on: ubuntu-22.04
     permissions:
-      contents: write
+      contents: read
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v5
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "24"
           cache: npm
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30
 
       - name: Install system dependencies
         run: |
@@ -254,159 +722,277 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci
 
-      - name: Set version
-        run: |
-          ver="$(echo '${{ github.event.inputs.version }}' | sed 's/^v//')"
-          cat > set-version.cjs << 'SCRIPT'
-          const fs = require("fs");
-          const ver = process.argv[2];
-          const conf = JSON.parse(fs.readFileSync("src-tauri/tauri.conf.json", "utf8"));
-          conf.version = ver;
-          fs.writeFileSync("src-tauri/tauri.conf.json", JSON.stringify(conf, null, 2));
-          let toml = fs.readFileSync("src-tauri/Cargo.toml", "utf8");
-          toml = toml.replace(/^version = "[^"]*"/m, 'version = "' + ver + '"');
-          fs.writeFileSync("src-tauri/Cargo.toml", toml);
-          SCRIPT
-          node set-version.cjs "$ver"
-
       - name: Build
-        run: npm run tauri build
+        run: npm run tauri -- build --no-sign
 
-      - name: Upload release assets
+      - name: Collect release assets
+        shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
-          TAG_NAME: ${{ github.event.inputs.version }}
+          RELEASE_VERSION: ${{ needs.validate-release.outputs.version }}
         run: |
-          ver="$(echo "$TAG_NAME" | sed 's/^v//')"
+          set -euo pipefail
           mkdir -p release-assets
 
-          # DEB
           deb_source="$(find src-tauri/target/release/bundle/deb -type f -name '*.deb' | sort | head -n 1)"
-          if [ -n "$deb_source" ]; then
-            cp "$deb_source" "release-assets/floral-notepaper_${ver}_amd64.deb"
+          if [[ -n "$deb_source" ]]; then
+            cp "$deb_source" "release-assets/floral-notepaper_${RELEASE_VERSION}_amd64.deb"
           fi
 
-          # RPM
           rpm_source="$(find src-tauri/target/release/bundle/rpm -type f -name '*.rpm' | sort | head -n 1)"
-          if [ -n "$rpm_source" ]; then
-            cp "$rpm_source" "release-assets/floral-notepaper-${ver}-1.x86_64.rpm"
+          if [[ -n "$rpm_source" ]]; then
+            cp "$rpm_source" "release-assets/floral-notepaper-${RELEASE_VERSION}-1.x86_64.rpm"
           fi
 
-          # AppImage
           appimage_source="$(find src-tauri/target/release/bundle/appimage -type f -name '*.AppImage' | sort | head -n 1)"
-          if [ -n "$appimage_source" ]; then
-            cp "$appimage_source" "release-assets/floral-notepaper_${ver}_amd64.AppImage"
+          if [[ -n "$appimage_source" ]]; then
+            cp "$appimage_source" "release-assets/floral-notepaper_${RELEASE_VERSION}_amd64.AppImage"
           fi
 
           shopt -s nullglob
           assets=(release-assets/*)
-          if [ ${#assets[@]} -eq 0 ]; then
-            echo "No Linux release assets found." >&2
+          if [[ ${#assets[@]} -eq 0 ]]; then
+            echo 'No Linux release assets found.' >&2
             exit 1
           fi
 
-          gh release upload "$TAG_NAME" release-assets/* --clobber --repo "$GITHUB_REPOSITORY"
+      - name: Upload Linux release assets
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: linux-release-assets
+          path: release-assets/*
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 7
 
   build-macos-x86_64:
-    needs: prepare-release
+    name: Build macOS Intel release asset
+    needs: validate-release
     runs-on: macos-15-intel
     permissions:
-      contents: write
+      contents: read
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v5
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "24"
           cache: npm
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30
         with:
           targets: x86_64-apple-darwin
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Set version & disable signing
-        run: |
-          ver="$(echo '${{ github.event.inputs.version }}' | sed 's/^v//')"
-          node scripts/set-version.mjs "$ver" --disable-macos-signing
+      - name: Build without signing
+        run: npm run tauri -- build --target x86_64-apple-darwin --no-sign
 
-      - name: Build
-        run: npm run tauri build -- --target x86_64-apple-darwin
-
-      - name: Upload release assets
+      - name: Collect release asset
+        shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
-          TAG_NAME: ${{ github.event.inputs.version }}
+          RELEASE_VERSION: ${{ needs.validate-release.outputs.version }}
         run: |
-          ver="$(echo "$TAG_NAME" | sed 's/^v//')"
-          mkdir -p release-assets
-          dmg_source="$(find src-tauri/target/x86_64-apple-darwin/release/bundle/dmg -type f -name '*.dmg' | sort | head -n 1)"
-          if [ -z "$dmg_source" ]; then
-            echo "No macOS x86_64 DMG release asset found." >&2
+          set -euo pipefail
+          dmg_candidates=()
+          while IFS= read -r candidate; do
+            dmg_candidates+=("$candidate")
+          done < <(find src-tauri/target/x86_64-apple-darwin/release/bundle/dmg -type f -name '*.dmg' | sort)
+          if [[ ${#dmg_candidates[@]} -ne 1 ]]; then
+            printf 'Expected exactly one macOS x86_64 DMG, found %s:\n' "${#dmg_candidates[@]}" >&2
+            printf '%s\n' "${dmg_candidates[@]}" >&2
             exit 1
           fi
-          dmg_asset="release-assets/floral-notepaper_${ver}_x64.dmg"
-          cp "$dmg_source" "$dmg_asset"
+
+          mkdir -p release-assets
+          dmg_asset="release-assets/floral-notepaper_${RELEASE_VERSION}_x64.dmg"
+          cp "${dmg_candidates[0]}" "$dmg_asset"
           xattr -cr "$dmg_asset"
-          gh release upload "$TAG_NAME" "$dmg_asset" --clobber --repo "$GITHUB_REPOSITORY"
+
+      - name: Upload macOS Intel release asset
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: macos-x64-release-asset
+          path: release-assets/floral-notepaper_${{ needs.validate-release.outputs.version }}_x64.dmg
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 7
 
   build-macos-aarch64:
-    needs: prepare-release
+    name: Build macOS Apple Silicon release asset
+    needs: validate-release
     runs-on: macos-15
     permissions:
-      contents: write
+      contents: read
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v5
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "24"
           cache: npm
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30
         with:
           targets: aarch64-apple-darwin
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Set version & disable signing
-        run: |
-          ver="$(echo '${{ github.event.inputs.version }}' | sed 's/^v//')"
-          node scripts/set-version.mjs "$ver" --disable-macos-signing
+      - name: Build without signing
+        run: npm run tauri -- build --target aarch64-apple-darwin --no-sign
 
-      - name: Build
-        run: npm run tauri build -- --target aarch64-apple-darwin
-
-      - name: Upload release assets
+      - name: Collect release asset
+        shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
-          TAG_NAME: ${{ github.event.inputs.version }}
+          RELEASE_VERSION: ${{ needs.validate-release.outputs.version }}
         run: |
-          ver="$(echo "$TAG_NAME" | sed 's/^v//')"
-          mkdir -p release-assets
-          dmg_source="$(find src-tauri/target/aarch64-apple-darwin/release/bundle/dmg -type f -name '*.dmg' | sort | head -n 1)"
-          if [ -z "$dmg_source" ]; then
-            echo "No macOS aarch64 DMG release asset found." >&2
+          set -euo pipefail
+          dmg_candidates=()
+          while IFS= read -r candidate; do
+            dmg_candidates+=("$candidate")
+          done < <(find src-tauri/target/aarch64-apple-darwin/release/bundle/dmg -type f -name '*.dmg' | sort)
+          if [[ ${#dmg_candidates[@]} -ne 1 ]]; then
+            printf 'Expected exactly one macOS aarch64 DMG, found %s:\n' "${#dmg_candidates[@]}" >&2
+            printf '%s\n' "${dmg_candidates[@]}" >&2
             exit 1
           fi
-          dmg_asset="release-assets/floral-notepaper_${ver}_aarch64.dmg"
-          cp "$dmg_source" "$dmg_asset"
-          xattr -cr "$dmg_asset"
-          gh release upload "$TAG_NAME" "$dmg_asset" --clobber --repo "$GITHUB_REPOSITORY"
 
-  cleanup-release:
-    needs: [prepare-release, build-windows, build-linux, build-macos-x86_64, build-macos-aarch64]
-    if: failure() && needs.prepare-release.outputs.created == 'true'
+          mkdir -p release-assets
+          dmg_asset="release-assets/floral-notepaper_${RELEASE_VERSION}_aarch64.dmg"
+          cp "${dmg_candidates[0]}" "$dmg_asset"
+          xattr -cr "$dmg_asset"
+
+      - name: Upload macOS Apple Silicon release asset
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: macos-aarch64-release-asset
+          path: release-assets/floral-notepaper_${{ needs.validate-release.outputs.version }}_aarch64.dmg
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 7
+
+  publish-draft-release:
+    name: Publish verified assets to draft release
+    needs:
+      - validate-release
+      - sign-windows-binary
+      - sign-and-verify-windows-installer
+      - build-linux
+      - build-macos-x86_64
+      - build-macos-aarch64
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: write
     steps:
-      - name: Delete draft release after failed build
+      - name: Checkout release notes
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Download signed Windows portable executable
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: signed-windows-portable
+          path: release-assets
+
+      - name: Download signed Windows installer
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: signed-windows-installer
+          path: release-assets
+
+      - name: Download Linux release assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: linux-release-assets
+          path: release-assets
+
+      - name: Download macOS Intel release asset
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: macos-x64-release-asset
+          path: release-assets
+
+      - name: Download macOS Apple Silicon release asset
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: macos-aarch64-release-asset
+          path: release-assets
+
+      - name: Validate release assets and generate checksums
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ needs.validate-release.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          required_assets=(
+            "floral-notepaper_${RELEASE_VERSION}.exe"
+            "floral-notepaper_${RELEASE_VERSION}_x64-setup.exe"
+            "floral-notepaper_${RELEASE_VERSION}_x64.dmg"
+            "floral-notepaper_${RELEASE_VERSION}_aarch64.dmg"
+          )
+          for asset in "${required_assets[@]}"; do
+            if [[ ! -f "release-assets/$asset" ]]; then
+              echo "Required release asset is missing: $asset" >&2
+              exit 1
+            fi
+          done
+
+          find release-assets -maxdepth 1 -type f ! -name SHA256SUMS.txt -print0 \
+            | sort -z \
+            | xargs -0 sha256sum \
+            | sed 's#  release-assets/#  #' \
+            > release-assets/SHA256SUMS.txt
+
+      - name: Create or update draft release
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG_NAME: ${{ github.event.inputs.version }}
+          RELEASE_TAG: ${{ needs.validate-release.outputs.tag }}
+          RELEASE_VERSION: ${{ needs.validate-release.outputs.version }}
         run: |
-          gh release delete "$TAG_NAME" --repo "$GITHUB_REPOSITORY" --cleanup-tag --yes || true
+          set -euo pipefail
+
+          release_note_file="Docs/release-note/${RELEASE_VERSION}.md"
+          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            is_draft="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft')"
+            if [[ "$is_draft" != "true" ]]; then
+              echo "Release $RELEASE_TAG is already published and will not be overwritten." >&2
+              exit 1
+            fi
+
+            while IFS= read -r asset; do
+              [[ -z "$asset" ]] && continue
+              gh release delete-asset "$RELEASE_TAG" "$asset" --repo "$GITHUB_REPOSITORY" --yes
+            done < <(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name')
+
+            gh release edit "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --draft \
+              --title "$RELEASE_TAG" \
+              --notes-file "$release_note_file"
+          else
+            gh release create "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --draft \
+              --title "$RELEASE_TAG" \
+              --notes-file "$release_note_file" \
+              --verify-tag
+          fi
+
+          gh release upload "$RELEASE_TAG" release-assets/* \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -378,9 +378,22 @@ jobs:
         id: restore
         shell: pwsh
         env:
+          SIGNING_MODE: ${{ needs.validate-release.outputs.mode }}
           RELEASE_VERSION: ${{ needs.validate-release.outputs.version }}
+          EXPECTED_CERTIFICATE_SUBJECT: ${{ vars.SIGNPATH_CERTIFICATE_SUBJECT }}
+          EXPECTED_CERTIFICATE_ISSUER: ${{ vars.SIGNPATH_CERTIFICATE_ISSUER }}
+          EXPECTED_CERTIFICATE_SHA1: ${{ vars.SIGNPATH_CERTIFICATE_SHA1 }}
         run: |
           $ErrorActionPreference = 'Stop'
+
+          if ($env:SIGNING_MODE -notin @('test', 'release')) {
+            throw "Unsupported signing mode: $($env:SIGNING_MODE)"
+          }
+          $expectedThumbprint = ($env:EXPECTED_CERTIFICATE_SHA1 -replace '\s', '').ToUpperInvariant()
+          if ($expectedThumbprint -notmatch '^[0-9A-F]{40}$') {
+            throw 'SIGNPATH_CERTIFICATE_SHA1 must contain a 40-character SHA-1 certificate thumbprint.'
+          }
+          $untrustedRootPattern = '(?i)(0x800B0109|untrusted root|root certificate.+not trusted)'
 
           $targetDir = 'src-tauri/target/release'
           New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
@@ -398,8 +411,28 @@ jobs:
             }
 
             $signature = Get-AuthenticodeSignature -LiteralPath $binary.Source
-            if ($signature.Status -ne 'Valid' -or -not $signature.TimeStamperCertificate) {
-              throw "The restored executable is not validly signed: $($binary.Source): $($signature.Status)"
+            $certificate = $signature.SignerCertificate
+            if (-not $certificate) {
+              throw "The restored executable does not contain a signer certificate: $($binary.Source)"
+            }
+            $actualThumbprint = ($certificate.Thumbprint -replace '\s', '').ToUpperInvariant()
+            if (
+              $actualThumbprint -ne $expectedThumbprint -or
+              $certificate.Subject -ne $env:EXPECTED_CERTIFICATE_SUBJECT -or
+              $certificate.Issuer -ne $env:EXPECTED_CERTIFICATE_ISSUER
+            ) {
+              throw "The restored executable was signed by an unexpected certificate: $($binary.Source)"
+            }
+            if (-not $signature.TimeStamperCertificate) {
+              throw "The restored executable does not contain a trusted timestamp: $($binary.Source)"
+            }
+
+            $isExpectedTestTrustFailure =
+              $env:SIGNING_MODE -eq 'test' -and
+              $signature.Status -in @('UnknownError', 'NotTrusted') -and
+              $signature.StatusMessage -match $untrustedRootPattern
+            if ($signature.Status -ne 'Valid' -and -not $isExpectedTestTrustFailure) {
+              throw "The restored executable is not validly signed: $($binary.Source): $($signature.Status): $($signature.StatusMessage)"
             }
 
             Copy-Item -LiteralPath $binary.Source -Destination $binary.Target -Force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,7 +317,7 @@ jobs:
             $signature = Get-AuthenticodeSignature -LiteralPath $Path
             $signature | Format-List Status, StatusMessage, SignerCertificate, TimeStamperCertificate
             if ($signature.Status -ne 'Valid') {
-              throw "Authenticode signature is not valid for $Path: $($signature.Status)"
+              throw "Authenticode signature is not valid for ${Path}: $($signature.Status)"
             }
             if (-not $signature.TimeStamperCertificate) {
               throw "The signature does not contain a trusted timestamp: $Path"
@@ -716,7 +716,7 @@ jobs:
             $signature = Get-AuthenticodeSignature -LiteralPath $Path
             $signature | Format-List Status, StatusMessage, SignerCertificate, TimeStamperCertificate
             if ($signature.Status -ne 'Valid') {
-              throw "Authenticode signature is not valid for $Path: $($signature.Status)"
+              throw "Authenticode signature is not valid for ${Path}: $($signature.Status)"
             }
             if (-not $signature.TimeStamperCertificate) {
               throw "The signature does not contain a trusted timestamp: $Path"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Release
 
 on:
   push:
+    branches:
+      - "ci/windows-artifact-sign"
     tags:
       - "v*"
 
@@ -17,6 +19,7 @@ jobs:
     permissions:
       contents: read
     outputs:
+      mode: ${{ steps.release.outputs.mode }}
       version: ${{ steps.release.outputs.version }}
       tag: ${{ steps.release.outputs.tag }}
     steps:
@@ -25,22 +28,32 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Validate tag, versions, and signing scope
+      - name: Validate source, versions, and signing scope
         id: release
         shell: bash
         run: |
           set -euo pipefail
 
-          tag="$GITHUB_REF_NAME"
-          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Release tags must use the stable SemVer form vMAJOR.MINOR.PATCH: $tag" >&2
-            exit 1
-          fi
-
-          version="${tag#v}"
           package_version="$(jq -r '.version' package.json)"
           tauri_version="$(jq -r '.version' src-tauri/tauri.conf.json)"
           cargo_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' src-tauri/Cargo.toml | head -n 1)"
+
+          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+            mode="release"
+            tag="$GITHUB_REF_NAME"
+            if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Release tags must use the stable SemVer form vMAJOR.MINOR.PATCH: $tag" >&2
+              exit 1
+            fi
+            version="${tag#v}"
+          elif [[ "$GITHUB_REF_TYPE" == "branch" && "$GITHUB_REF_NAME" == "ci/windows-artifact-sign" ]]; then
+            mode="test"
+            tag=""
+            version="$package_version"
+          else
+            echo "Unsupported release source: $GITHUB_REF_TYPE $GITHUB_REF_NAME" >&2
+            exit 1
+          fi
 
           for entry in \
             "package.json:$package_version" \
@@ -89,6 +102,7 @@ jobs:
             exit 1
           fi
 
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
@@ -204,9 +218,11 @@ jobs:
       - name: Verify signed executable
         shell: pwsh
         env:
+          SIGNING_MODE: ${{ needs.validate-release.outputs.mode }}
           RELEASE_VERSION: ${{ needs.validate-release.outputs.version }}
           EXPECTED_CERTIFICATE_SUBJECT: ${{ vars.SIGNPATH_CERTIFICATE_SUBJECT }}
           EXPECTED_CERTIFICATE_ISSUER: ${{ vars.SIGNPATH_CERTIFICATE_ISSUER }}
+          EXPECTED_CERTIFICATE_SHA1: ${{ vars.SIGNPATH_CERTIFICATE_SHA1 }}
         run: |
           $ErrorActionPreference = 'Stop'
 
@@ -227,12 +243,9 @@ jobs:
             return $candidate.FullName
           }
 
-          function Assert-AuthenticodeSignature {
+          function Get-PinnedSignerCertificate {
             param([Parameter(Mandatory = $true)][string]$Path)
 
-            if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
-              throw "Signed file was not found: $Path"
-            }
             if ([string]::IsNullOrWhiteSpace($env:EXPECTED_CERTIFICATE_SUBJECT)) {
               throw 'SIGNPATH_CERTIFICATE_SUBJECT is not configured.'
             }
@@ -240,16 +253,71 @@ jobs:
               throw 'SIGNPATH_CERTIFICATE_ISSUER is not configured.'
             }
 
+            $expectedThumbprint = ($env:EXPECTED_CERTIFICATE_SHA1 -replace '\s', '').ToUpperInvariant()
+            if ($expectedThumbprint -notmatch '^[0-9A-F]{40}$') {
+              throw 'SIGNPATH_CERTIFICATE_SHA1 must contain a 40-character SHA-1 certificate thumbprint.'
+            }
+
+            $signature = Get-AuthenticodeSignature -LiteralPath $Path
+            if (-not $signature.SignerCertificate) {
+              throw "The Authenticode signature does not contain a signer certificate: $Path"
+            }
+
+            $certificate = $signature.SignerCertificate
+            $actualThumbprint = ($certificate.Thumbprint -replace '\s', '').ToUpperInvariant()
+            if ($actualThumbprint -ne $expectedThumbprint) {
+              throw "Unexpected certificate thumbprint: $actualThumbprint"
+            }
+            if ($certificate.Subject -ne $env:EXPECTED_CERTIFICATE_SUBJECT) {
+              throw "Unexpected certificate subject: $($certificate.Subject)"
+            }
+            if ($certificate.Issuer -ne $env:EXPECTED_CERTIFICATE_ISSUER) {
+              throw "Unexpected certificate issuer: $($certificate.Issuer)"
+            }
+
+            return $certificate
+          }
+
+          function Add-PinnedTestCertificateToTrustStore {
+            param([Parameter(Mandatory = $true)][string]$Path)
+
+            if ($env:SIGNING_MODE -eq 'release') {
+              return
+            }
+            if ($env:SIGNING_MODE -ne 'test') {
+              throw "Unsupported signing mode: $($env:SIGNING_MODE)"
+            }
+
+            $certificate = Get-PinnedSignerCertificate -Path $Path
+            if ($certificate.Subject -ne $certificate.Issuer) {
+              throw 'The pinned test certificate must be self-signed before it can be trusted on the ephemeral runner.'
+            }
+
+            $store = [System.Security.Cryptography.X509Certificates.X509Store]::new(
+              [System.Security.Cryptography.X509Certificates.StoreName]::Root,
+              [System.Security.Cryptography.X509Certificates.StoreLocation]::CurrentUser
+            )
+            try {
+              $store.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
+              $store.Add($certificate)
+            } finally {
+              $store.Close()
+            }
+          }
+
+          function Assert-AuthenticodeSignature {
+            param([Parameter(Mandatory = $true)][string]$Path)
+
+            if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+              throw "Signed file was not found: $Path"
+            }
+
+            $null = Get-PinnedSignerCertificate -Path $Path
+
             $signature = Get-AuthenticodeSignature -LiteralPath $Path
             $signature | Format-List Status, StatusMessage, SignerCertificate, TimeStamperCertificate
             if ($signature.Status -ne 'Valid') {
               throw "Authenticode signature is not valid for $Path: $($signature.Status)"
-            }
-            if ($signature.SignerCertificate.Subject -ne $env:EXPECTED_CERTIFICATE_SUBJECT) {
-              throw "Unexpected certificate subject: $($signature.SignerCertificate.Subject)"
-            }
-            if ($signature.SignerCertificate.Issuer -ne $env:EXPECTED_CERTIFICATE_ISSUER) {
-              throw "Unexpected certificate issuer: $($signature.SignerCertificate.Issuer)"
             }
             if (-not $signature.TimeStamperCertificate) {
               throw "The signature does not contain a trusted timestamp: $Path"
@@ -264,6 +332,7 @@ jobs:
 
           $mainBinary = "signed-windows-binary/floral-notepaper_$($env:RELEASE_VERSION).exe"
           $helperBinary = 'signed-windows-binary/floral-notepaper-update-helper.exe'
+          Add-PinnedTestCertificateToTrustStore -Path $mainBinary
           Assert-AuthenticodeSignature -Path $mainBinary
           Assert-AuthenticodeSignature -Path $helperBinary
 
@@ -550,8 +619,6 @@ jobs:
           wait-for-completion: true
           output-artifact-directory: signed-windows-installer
           skip-decompress: true
-          parameters: |
-            version: ${{ toJSON(needs.validate-release.outputs.version) }}
 
       - name: Download signed Windows binaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -562,9 +629,11 @@ jobs:
       - name: Verify installer and installed executable
         shell: pwsh
         env:
+          SIGNING_MODE: ${{ needs.validate-release.outputs.mode }}
           RELEASE_VERSION: ${{ needs.validate-release.outputs.version }}
           EXPECTED_CERTIFICATE_SUBJECT: ${{ vars.SIGNPATH_CERTIFICATE_SUBJECT }}
           EXPECTED_CERTIFICATE_ISSUER: ${{ vars.SIGNPATH_CERTIFICATE_ISSUER }}
+          EXPECTED_CERTIFICATE_SHA1: ${{ vars.SIGNPATH_CERTIFICATE_SHA1 }}
         run: |
           $ErrorActionPreference = 'Stop'
 
@@ -585,12 +654,9 @@ jobs:
             return $candidate.FullName
           }
 
-          function Assert-AuthenticodeSignature {
+          function Get-PinnedSignerCertificate {
             param([Parameter(Mandatory = $true)][string]$Path)
 
-            if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
-              throw "Signed file was not found: $Path"
-            }
             if ([string]::IsNullOrWhiteSpace($env:EXPECTED_CERTIFICATE_SUBJECT)) {
               throw 'SIGNPATH_CERTIFICATE_SUBJECT is not configured.'
             }
@@ -598,16 +664,71 @@ jobs:
               throw 'SIGNPATH_CERTIFICATE_ISSUER is not configured.'
             }
 
+            $expectedThumbprint = ($env:EXPECTED_CERTIFICATE_SHA1 -replace '\s', '').ToUpperInvariant()
+            if ($expectedThumbprint -notmatch '^[0-9A-F]{40}$') {
+              throw 'SIGNPATH_CERTIFICATE_SHA1 must contain a 40-character SHA-1 certificate thumbprint.'
+            }
+
+            $signature = Get-AuthenticodeSignature -LiteralPath $Path
+            if (-not $signature.SignerCertificate) {
+              throw "The Authenticode signature does not contain a signer certificate: $Path"
+            }
+
+            $certificate = $signature.SignerCertificate
+            $actualThumbprint = ($certificate.Thumbprint -replace '\s', '').ToUpperInvariant()
+            if ($actualThumbprint -ne $expectedThumbprint) {
+              throw "Unexpected certificate thumbprint: $actualThumbprint"
+            }
+            if ($certificate.Subject -ne $env:EXPECTED_CERTIFICATE_SUBJECT) {
+              throw "Unexpected certificate subject: $($certificate.Subject)"
+            }
+            if ($certificate.Issuer -ne $env:EXPECTED_CERTIFICATE_ISSUER) {
+              throw "Unexpected certificate issuer: $($certificate.Issuer)"
+            }
+
+            return $certificate
+          }
+
+          function Add-PinnedTestCertificateToTrustStore {
+            param([Parameter(Mandatory = $true)][string]$Path)
+
+            if ($env:SIGNING_MODE -eq 'release') {
+              return
+            }
+            if ($env:SIGNING_MODE -ne 'test') {
+              throw "Unsupported signing mode: $($env:SIGNING_MODE)"
+            }
+
+            $certificate = Get-PinnedSignerCertificate -Path $Path
+            if ($certificate.Subject -ne $certificate.Issuer) {
+              throw 'The pinned test certificate must be self-signed before it can be trusted on the ephemeral runner.'
+            }
+
+            $store = [System.Security.Cryptography.X509Certificates.X509Store]::new(
+              [System.Security.Cryptography.X509Certificates.StoreName]::Root,
+              [System.Security.Cryptography.X509Certificates.StoreLocation]::CurrentUser
+            )
+            try {
+              $store.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
+              $store.Add($certificate)
+            } finally {
+              $store.Close()
+            }
+          }
+
+          function Assert-AuthenticodeSignature {
+            param([Parameter(Mandatory = $true)][string]$Path)
+
+            if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+              throw "Signed file was not found: $Path"
+            }
+
+            $null = Get-PinnedSignerCertificate -Path $Path
+
             $signature = Get-AuthenticodeSignature -LiteralPath $Path
             $signature | Format-List Status, StatusMessage, SignerCertificate, TimeStamperCertificate
             if ($signature.Status -ne 'Valid') {
               throw "Authenticode signature is not valid for $Path: $($signature.Status)"
-            }
-            if ($signature.SignerCertificate.Subject -ne $env:EXPECTED_CERTIFICATE_SUBJECT) {
-              throw "Unexpected certificate subject: $($signature.SignerCertificate.Subject)"
-            }
-            if ($signature.SignerCertificate.Issuer -ne $env:EXPECTED_CERTIFICATE_ISSUER) {
-              throw "Unexpected certificate issuer: $($signature.SignerCertificate.Issuer)"
             }
             if (-not $signature.TimeStamperCertificate) {
               throw "The signature does not contain a trusted timestamp: $Path"
@@ -623,6 +744,7 @@ jobs:
           $installer = "signed-windows-installer/floral-notepaper_$($env:RELEASE_VERSION)_x64-setup.exe"
           $portable = "signed-windows-binaries/floral-notepaper_$($env:RELEASE_VERSION).exe"
           $helper = 'signed-windows-binaries/floral-notepaper-update-helper.exe'
+          Add-PinnedTestCertificateToTrustStore -Path $installer
           Assert-AuthenticodeSignature -Path $installer
           Assert-AuthenticodeSignature -Path $portable
           Assert-AuthenticodeSignature -Path $helper
@@ -882,6 +1004,86 @@ jobs:
           overwrite: true
           retention-days: 7
 
+  verify-test-release-assets:
+    name: Verify test release assets without publishing
+    needs:
+      - validate-release
+      - sign-windows-binary
+      - sign-and-verify-windows-installer
+      - build-linux
+      - build-macos-x86_64
+      - build-macos-aarch64
+    if: needs.validate-release.outputs.mode == 'test'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Download signed Windows portable executable
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: signed-windows-portable
+          path: test-release-assets
+
+      - name: Download signed Windows installer
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: signed-windows-installer
+          path: test-release-assets
+
+      - name: Download Linux release assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: linux-release-assets
+          path: test-release-assets
+
+      - name: Download macOS Intel release asset
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: macos-x64-release-asset
+          path: test-release-assets
+
+      - name: Download macOS Apple Silicon release asset
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: macos-aarch64-release-asset
+          path: test-release-assets
+
+      - name: Validate test assets and generate checksums
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ needs.validate-release.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          required_assets=(
+            "floral-notepaper_${RELEASE_VERSION}.exe"
+            "floral-notepaper_${RELEASE_VERSION}_x64-setup.exe"
+            "floral-notepaper_${RELEASE_VERSION}_x64.dmg"
+            "floral-notepaper_${RELEASE_VERSION}_aarch64.dmg"
+          )
+          for asset in "${required_assets[@]}"; do
+            if [[ ! -f "test-release-assets/$asset" ]]; then
+              echo "Required test asset is missing: $asset" >&2
+              exit 1
+            fi
+          done
+
+          find test-release-assets -maxdepth 1 -type f ! -name SHA256SUMS.txt -print0 \
+            | sort -z \
+            | xargs -0 sha256sum \
+            | sed 's#  test-release-assets/#  #' \
+            > test-release-assets/SHA256SUMS.txt
+
+      - name: Upload aggregate test release assets
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: test-release-assets
+          path: test-release-assets/*
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 7
+
   publish-draft-release:
     name: Publish verified assets to draft release
     needs:
@@ -891,6 +1093,7 @@ jobs:
       - build-linux
       - build-macos-x86_64
       - build-macos-aarch64
+    if: needs.validate-release.outputs.mode == 'release'
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,10 @@ npx oxfmt --check                           # 格式检查
 
 PR 标题同样遵循 Conventional Commits 格式，例如 `feat: 添加笔记标签功能`。
 
+## 发布流程（维护者）
+
+正式版本的 Tag、跨平台构建、Windows SignPath 签名、安装验证和 Draft Release 操作，请参考 [Release 发布流程](Docs/RELEASE_WORKFLOW.md)。
+
 ## 问题反馈
 
 - 报告 bug：[提交 Issue](https://github.com/Achilng/floral-notepaper/issues/new?template=bug.yml)

--- a/Docs/RELEASE_WORKFLOW.md
+++ b/Docs/RELEASE_WORKFLOW.md
@@ -1,0 +1,320 @@
+# Release 发布流程
+
+本文档面向花笺维护者，说明 [Release Workflow](../.github/workflows/release.yml) 的配置、触发方式、构建与签名链路、验证规则以及失败后的处理方式。
+
+该 Workflow 负责生成经过验证的多平台发布产物，并创建或更新 GitHub Draft Release。它不会自动把 Draft Release 发布为正式 Release。
+
+## 流程概览
+
+Release Workflow 仅由格式为 `vMAJOR.MINOR.PATCH` 的 Tag Push 触发，例如 `v1.2.3`。
+
+```mermaid
+flowchart TD
+  A["推送 vMAJOR.MINOR.PATCH Tag"] --> B["验证 Tag、main 来源、版本和签名范围"]
+  B --> C["构建 Windows 未签名 EXE"]
+  C --> D["SignPath 签名并验证 EXE"]
+  D --> E["使用已签名 EXE 构建 NSIS"]
+  E --> F["SignPath 签名并验证安装器"]
+  F --> G["Current User / All Users 安装与卸载测试"]
+  B --> H["构建 DEB、RPM、AppImage"]
+  B --> I["构建 macOS Intel / Apple Silicon DMG"]
+  G --> J["聚合产物、生成校验和与构建信息"]
+  H --> J
+  I --> J
+  J --> K["创建或更新 Draft Release"]
+  K --> L["维护者人工核验并发布"]
+```
+
+同一个 Tag 的运行通过 Workflow concurrency group 串行化。新运行不会取消正在执行的发布运行。
+
+## 发布权限和外部配置
+
+### GitHub Environment
+
+仓库必须存在名为 `release-signing` 的 GitHub Environment。两个 SignPath Job 都只能通过该 Environment 取得正式签名凭据。
+
+建议为该 Environment 配置：
+
+- Required reviewers，并禁止发起者自审；
+- 仅允许受保护的 `v*` Tag 访问；
+- 禁止管理员绕过保护规则；
+- 正式签名凭据只存放在该 Environment，不放在仓库级 Secrets 中。
+
+### Secrets 和 Variables
+
+`release-signing` Environment 需要提供以下配置：
+
+| 类型     | 名称                                                     | 用途                       |
+| -------- | -------------------------------------------------------- | -------------------------- |
+| Secret   | `SIGNPATH_RELEASE_API_TOKEN`                             | 提交正式 SignPath 签名请求 |
+| Variable | `SIGNPATH_ORGANIZATION_ID`                               | SignPath Organization ID   |
+| Variable | `SIGNPATH_PROJECT_SLUG`                                  | SignPath Project Slug      |
+| Variable | `SIGNPATH_WINDOWS_BINARY_ARTIFACT_CONFIGURATION_SLUG`    | Windows 主程序签名配置     |
+| Variable | `SIGNPATH_WINDOWS_INSTALLER_ARTIFACT_CONFIGURATION_SLUG` | Windows 安装器签名配置     |
+| Variable | `SIGNPATH_RELEASE_CERTIFICATE_SUBJECT`                   | 正式证书 Subject 固定值    |
+| Variable | `SIGNPATH_RELEASE_CERTIFICATE_ISSUER`                    | 正式证书 Issuer 固定值     |
+| Variable | `SIGNPATH_RELEASE_CERTIFICATE_SHA1`                      | 正式证书 SHA-1 指纹        |
+
+Workflow 固定使用 SignPath policy slug `release-signing`，不会从变量动态选择测试策略。
+
+建议在 SignPath 中同时启用：
+
+- Trusted Build System；
+- Origin Verification；
+- 正式签名人工审批；
+- 仓库、Workflow、Tag 和 Commit 来源限制；
+- 禁止 rerun 或其他不符合项目发布规则的来源。
+
+### Tag 保护
+
+GitHub 应为 `v*` 配置 Tag ruleset，限制 Tag 的创建、更新、删除和强制推送权限。
+
+Workflow 自身还会在以下时间点读取远端 Tag：
+
+1. 初始发布验证；
+2. Windows 主程序签名前；
+3. Windows 安装器签名前；
+4. 创建或更新 Draft Release 前。
+
+每次检查都要求：
+
+- Tag 仍然存在；
+- Tag 仍指向最初触发 Workflow 的 Commit；
+- 该 Commit 仍属于远端 `main` 的历史。
+
+只要 Tag 被删除、移动，或 Commit 不再属于 `main`，后续签名或发布就会停止。
+
+## 发布前准备
+
+### 1. 确认代码状态
+
+发布 Commit 必须已经合入 `main`，并通过完整 PR Checks。建议从最新的 `main` Head 发布。
+
+```bash
+git switch main
+git pull --ff-only origin main
+```
+
+### 2. 同步版本号
+
+以下三处版本必须完全一致：
+
+- `package.json` 的 `version`；
+- `src-tauri/tauri.conf.json` 的 `version`；
+- `src-tauri/Cargo.toml` 的 package `version`。
+
+可以使用项目脚本同步版本：
+
+```bash
+npm run version:sync -- 1.2.3
+npm install --package-lock-only --ignore-scripts
+cargo check --manifest-path src-tauri/Cargo.toml
+```
+
+后两条命令用于同步 `package-lock.json` 和 `src-tauri/Cargo.lock`。执行后应检查 `package.json`、`package-lock.json`、Tauri 配置和 Cargo 文件的实际差异。
+
+### 3. 编写 Release Note
+
+为新版本创建：
+
+```text
+Docs/release-note/1.2.3.md
+```
+
+文件名不包含 `v`。缺少对应 Release Note 时，Workflow 会在构建前失败。
+
+### 4. 执行发布前检查
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml -p floral-notepaper --lib
+npm test
+cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets
+npm run lint
+npm run fmt -- --check
+cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
+```
+
+全部通过后再合入版本变更。不要用 Release Workflow 替代 PR Checks。
+
+### 5. 创建并推送 Tag
+
+先确认本地 `main` 和远端一致，再在目标 Commit 上创建 annotated Tag：
+
+```bash
+git tag -a v1.2.3 -m "release: v1.2.3"
+git push origin v1.2.3
+```
+
+Tag 名必须严格匹配 `vMAJOR.MINOR.PATCH`。预发布后缀、构建元数据和其他格式不会通过验证。
+
+Tag 推送后不要移动或复用该 Tag。若发现需要修复的问题，应修复代码并发布新的补丁版本，而不是把原 Tag 指向另一个 Commit。
+
+## Workflow Job 说明
+
+| Job                                 | 主要职责                                                                               |
+| ----------------------------------- | -------------------------------------------------------------------------------------- |
+| `validate-release`                  | 验证 Tag 来源、版本、Release Note、Rust binary target、Tauri bundle 签名范围和安装模式 |
+| `build-windows-binary`              | 构建未签名 Windows 主程序，并在签名前写入 Tauri NSIS bundle marker                     |
+| `sign-windows-binary`               | 重新验证 Tag，提交正式 SignPath 签名请求，验证签名、时间戳和正式证书固定值             |
+| `build-windows-installer`           | 恢复已签名主程序，验证其哈希，构建未签名 NSIS 安装器                                   |
+| `sign-and-verify-windows-installer` | 签名安装器，验证 portable EXE 和安装器，执行两种安装模式的安装与卸载测试               |
+| `build-linux`                       | 构建并强制收集恰好一个 DEB、RPM 和 AppImage                                            |
+| `build-macos-x86_64`                | 构建 Intel DMG                                                                         |
+| `build-macos-aarch64`               | 构建 Apple Silicon DMG                                                                 |
+| `publish-draft-release`             | 聚合全部产物，生成 `SHA256SUMS.txt` 和 `BUILD-INFO.txt`，创建或更新 Draft Release      |
+
+发布构建统一使用固定的 Rust `1.96.1` 工具链，避免相同 Tag 在不同时间使用不同的 `stable` 编译器。
+
+## Windows 签名和安装验证
+
+### 主程序签名
+
+Windows 主程序在 SignPath 签名前会把 Tauri bundle type marker 从 `UNK` 改为 `NSS`。Workflow 要求：
+
+- `UNK` marker 在修改前恰好出现一次；
+- `NSS` marker 在修改前不存在；
+- 两个 marker 长度一致；
+- 修改后只保留一个 `NSS` marker；
+- SignPath 返回的文件必须使用配置的正式证书；
+- Authenticode 状态必须为 `Valid`；
+- 必须包含时间戳；
+- `signtool verify /pa /all /v` 必须通过。
+
+测试证书和不受信任根证书不会被 Release Workflow 接受。
+
+### NSIS 构建
+
+NSIS 打包前，Workflow 会记录已签名主程序的 SHA-256。打包后再次读取 `src-tauri/target/release/floral-notepaper.exe`，确保 bundler 没有替换或修改已签名文件。
+
+### 安装测试
+
+由于 `tauri.conf.json` 声明 `installMode: both`，CI 会依次测试：
+
+- `/S /CurrentUser`；
+- `/S /AllUsers`。
+
+每种模式都会验证：
+
+- 安装器和 portable EXE 的正式签名；
+- 安装后主程序的正式签名；
+- 安装后主程序与 portable EXE 的 SHA-256 一致；
+- 安装目录中的实际 PE 文件只包含主程序和已知卸载器；
+- 卸载器是合法 PE，并记录 SHA-256；
+- 卸载成功后主程序、安装目录和卸载注册表项均已删除。
+
+### 卸载器签名例外
+
+当前 Tauri/NSIS 流程在安装期间生成 `uninstall.exe`。在 SignPath Artifact Configuration 支持该嵌套产物的 deep signing 前，Workflow 明确允许卸载器状态为 `NotSigned`，并把它作为已知发布例外记录到 Job Summary。
+
+如果卸载器带有签名，则该签名必须使用同一正式证书并通过完整验证。任何无效、损坏或其他异常签名状态都会使发布失败。
+
+该例外不表示风险已经消除。正式启用卸载器 deep signing 后，应删除 `NotSigned` 例外并强制要求有效签名。
+
+## 发布产物
+
+Workflow 要求以下七个产物全部存在：
+
+| 平台                | 文件名                                    |
+| ------------------- | ----------------------------------------- |
+| Windows portable    | `floral-notepaper_VERSION.exe`            |
+| Windows NSIS        | `floral-notepaper_VERSION_x64-setup.exe`  |
+| Linux DEB           | `floral-notepaper_VERSION_amd64.deb`      |
+| Linux RPM           | `floral-notepaper-VERSION-1.x86_64.rpm`   |
+| Linux AppImage      | `floral-notepaper_VERSION_amd64.AppImage` |
+| macOS Intel         | `floral-notepaper_VERSION_x64.dmg`        |
+| macOS Apple Silicon | `floral-notepaper_VERSION_aarch64.dmg`    |
+
+其中 `VERSION` 是不带 `v` 的版本号。
+
+此外还会生成：
+
+- `SHA256SUMS.txt`：全部发布文件的 SHA-256；
+- `BUILD-INFO.txt`：Tag、Commit SHA、GitHub Actions Run ID 和 Run Attempt。
+
+## Draft Release 行为
+
+如果 Tag 尚无 GitHub Release，Workflow 会创建 Draft Release；如果已存在同 Tag 的 Draft Release，则更新标题和 Release Note，并使用 `gh release upload --clobber` 覆盖本 Workflow 管理的同名文件。
+
+Workflow 不会：
+
+- 覆盖已经发布的非 Draft Release；
+- 删除名称未知的 Release 附件；
+- 自动把 Draft 标记为正式发布。
+
+维护者应在 GitHub 页面人工核验：
+
+1. 七个预期平台产物全部存在；
+2. `SHA256SUMS.txt` 与实际附件一致；
+3. `BUILD-INFO.txt` 中的 Commit 是预期发布 Commit；
+4. Windows 文件的 Publisher 和签名状态正确；
+5. Release Note 内容及版本正确；
+6. 对应 PR Checks 和 Release Workflow 全部成功。
+
+确认无误后再手动发布 Draft Release。
+
+## 失败处理
+
+### Tag 来源验证失败
+
+常见原因：
+
+- Tag 指向尚未合入 `main` 的 Commit；
+- Tag 在运行期间被删除或移动；
+- 本次运行来自不支持的 Ref；
+- Tag 名不是稳定 SemVer 格式。
+
+不要通过移动原 Tag 绕过检查。应修复来源问题，并在需要时使用新的补丁版本。
+
+### 版本或 Release Note 验证失败
+
+检查三处版本号与 `Docs/release-note/VERSION.md`。修复后通过 PR 合入 `main`，再创建新 Tag。
+
+### SignPath 请求失败
+
+依次确认：
+
+- `release-signing` Environment 是否批准；
+- `SIGNPATH_RELEASE_API_TOKEN` 是否有效；
+- SignPath project 和 artifact configuration slug 是否正确；
+- `release-signing` policy 是否允许本仓库、Workflow、Tag 和 Commit；
+- Origin Verification 是否给出明确拒绝原因；
+- 正式证书固定值是否与 SignPath 实际证书一致。
+
+不要把 Release Workflow 临时改回测试 policy，也不要放宽正式证书验证以使构建通过。
+
+### Linux 或 macOS 产物数量错误
+
+Workflow 要求每种格式恰好一个候选文件。零个候选通常表示 bundler 未生成目标格式；多个候选通常表示输出目录包含旧文件或 Tauri 输出结构发生变化。
+
+应修正构建或收集逻辑，不要改成任意选择第一个文件。
+
+### Windows 安装测试失败
+
+根据失败阶段检查：
+
+- portable EXE 与安装后文件的 SHA-256；
+- Authenticode 和时间戳状态；
+- Current User 与 All Users 对应的卸载注册表位置；
+- 安装目录中的额外 PE 文件；
+- 卸载后的目录、文件和注册表残留；
+- NSIS hook 或 Tauri installer 行为是否发生变化。
+
+### 重试原则
+
+同 Tag 的运行不会并发执行。只有在确认 Tag 没有移动、代码和配置没有变化，且失败属于临时基础设施问题时，才适合重新运行失败 Job。
+
+若修复需要修改仓库内容，应通过新 Commit 和新版本 Tag 发布，不应让同一 Tag 对应不同源码或不同 Workflow。
+
+## 维护要求
+
+修改以下内容时，应同步更新本文档：
+
+- `.github/workflows/release.yml` 的触发条件、Job 或权限；
+- SignPath policy、artifact configuration、证书或变量命名；
+- Tauri bundle target 或 Windows `installMode`；
+- 发布产物名称、平台或架构；
+- Draft Release 创建、覆盖或校验清单行为；
+- Rust 发布工具链版本；
+- 卸载器签名例外。
+
+对 Release Workflow 的变更应经过安全审查，并由 CODEOWNERS 保护 Workflow 和 SignPath policy 文件。

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1171,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "floral-notepaper"
-version = "1.0.4"
+version = "1.1.0"
 dependencies = [
  "block2",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floral-notepaper"
-version = "1.0.4"
+version = "1.1.0"
 description = "A lightweight cross-platform desktop note app"
 authors = ["Achilng"]
 edition = "2021"


### PR DESCRIPTION
## Summary / 概要

- 将 Windows Release 流程拆分为内部 EXE 签名、NSIS 打包、最终安装器签名和安装验证。
- 通过 SignPath GitHub Connector 提交两次受约束的签名请求，并固定校验证书 SHA-1、Subject、Issuer 与时间戳。
- 增加 `ci/windows-artifact-sign` 测试模式：构建并验证全部平台产物，但不创建 GitHub Release。
- 在 SignPath 签名前把 Tauri bundle type 从 `UNK` 严格标记为 `NSS`，避免 NSIS bundler 后续修改已签名 PE 导致 `HashMismatch`。
- 将 Rust package 版本同步到 `1.1.0`。

### Root cause / 根因

Tauri 2 会在 NSIS 打包阶段把主程序中的 `__TAURI_BUNDLE_TYPE_VAR_UNK` 修改为 `..._NSS`。原流程先签名再由 bundler 修改这三个字节，因此安装后的 EXE 保留证书但 Authenticode 摘要失配。现在改为先应用唯一的 NSIS 标记、再交给 SignPath 签名，并在打包前后及安装后校验签名和 SHA-256。

## Affected Platforms / 影响平台

- [x] Windows
- [ ] macOS
- [ ] Linux
- [ ] Platform-agnostic / 平台无关

## Testing / 测试

1. 本地通过前端 96 项测试、Rust 146 项测试、oxlint、跟踪文件 oxfmt、cargo fmt、cargo clippy 与 actionlint。
2. [Release 测试运行 29257341076](https://github.com/Achilng/floral-notepaper/actions/runs/29257341076) 最终成功；Linux、macOS Intel、macOS Apple Silicon 与 Windows 产物均完成聚合校验。
3. Windows 已验证两次 SignPath 请求、固定测试证书与时间戳、NSIS 静默安装、安装后 EXE Authenticode 和 SHA-256、以及静默卸载；测试模式正确跳过 GitHub Release 发布。

## Checklist / 检查清单

### Code quality / 代码质量

- [x] `npx oxfmt --check`（全部 Git 跟踪文件）
- [x] `npx oxlint`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets`
- [x] `cargo test -p floral-notepaper --lib`
- [x] `npm test`
