### PR TITLE
fix: 深色模式下 LaTeX 运算符不再显示为绿色

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -627,6 +627,12 @@ input::placeholder {
 .katex .mop {
   color: var(--color-bamboo);
 }
+/* In dark mode --color-bamboo is a vivid green that makes operators (∫, \sin …)
+   and their limits stand out as "colored"; fall back to the body ink so math
+   renders in one uniform color. */
+:root[data-theme="dark"] .katex .mop {
+  color: var(--color-ink-soft);
+}
 .katex .katex-html .newline {
   height: 0.5em;
 }


### PR DESCRIPTION
## Summary / 概要

修复深色模式下部分 LaTeX 公式显示为绿色的问题。

深色模式下 `--color-bamboo` 为较鲜艳的绿色，`.katex .mop` 会将积分号、`\sin` 等运算符染绿；而积分的上下标（`msupsub`）在 DOM 中嵌套于运算符的 `.mop` span 内，会继承该颜色，导致积分号、上下标、函数名整体呈现绿色。

本 PR 仅为深色模式覆盖 `.katex .mop` 的颜色，回落到与公式主体一致的 `--color-ink-soft`，使数学公式颜色统一。浅色模式下运算符的墨绿强调（deep green）保持不变。

改动仅 6 行 CSS，见 `src/App.css`。

## Related Issue / 关联 Issue

Closes #333

## Affected Platforms / 影响平台

- [x] Platform-agnostic / 平台无关（纯 CSS，主题相关）

## Screenshots or Recordings / 截图或录屏

复现公式：`\int_{-1}^{1} \sin x \mathrm{d}x`

- 修复前（深色模式）：积分号 `∫`、上下标 `-1` / `1`、`\sin` 均显示为绿色。
- 修复后（深色模式）：以上元素统一显示为公式主体的 ink 色，与其余符号一致；浅色模式不受影响。

![深色模式 LaTeX 修复前后对比](https://raw.githubusercontent.com/Gardenia-i/floral-notepaper/pr-assets/333-dark-latex.png)

## Testing / 测试

1. 深色模式下输入 `\int_{-1}^{1} \sin x \mathrm{d}x`，确认积分号、上下标、`\sin` 不再为绿色，且与公式其余部分颜色一致。
2. 切换到浅色模式，确认运算符的墨绿强调保持不变。
3. 用项目内 KaTeX 渲染上述公式，验证 `∫` 与 `\sin` 对应 `.mop`，且积分上下标 `msupsub` 嵌套于 `.mop` 内（继承其颜色），即本次覆盖规则可同时修正这三处。

## Checklist / 检查清单

### Code quality / 代码质量

- [x] `npx oxfmt --check`
- [x] `npx oxlint`
- [x] `npm test`（96/96 通过）
- [ ] `cargo fmt --check` / `cargo clippy` / `cargo test`（本 PR 未改动 Rust 代码，不适用）
