### PR TITLE
fix: 数字间的单个波浪号不再被渲染为删除线

### DIFF
--- a/src/features/markdown/MarkdownPreview.test.tsx
+++ b/src/features/markdown/MarkdownPreview.test.tsx
@@ -16,6 +16,21 @@ describe("MarkdownPreview", () => {
     expect(markup).toContain("正文");
   });
 
+  test("does not strike through a lone tilde between numbers", () => {
+    const markup = renderToStaticMarkup(<MarkdownPreview content="0.2~3 μm / 微藻 3~20 μm" />);
+
+    expect(markup).not.toContain("<del");
+    expect(markup).toContain("0.2~3 μm");
+    expect(markup).toContain("3~20 μm");
+  });
+
+  test("still renders double-tilde strikethrough", () => {
+    const markup = renderToStaticMarkup(<MarkdownPreview content="~~已完成~~" />);
+
+    expect(markup).toContain("<del");
+    expect(markup).toContain("已完成");
+  });
+
   test("keeps code block controls outside the horizontally scrollable pre", () => {
     const markup = renderToStaticMarkup(
       <MarkdownPreview content={"```text\nvery long code line\n```"} />,

--- a/src/features/markdown/MarkdownPreview.tsx
+++ b/src/features/markdown/MarkdownPreview.tsx
@@ -71,7 +71,11 @@ interface MarkdownPreviewProps {
   imageBaseDir?: string;
 }
 
-const remarkPlugins = [remarkGfm, remarkMath, remarkAlerts];
+// singleTilde: false — only ~~text~~ is strikethrough; a lone ~ stays literal so
+// numeric ranges like "0.2~3 μm" aren't mis-parsed as GFM strikethrough.
+const remarkPlugins = [[remarkGfm, { singleTilde: false }], remarkMath, remarkAlerts] as Parameters<
+  typeof Markdown
+>[0]["remarkPlugins"];
 const sanitizeSchema = {
   ...defaultSchema,
   tagNames: [...(defaultSchema.tagNames ?? []), "mark", "center", "font", "u", "abbr"],


### PR DESCRIPTION
## Summary / 概要

修复预览模式下数字之间的单个波浪号 `~` 被渲染为删除线的问题。

`remark-gfm` 默认 `singleTilde: true`，会把单个 `~...~` 也识别为 GFM 删除线。当波浪号两侧均为数字时（如 `0.2~3 μm`、`微藻 3~20 μm`），文本中相邻的两个波浪号会被错误配对为删除线标记，导致中间内容被划线。

本 PR 为 `remark-gfm` 传入 `singleTilde: false`：仅 `~~text~~`（双波浪号）触发删除线，单个 `~` 按字面显示。改动位于 `src/features/markdown/MarkdownPreview.tsx`，并新增两条回归测试。

## Related Issue / 关联 Issue

Closes #329

## Affected Platforms / 影响平台

- [x] Platform-agnostic / 平台无关（Markdown 渲染配置）

## Screenshots or Recordings / 截图或录屏

复现文本：`0.2~3 μm / 微藻 3~20 μm`、`0.01~0.3 μm（细菌 0.5~5 μm）`

- 修复前：`3 μm / 微藻 3`、`0.3 μm（细菌 0.5` 等中间文本被渲染为删除线横线。
- 修复后：波浪号正常显示为字面字符，删除线消失；`~~text~~` 双波浪号删除线不受影响。

![波浪号渲染修复前后对比](https://raw.githubusercontent.com/Gardenia-i/floral-notepaper/pr-assets/329-tilde-strikethrough.png)

## Testing / 测试

1. 预览模式输入 `0.2~3 μm / 微藻 3~20 μm`，确认不再出现删除线，波浪号正常显示。
2. 输入 `~~已完成~~`，确认双波浪号删除线仍正常渲染（无回归）。
3. 新增单元测试 `MarkdownPreview.test.tsx`：
   - `does not strike through a lone tilde between numbers`（断言输出不含 `<del>`）
   - `still renders double-tilde strikethrough`（断言 `~~` 仍生成 `<del>`）
4. 另用项目内 `remark-gfm` 对复现文本解析 mdast 核验：默认设置产生 `delete` 节点，`singleTilde: false` 后不再产生，`~~text~~` 仍产生。

## Checklist / 检查清单

### Code quality / 代码质量

- [x] `npx oxfmt --check`
- [x] `npx oxlint`
- [x] `npm test`（98/98 通过）
- [x] `npx tsc --noEmit`（类型检查通过）
- [ ] `cargo fmt --check` / `cargo clippy` / `cargo test`（本 PR 未改动 Rust 代码，不适用）
