### PR TITLE
fix: 工具栏插入格式后编辑器不再跳到笔记顶部

### DIFF
--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -270,6 +270,9 @@ function applyFormat(
     }
   }
 
+  // Selecting the whole value scrolls the textarea to the top; capture the
+  // scroll offset so we can restore the viewport after replacing the content.
+  const previousScrollTop = textarea.scrollTop;
   textarea.focus();
   textarea.setSelectionRange(0, value.length);
   document.execCommand("insertText", false, result);
@@ -277,6 +280,7 @@ function applyFormat(
   markDirty();
   requestAnimationFrame(() => {
     textarea.setSelectionRange(cursorStart, cursorEnd);
+    textarea.scrollTop = previousScrollTop;
   });
 }
 


### PR DESCRIPTION
## Summary / 概要

修复在编辑器中点击工具栏的「分割线 / 无序列表 / 有序列表 / 代码 / 引用 / 行内公式 / 块级公式」等插入按钮后，笔记视图跳转到最顶部的问题。

`applyFormat` 为了保留原生撤销/重做栈，采用「全选 + `execCommand("insertText")` 替换整篇内容」的方式写入。但 `setSelectionRange(0, value.length)` 会把 `textarea` 滚动到顶部，而随后的 `requestAnimationFrame` 只恢复了选区、没有恢复滚动位置，因此在长笔记末尾插入内容时视图会跳到开头。

本 PR 在替换前保存 `textarea.scrollTop`，并在 `requestAnimationFrame` 中恢复选区时一并还原滚动位置，使插入后视图停留在原来的位置。改动仅 `src/components/MainWindow.tsx`。

## Related Issue / 关联 Issue

Closes #343

## Affected Platforms / 影响平台

- [x] Platform-agnostic / 平台无关

## Screenshots or Recordings / 截图或录屏

该问题是滚动位置跳变，静态截图不易体现，录制了左右对比动图（左：修复前 / 右：修复后）。相同操作（滚动到笔记中部后点击工具栏「分割线」按钮插入内容）下，修复前视图跳到笔记顶部且不再恢复，修复后视图停留在插入位置：

![工具栏插入格式后的滚动位置对比（修复前 / 修复后）](https://raw.githubusercontent.com/Gardenia-i/floral-notepaper/pr-assets/343-scroll-jump.gif)

## Testing / 测试

1. 打开有多行内容、需要滚动的笔记，滚动到底部。
2. 在末尾依次点击「分割线 / 无序列表 / 有序列表 / 代码 / 引用 / 行内公式 / 块级公式」按钮，确认每次插入后视图均停留在原位置、光标位于插入处。
3. 选中一段文本后点击「加粗 / 斜体」，确认包裹格式与选区/滚动行为正常（无回归）。
4. 插入后按 Ctrl+Z / Ctrl+Y，确认撤销/重做仍正常（`execCommand` 撤销栈未受影响）。

## Checklist / 检查清单

### Code quality / 代码质量

- [x] `npx oxfmt --check`
- [x] `npx oxlint`
- [x] `npm test`（96/96 通过）
- [x] `npx tsc --noEmit`（类型检查通过）
- [ ] `cargo fmt --check` / `cargo clippy` / `cargo test`（本 PR 未改动 Rust 代码，不适用）
