### PR TITLE
feat: 新增键盘无障碍导航支持

### DIFF
--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -215,12 +215,61 @@ export function ContextMenuProvider({ children }: { children: React.ReactNode })
     [menu, runCommand, t, tileContextMenuItems],
   );
 
+  // 菜单打开时自动聚焦第一个可用的菜单项
+  useEffect(() => {
+    if (menu && !menuClosing) {
+      requestAnimationFrame(() => {
+        const first = menuRef.current?.querySelector<HTMLButtonElement>("button:not([disabled])");
+        first?.focus();
+      });
+    }
+  }, [menu, menuClosing]);
+
+  // 键盘方向键导航
+  const handleMenuKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (menuClosing || !menuRef.current) return;
+
+      const buttons = Array.from(
+        menuRef.current.querySelectorAll<HTMLButtonElement>("button:not([disabled])"),
+      );
+      if (buttons.length === 0) return;
+
+      const currentIndex = buttons.indexOf(document.activeElement as HTMLButtonElement);
+
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          {
+            const next = buttons[Math.min(currentIndex + 1, buttons.length - 1)];
+            next?.focus();
+          }
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          {
+            const prev = buttons[Math.max(currentIndex - 1, 0)];
+            prev?.focus();
+          }
+          break;
+        case "Escape":
+          e.preventDefault();
+          dismissMenu();
+          break;
+      }
+    },
+    [menuClosing, dismissMenu],
+  );
+
   return (
     <>
       {children}
       {menu && (
         <div
           ref={menuRef}
+          role="menu"
+          tabIndex={-1}
+          onKeyDown={handleMenuKeyDown}
           className={`fixed z-[9999] min-w-[152px] py-1.5 bg-cloud/95 backdrop-blur-sm border border-paper-deep/50 rounded-lg overflow-x-hidden overflow-y-auto select-none ${menuClosing ? "animate-menu-exit" : "animate-menu-enter"}`}
           style={{
             left: menuPosition?.x ?? menu.x,

--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -1414,6 +1414,38 @@ export function MainWindow({
     }
   };
 
+  // ↑/↓ 键盘选择笔记
+  const handleNoteKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>, noteId: string) => {
+      const el = e.currentTarget;
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          {
+            const next = el.nextElementSibling;
+            if (next?.hasAttribute("data-note-item")) {
+              (next as HTMLElement).focus();
+            }
+          }
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          {
+            const prev = el.previousElementSibling;
+            if (prev?.hasAttribute("data-note-item")) {
+              (prev as HTMLElement).focus();
+            }
+          }
+          break;
+        case "Enter":
+          e.preventDefault();
+          void handleSelectNote(noteId);
+          break;
+      }
+    },
+    [handleSelectNote],
+  );
+
   const handleRemoveExternalFile = async (id: string) => {
     if (selectedId === id && saveState === "dirty") {
       const shouldSave = window.confirm(
@@ -2367,12 +2399,15 @@ export function MainWindow({
                             return (
                               <div
                                 key={note.id}
+                                tabIndex={0}
+                                data-note-item="true"
                                 draggable
                                 onDragStart={(e) => {
                                   e.dataTransfer.setData("text/plain", note.id);
                                   e.dataTransfer.effectAllowed = "move";
                                 }}
                                 onClick={() => void handleSelectNote(note.id)}
+                                onKeyDown={(e) => handleNoteKeyDown(e, note.id)}
                                 onContextMenu={(event) => handleOpenNoteMenu(event, note.id)}
                                 onMouseEnter={() => setHoveredId(note.id)}
                                 onMouseLeave={() => setHoveredId(null)}
@@ -2544,12 +2579,15 @@ export function MainWindow({
                                 return (
                                   <div
                                     key={note.id}
+                                    tabIndex={0}
+                                    data-note-item="true"
                                     draggable
                                     onDragStart={(e) => {
                                       e.dataTransfer.setData("text/plain", note.id);
                                       e.dataTransfer.effectAllowed = "move";
                                     }}
                                     onClick={() => void handleSelectNote(note.id)}
+                                    onKeyDown={(e) => handleNoteKeyDown(e, note.id)}
                                     onContextMenu={(event) => handleOpenNoteMenu(event, note.id)}
                                     onMouseEnter={() => setHoveredId(note.id)}
                                     onMouseLeave={() => setHoveredId(null)}
@@ -2921,6 +2959,11 @@ export function MainWindow({
                           onDrop={imageDropHandler}
                           onDragOver={imageDragOverHandler}
                           onScroll={handleEditorScroll}
+                          onKeyDown={(e) => {
+                            if (e.key === "Escape") {
+                              e.currentTarget.blur();
+                            }
+                          }}
                           className="w-full h-full leading-[1.9] text-ink-soft font-body placeholder:text-ink-ghost/40"
                           style={{
                             fontSize: `${settingsConfig?.fontSize ?? 14}px`,

--- a/src/components/NotePad.tsx
+++ b/src/components/NotePad.tsx
@@ -801,6 +801,9 @@ export function NotePad({
                     setStatus("dirty");
                   }}
                   onKeyDown={(event) => {
+                    if (event.key === "Escape") {
+                      event.currentTarget.blur();
+                    }
                     if (event.key === "Enter" || event.key === "ArrowDown") {
                       event.preventDefault();
                       contentRef.current?.focus();
@@ -823,6 +826,9 @@ export function NotePad({
                   onDrop={imageDropHandler}
                   onDragOver={imageDragOverHandler}
                   onKeyDown={(event) => {
+                    if (event.key === "Escape") {
+                      event.currentTarget.blur();
+                    }
                     if (event.key === "ArrowUp") {
                       const ta = contentRef.current;
                       if (ta && ta.selectionStart === ta.selectionEnd) {

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -88,9 +88,25 @@ export function SettingsPanel({ config, onChange, onMigrateDataDir, onClose }: S
     [t],
   );
 
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const firstFocusable = panelRef.current?.querySelector<HTMLElement>(
+      'button, input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    );
+    const timer = setTimeout(() => firstFocusable?.focus(), 60);
+    return () => clearTimeout(timer);
+  }, []);
+
   return (
-    <aside className="w-[360px] h-full shrink-0 border-l border-paper-deep/30 bg-cloud/92 backdrop-blur-sm flex flex-col">
-      <div className="flex items-center justify-between h-11 px-4 border-b border-paper-deep/25">
+    <aside
+      ref={panelRef}
+      className="w-[360px] h-full shrink-0 min-h-0 overflow-y-auto scrollbar-hidden border-l border-paper-deep/30 bg-cloud/92 backdrop-blur-sm flex flex-col"
+      onKeyDown={(e) => {
+        if (e.key === "Escape") onClose();
+      }}
+    >
+      <div className="flex items-center justify-between h-11 px-4 border-b border-paper-deep/25 shrink-0">
         <h2 className="text-[13px] font-display font-medium text-ink-soft">
           {t("settings.title", { defaultValue: "应用设置" })}
         </h2>
@@ -114,7 +130,7 @@ export function SettingsPanel({ config, onChange, onMigrateDataDir, onClose }: S
         </button>
       </div>
 
-      <div className="flex-1 overflow-y-auto scrollbar-hidden px-4 py-4 space-y-5">
+      <div className="flex-1 px-4 py-4 space-y-5">
         <section className="space-y-2">
           <label className="block text-[11px] font-body text-ink-faint">
             {t("settings.theme.label", { defaultValue: "主题" })}
@@ -490,7 +506,15 @@ interface ToggleRowProps {
 
 function ToggleRow({ label, checked, onChange }: ToggleRowProps) {
   return (
-    <label className="flex items-center justify-between h-9 rounded-lg px-2.5 bg-paper-warm/45 border border-paper-deep/25 cursor-pointer">
+    <label
+      className="flex items-center justify-between h-9 rounded-lg px-2.5 bg-paper-warm/45 border border-paper-deep/25 cursor-pointer focus-within:ring-2 focus-within:ring-bamboo/40"
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          onChange(!checked);
+        }
+      }}
+    >
       <span className="text-[12px] text-ink-soft">{label}</span>
       <input
         type="checkbox"


### PR DESCRIPTION
## Summary / 概要

为编辑器、笔记列表、右键菜单和设置面板添加键盘无障碍导航支持。

- **笔记列表**：笔记项添加 `tabIndex={0}` 使 Tab 可聚焦，↑/↓ 在笔记间移动焦点，Enter 加载笔记到编辑器
- **编辑器**：textarea 中按 Escape 释放焦点，解决 Tab 陷阱
- **右键菜单**：打开时自动聚焦第一项，↑/↓ 方向键导航，Enter 执行，Escape 关闭
- **设置面板**：打开时自动聚焦第一个可交互元素，Toggle 开关支持 Enter 切换，Escape 关闭面板；ToggleRow 添加 `focus-within` 聚焦环

## Related Issue / 关联 Issue

无关联 Issue，基于无障碍改进建议

## Affected Platforms / 影响平台

- [ ] Windows
- [ ] macOS
- [ ] Linux
- [x] Platform-agnostic / 平台无关

## Screenshots or Recordings / 截图或录屏

原版：
https://github.com/bedhere/floral-notepaper/releases/download/v0.0.1-demo/original.mp4
更新后
https://github.com/bedhere/floral-notepaper/releases/download/v0.0.1-demo/update.mp4

## Testing / 测试

1. Tab 进入侧边栏笔记列表，↑/↓ 选择笔记，Enter 加载到编辑器
2. Tab 进入编辑器 textarea，按 Escape 释放焦点，再按 Tab 继续导航
3. Shift+F10 唤出右键菜单，↑/↓ 导航，Enter 执行，Escape 关闭
4. Enter 打开设置面板，验证焦点自动进入面板
5. Tab 在设置面板内移动，验证 Toggle 开关有聚焦环，按 Enter 可切换
6. 在设置面板内按 Escape 关闭面板
7. 运行  测试代码 全部通过

## Checklist / 检查清单

- [x] `npx oxfmt --check`
- [x] `npx oxlint`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `npm test`