### PR TITLE
chore/将macOS最低版本改为12.0

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -42,7 +42,7 @@
       }
     },
     "macOS": {
-      "minimumSystemVersion": "15.0"
+      "minimumSystemVersion": "12.0"
     },
     "windows": {
       "nsis": {


### PR DESCRIPTION
只改动了tauri.conf.json

<!--
  提交 PR 前请逐项勾选确认。Please check all boxes before submitting.
  选择性填写，没有就不写。Fill in what's relevant; leave blank if not applicable.
-->

## Summary / 概要

将 `tauri.conf.json` 中 macOS 的 `minimumSystemVersion` 改为 12.0

## Related Issue / 关联 Issue

没有 Issue

## Affected Platforms / 影响平台

<!-- 勾选受影响或已验证的平台。Check platforms affected or verified. -->

- [ ] Windows
- [x] macOS
- [ ] Linux
- [ ] Platform-agnostic / 平台无关

## Screenshots or Recordings / 截图或录屏

无前端变更

## Testing / 测试

在 macOS 12 上运行即可测试。我的工作环境/测试环境均为 macOS 12.7.4

## Checklist / 检查清单

### Code quality / 代码质量

您确认您运行并通过了：

- [x] `npx oxfmt --check`
- [x] `npx oxlint`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `npm test`

<!-- 感谢你对花笺 Floral Notepaper 的贡献！Thank you for your contribution! -->
