### PR TITLE
feat(notepad): preview pasted images inline

### DIFF
--- a/src/components/BackgroundLayer.test.tsx
+++ b/src/components/BackgroundLayer.test.tsx
@@ -1,0 +1,35 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test, vi } from "vitest";
+import type { AppConfig } from "../features/settings/types";
+import { BackgroundLayer } from "./BackgroundLayer";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  convertFileSrc: vi.fn((path: string) => `asset://${path}`),
+}));
+
+describe("BackgroundLayer", () => {
+  test("renders a configured custom wallpaper", () => {
+    const config = {
+      backgroundImagePath: "C:/data/backgrounds/wallpaper.png",
+      backgroundFit: "repeat",
+      backgroundDim: 0.35,
+      backgroundBlur: 4,
+      backgroundScale: 1.2,
+      backgroundPositionX: 30,
+      backgroundPositionY: 70,
+    } as AppConfig;
+
+    const markup = renderToStaticMarkup(<BackgroundLayer config={config} />);
+
+    expect(markup).toContain("asset://C:/data/backgrounds/wallpaper.png");
+    expect(markup).toContain("background-repeat:repeat");
+    expect(markup).toContain("background-position:30% 70%");
+    expect(markup).toContain("filter:blur(4px)");
+    expect(markup).toContain("transform:scale(1.2)");
+    expect(markup).toContain("opacity:0.35");
+  });
+
+  test("renders nothing when no wallpaper is configured", () => {
+    expect(renderToStaticMarkup(<BackgroundLayer config={null} />)).toBe("");
+  });
+});

--- a/src/components/NotePad.tsx
+++ b/src/components/NotePad.tsx
@@ -5,6 +5,11 @@ import { useTranslation } from "react-i18next";
 import { createNote, getErrorMessage, getNote, listNotes, updateNote } from "../features/notes/api";
 import { useImagePaste } from "../features/images/useImagePaste";
 import { useImageBaseDir } from "../features/images/useImageBaseDir";
+import { NoteInlineImageEditor } from "../features/images/NoteInlineImageEditor";
+import {
+  extractNoteImageReferences,
+  visibleNoteText,
+} from "../features/images/noteImageReferences";
 import { reportInstallPreparation } from "../features/update/api";
 import type { UpdateInstallPrepareRequest } from "../features/update/types";
 import { showToast } from "./Toast";
@@ -30,7 +35,7 @@ import {
   normalizeTileColor,
   resolveTileColor,
 } from "../features/settings/tileColor";
-import type { TileColorMode } from "../features/settings/types";
+import type { AppConfig, TileColorMode } from "../features/settings/types";
 import {
   shouldEnterPadFromTileOnDoubleClick,
   shouldReturnToTileAfterManualSave,
@@ -52,6 +57,7 @@ import {
 } from "../features/windows/tileWindowEvents";
 import { NotepadOpenPanel } from "./NotepadOpenPanel";
 import { Tile } from "./Tile";
+import { BackgroundLayer } from "./BackgroundLayer";
 
 type OpenMode = "new" | "open";
 type NotePadStatus = "empty" | "opened" | "saved" | "dirty" | "saveFailed" | "copied";
@@ -112,7 +118,7 @@ function SurfaceResizeHandles() {
             event.stopPropagation();
             void startCurrentWindowResize(handle.direction).catch(() => undefined);
           }}
-          className={`absolute ${handle.size} opacity-0 ${handle.className}`}
+          className={`absolute z-20 ${handle.size} opacity-0 ${handle.className}`}
         />
       ))}
     </>
@@ -133,6 +139,7 @@ export function NotePad({
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
   const [status, setStatus] = useState<NotePadStatus>("empty");
+  const [settingsConfig, setSettingsConfig] = useState<AppConfig | null>(null);
   const [noteSurfaceAutoSave, setNoteSurfaceAutoSave] = useState(initialAutoSave);
   const [tileColorRaw, setTileColorRaw] = useState(normalizeTileColor(initialTileColor));
   const [tileColorMode, setTileColorMode] = useState<TileColorMode>("system");
@@ -144,6 +151,7 @@ export function NotePad({
     resolveTileColor("system", normalizeTileColor(initialTileColor)),
   );
   const [isExiting, setIsExiting] = useState(false);
+  const [inlineEditorFocusOffset, setInlineEditorFocusOffset] = useState<number | null>(null);
   const titleRef = useRef<HTMLInputElement>(null);
   const contentRef = useRef<HTMLTextAreaElement>(null);
   const tileDragIntentRef = useRef<{ x: number; y: number } | null>(null);
@@ -198,6 +206,7 @@ export function NotePad({
     setEditingNoteId(note.id);
     setTitle(note.title);
     setContent(note.content);
+    setInlineEditorFocusOffset(null);
     setMode("new");
     setStatus("opened");
   }, []);
@@ -209,6 +218,7 @@ export function NotePad({
       try {
         const [loadedConfig] = await Promise.all([getConfig(), refreshNotes()]);
         if (!cancelled) {
+          setSettingsConfig(loadedConfig);
           setNoteSurfaceAutoSave(loadedConfig.noteSurfaceAutoSave);
           setSurfaceFontSize(loadedConfig.surfaceFontSize ?? 14);
           setTileRenderMarkdown(loadedConfig.tileRenderMarkdown ?? false);
@@ -263,14 +273,8 @@ export function NotePad({
   }, []);
 
   useEffect(() => {
-    const unlisten = listen<{
-      tileColor?: string;
-      tileColorMode?: TileColorMode;
-      surfaceFontSize?: number;
-      tileRenderMarkdown?: boolean;
-      tileDoubleClickToEdit?: boolean;
-      tileSaveReturnsToPin?: boolean;
-    }>("config-changed", (event) => {
+    const unlisten = listen<AppConfig>("config-changed", (event) => {
+      setSettingsConfig(event.payload);
       const mode = event.payload.tileColorMode ?? tileColorModeRef.current;
       const raw = event.payload.tileColor ?? tileColorRawRef.current;
       setTileColorMode(mode);
@@ -319,6 +323,7 @@ export function NotePad({
       setEditingNoteId(null);
       setTitle("");
       setContent("");
+      setInlineEditorFocusOffset(null);
       setMode("new");
       setStatus("empty");
       setIsExiting(false);
@@ -403,6 +408,11 @@ export function NotePad({
   );
 
   const imageBaseDir = useImageBaseDir();
+  const hasNoteImages = useMemo(() => extractNoteImageReferences(content).length > 0, [content]);
+
+  const handleImagesInserted = useCallback((_relativePaths: string[], cursorOffset: number) => {
+    setInlineEditorFocusOffset(cursorOffset);
+  }, []);
 
   const ensureNoteSaved = useCallback(async (): Promise<string | null> => {
     if (editingNoteId) return editingNoteId;
@@ -425,6 +435,7 @@ export function NotePad({
     markDirty: () => setStatus("dirty"),
     onEnsureNoteSaved: ensureNoteSaved,
     onError: showToast,
+    onInserted: handleImagesInserted,
     t,
   });
 
@@ -610,6 +621,7 @@ export function NotePad({
         setEditingNoteId(null);
         setTitle("");
         setContent("");
+        setInlineEditorFocusOffset(null);
         setNotes([]);
         setMode("new");
         setStatus("empty");
@@ -705,6 +717,7 @@ export function NotePad({
     setEditingNoteId(null);
     setTitle("");
     setContent("");
+    setInlineEditorFocusOffset(null);
     setMode("new");
     setStatus("empty");
   };
@@ -758,7 +771,8 @@ export function NotePad({
         </Tile>
       ) : (
         <div className={padSurfaceClassName} data-surface-mode={surfaceMode}>
-          <>
+          <BackgroundLayer config={settingsConfig} />
+          <div className="relative z-10 flex flex-col flex-1 min-h-0">
             <div
               className="flex items-center justify-between px-4 pt-3 pb-0 cursor-default"
               onMouseDown={handleDrag}
@@ -859,37 +873,60 @@ export function NotePad({
                   style={{ fontSize: `${surfaceFontSize}px` }}
                 />
 
-                <textarea
-                  ref={contentRef}
-                  data-tab-indent="true"
-                  value={content}
-                  onChange={(event) => {
-                    setContent(event.target.value);
-                    setStatus("dirty");
-                  }}
-                  onPaste={imagePasteHandler}
-                  onDrop={imageDropHandler}
-                  onDragOver={imageDragOverHandler}
-                  onKeyDown={(event) => {
-                    if (event.key === "ArrowUp") {
-                      const ta = contentRef.current;
-                      if (ta && ta.selectionStart === ta.selectionEnd) {
-                        const textBeforeCursor = content.slice(0, ta.selectionStart);
-                        if (!textBeforeCursor.includes("\n")) {
-                          event.preventDefault();
-                          titleRef.current?.focus();
+                {hasNoteImages && imageBaseDir ? (
+                  <NoteInlineImageEditor
+                    content={content}
+                    imageBaseDir={imageBaseDir}
+                    fontSize={surfaceFontSize}
+                    noteId={editingNoteId}
+                    focusOffset={inlineEditorFocusOffset}
+                    primaryTextareaRef={contentRef}
+                    setContent={setContent}
+                    markDirty={() => setStatus("dirty")}
+                    onEnsureNoteSaved={ensureNoteSaved}
+                    onImagesInserted={handleImagesInserted}
+                    onError={showToast}
+                    onArrowUpFromStart={() => titleRef.current?.focus()}
+                    onFocusRestored={() => setInlineEditorFocusOffset(null)}
+                  />
+                ) : (
+                  <textarea
+                    ref={contentRef}
+                    data-tab-indent="true"
+                    value={content}
+                    onChange={(event) => {
+                      setContent(event.target.value);
+                      setStatus("dirty");
+                    }}
+                    onPaste={imagePasteHandler}
+                    onDrop={imageDropHandler}
+                    onDragOver={imageDragOverHandler}
+                    onKeyDown={(event) => {
+                      if (event.key === "ArrowUp") {
+                        const ta = contentRef.current;
+                        if (ta && ta.selectionStart === ta.selectionEnd) {
+                          const textBeforeCursor = content.slice(0, ta.selectionStart);
+                          if (!textBeforeCursor.includes("\n")) {
+                            event.preventDefault();
+                            titleRef.current?.focus();
+                          }
                         }
                       }
-                    }
-                  }}
-                  placeholder={t("notepad.placeholder.content", { defaultValue: "写点什么……" })}
-                  className="w-full flex-1 min-h-0 pb-2 leading-relaxed text-ink-soft font-body placeholder:text-ink-ghost/50"
-                  style={{ fontSize: `${surfaceFontSize}px`, tabSize: `var(--tab-indent-size, 2)` }}
-                />
+                    }}
+                    placeholder={t("notepad.placeholder.content", {
+                      defaultValue: "写点什么……",
+                    })}
+                    className="w-full flex-1 min-h-0 pb-2 leading-relaxed text-ink-soft font-body placeholder:text-ink-ghost/50"
+                    style={{
+                      fontSize: `${surfaceFontSize}px`,
+                      tabSize: `var(--tab-indent-size, 2)`,
+                    }}
+                  />
+                )}
 
                 <div className="flex items-center justify-between mt-auto pt-2 border-t border-paper-deep/30 shrink-0">
                   <span className="text-[11px] text-ink-ghost font-mono tabular-nums truncate max-w-[170px]">
-                    {`${countNoteChars(content)} ${t("common.wordCountUnit", { defaultValue: "字" })} · ${statusLabel[status]}`}
+                    {`${countNoteChars(visibleNoteText(content))} ${t("common.wordCountUnit", { defaultValue: "字" })} · ${statusLabel[status]}`}
                   </span>
                   <div className="flex items-center gap-2">
                     <button
@@ -913,7 +950,7 @@ export function NotePad({
                 onOpenNote={(noteId) => void handleOpenNote(noteId)}
               />
             )}
-          </>
+          </div>
           <SurfaceResizeHandles />
         </div>
       )}

--- a/src/features/images/NoteInlineImageEditor.test.tsx
+++ b/src/features/images/NoteInlineImageEditor.test.tsx
@@ -1,0 +1,41 @@
+import { createRef } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test, vi } from "vitest";
+import { NoteInlineImageEditor } from "./NoteInlineImageEditor";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  convertFileSrc: vi.fn((path: string) => `asset://${path}`),
+  invoke: vi.fn(),
+}));
+
+describe("NoteInlineImageEditor", () => {
+  test("renders a managed image in content order without exposing its Markdown", () => {
+    const markup = renderToStaticMarkup(
+      <NoteInlineImageEditor
+        content={"before\n![](images/note-1/photo.png)\nafter"}
+        imageBaseDir="C:/data"
+        fontSize={14}
+        noteId="note-1"
+        focusOffset={null}
+        primaryTextareaRef={createRef<HTMLTextAreaElement>()}
+        setContent={vi.fn()}
+        markDirty={vi.fn()}
+        onEnsureNoteSaved={vi.fn(async () => "note-1")}
+        onImagesInserted={vi.fn()}
+        onError={vi.fn()}
+        onArrowUpFromStart={vi.fn()}
+        onFocusRestored={vi.fn()}
+      />,
+    );
+
+    const beforeIndex = markup.indexOf(">before</textarea>");
+    const imageIndex = markup.indexOf("<img");
+    const afterIndex = markup.indexOf(">after</textarea>");
+
+    expect(beforeIndex).toBeGreaterThan(-1);
+    expect(imageIndex).toBeGreaterThan(beforeIndex);
+    expect(afterIndex).toBeGreaterThan(imageIndex);
+    expect(markup).not.toContain("![](");
+    expect(markup).toContain('src="asset://C:/data/images/note-1/photo.png"');
+  });
+});

--- a/src/features/images/NoteInlineImageEditor.tsx
+++ b/src/features/images/NoteInlineImageEditor.tsx
@@ -1,0 +1,273 @@
+import { convertFileSrc } from "@tauri-apps/api/core";
+import { useCallback, useLayoutEffect, useMemo, useRef } from "react";
+import type { RefObject } from "react";
+import { useTranslation } from "react-i18next";
+import { resolveMarkdownImageSrc } from "../markdown/imageSrc";
+import { useImagePaste } from "./useImagePaste";
+import { parseNoteContentParts } from "./noteImageReferences";
+import type { NoteContentPart } from "./noteImageReferences";
+
+type TextPart = Extract<NoteContentPart, { type: "text" }>;
+
+interface TextPartEditorProps {
+  part: TextPart;
+  partIndex: number;
+  fontSize: number;
+  noteId: string | null;
+  primary: boolean;
+  primaryTextareaRef: RefObject<HTMLTextAreaElement | null>;
+  hasPreviousImage: boolean;
+  hasNextImage: boolean;
+  registerRef: (partIndex: number, textarea: HTMLTextAreaElement | null) => void;
+  onChange: (partIndex: number, value: string) => void;
+  onRemoveAdjacentImage: (partIndex: number, direction: "previous" | "next") => void;
+  onEnsureNoteSaved: () => Promise<string | null>;
+  onInserted: (relativePaths: string[], cursorOffset: number) => void;
+  onError: (message: string) => void;
+  onArrowUpFromStart: () => void;
+  markDirty: () => void;
+}
+
+function TextPartEditor({
+  part,
+  partIndex,
+  fontSize,
+  noteId,
+  primary,
+  primaryTextareaRef,
+  hasPreviousImage,
+  hasNextImage,
+  registerRef,
+  onChange,
+  onRemoveAdjacentImage,
+  onEnsureNoteSaved,
+  onInserted,
+  onError,
+  onArrowUpFromStart,
+  markDirty,
+}: TextPartEditorProps) {
+  const { t } = useTranslation();
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const collapseEmptyPart = part.value.length === 0 && hasNextImage;
+
+  const setTextareaRef = useCallback(
+    (textarea: HTMLTextAreaElement | null) => {
+      textareaRef.current = textarea;
+      registerRef(partIndex, textarea);
+      if (primary) primaryTextareaRef.current = textarea;
+    },
+    [partIndex, primary, primaryTextareaRef, registerRef],
+  );
+
+  useLayoutEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    textarea.style.height = "0px";
+    textarea.style.height = collapseEmptyPart
+      ? "0px"
+      : `${Math.max(textarea.scrollHeight, Math.ceil(fontSize * 1.8))}px`;
+  }, [collapseEmptyPart, fontSize, part.value]);
+
+  const { handlePaste, handleDrop, handleDragOver } = useImagePaste({
+    noteId,
+    textareaRef,
+    setContent: (value) => onChange(partIndex, value),
+    markDirty,
+    onEnsureNoteSaved,
+    onError,
+    onInserted: (relativePaths, cursorOffset) =>
+      onInserted(relativePaths, part.start + cursorOffset),
+    t,
+  });
+
+  return (
+    <textarea
+      ref={setTextareaRef}
+      data-tab-indent="true"
+      data-note-text-part={partIndex}
+      value={part.value}
+      rows={1}
+      onChange={(event) => {
+        onChange(partIndex, event.target.value);
+        markDirty();
+      }}
+      onPaste={handlePaste}
+      onDrop={handleDrop}
+      onDragOver={handleDragOver}
+      onKeyDown={(event) => {
+        const textarea = event.currentTarget;
+        if (
+          event.key === "Backspace" &&
+          hasPreviousImage &&
+          textarea.selectionStart === 0 &&
+          textarea.selectionEnd === 0
+        ) {
+          event.preventDefault();
+          onRemoveAdjacentImage(partIndex, "previous");
+          return;
+        }
+        if (
+          event.key === "Delete" &&
+          hasNextImage &&
+          textarea.selectionStart === textarea.value.length &&
+          textarea.selectionEnd === textarea.value.length
+        ) {
+          event.preventDefault();
+          onRemoveAdjacentImage(partIndex, "next");
+          return;
+        }
+        if (
+          primary &&
+          event.key === "ArrowUp" &&
+          textarea.selectionStart === textarea.selectionEnd &&
+          !textarea.value.slice(0, textarea.selectionStart).includes("\n")
+        ) {
+          event.preventDefault();
+          onArrowUpFromStart();
+        }
+      }}
+      className={`block w-full shrink-0 resize-none overflow-hidden leading-relaxed text-ink-soft font-body ${collapseEmptyPart ? "min-h-0 p-0" : "min-h-7 pb-1"}`}
+      style={{ fontSize: `${fontSize}px`, tabSize: `var(--tab-indent-size, 2)` }}
+    />
+  );
+}
+
+interface NoteInlineImageEditorProps {
+  content: string;
+  imageBaseDir: string;
+  fontSize: number;
+  noteId: string | null;
+  focusOffset: number | null;
+  primaryTextareaRef: RefObject<HTMLTextAreaElement | null>;
+  setContent: (value: string) => void;
+  markDirty: () => void;
+  onEnsureNoteSaved: () => Promise<string | null>;
+  onImagesInserted: (relativePaths: string[], cursorOffset: number) => void;
+  onError: (message: string) => void;
+  onArrowUpFromStart: () => void;
+  onFocusRestored: () => void;
+}
+
+export function NoteInlineImageEditor({
+  content,
+  imageBaseDir,
+  fontSize,
+  noteId,
+  focusOffset,
+  primaryTextareaRef,
+  setContent,
+  markDirty,
+  onEnsureNoteSaved,
+  onImagesInserted,
+  onError,
+  onArrowUpFromStart,
+  onFocusRestored,
+}: NoteInlineImageEditorProps) {
+  const parts = useMemo(() => parseNoteContentParts(content), [content]);
+  const textareaRefs = useRef(new Map<number, HTMLTextAreaElement>());
+
+  const registerRef = useCallback((partIndex: number, textarea: HTMLTextAreaElement | null) => {
+    if (textarea) textareaRefs.current.set(partIndex, textarea);
+    else textareaRefs.current.delete(partIndex);
+  }, []);
+
+  useLayoutEffect(() => {
+    if (focusOffset == null) return;
+
+    let targetIndex = parts.findIndex(
+      (part) => part.type === "text" && focusOffset >= part.start && focusOffset <= part.end,
+    );
+    if (targetIndex < 0) {
+      targetIndex = parts.findIndex((part) => part.type === "text" && part.start >= focusOffset);
+    }
+    if (targetIndex < 0) {
+      for (let index = parts.length - 1; index >= 0; index -= 1) {
+        if (parts[index].type === "text") {
+          targetIndex = index;
+          break;
+        }
+      }
+    }
+
+    const targetPart = parts[targetIndex];
+    const textarea = textareaRefs.current.get(targetIndex);
+    if (targetPart?.type === "text" && textarea) {
+      const cursor = Math.max(0, Math.min(targetPart.value.length, focusOffset - targetPart.start));
+      textarea.focus();
+      textarea.setSelectionRange(cursor, cursor);
+    }
+    onFocusRestored();
+  }, [focusOffset, onFocusRestored, parts]);
+
+  const serializeParts = useCallback(
+    (replacementIndex?: number, replacementValue?: string, removedIndex?: number) =>
+      parts
+        .filter((_, index) => index !== removedIndex)
+        .map((part, index) => {
+          if (index === replacementIndex && part.type === "text") return replacementValue ?? "";
+          return part.type === "text" ? part.value : part.raw;
+        })
+        .join(""),
+    [parts],
+  );
+
+  const handleTextChange = useCallback(
+    (partIndex: number, value: string) => setContent(serializeParts(partIndex, value)),
+    [serializeParts, setContent],
+  );
+
+  const removeAdjacentImage = useCallback(
+    (partIndex: number, direction: "previous" | "next") => {
+      const imageIndex = direction === "previous" ? partIndex - 1 : partIndex + 1;
+      if (parts[imageIndex]?.type !== "image") return;
+      setContent(serializeParts(undefined, undefined, imageIndex));
+      markDirty();
+    },
+    [markDirty, parts, serializeParts, setContent],
+  );
+
+  let firstTextPartIndex = parts.findIndex(
+    (part, index) =>
+      part.type === "text" && !(part.value.length === 0 && parts[index + 1]?.type === "image"),
+  );
+  if (firstTextPartIndex < 0) {
+    firstTextPartIndex = parts.findIndex((part) => part.type === "text");
+  }
+
+  return (
+    <div data-notepad-inline-image-editor="true" className="flex-1 min-h-0 overflow-y-auto pb-2">
+      {parts.map((part, index) =>
+        part.type === "text" ? (
+          <TextPartEditor
+            key={`text-${part.start}-${index}`}
+            part={part}
+            partIndex={index}
+            fontSize={fontSize}
+            noteId={noteId}
+            primary={index === firstTextPartIndex}
+            primaryTextareaRef={primaryTextareaRef}
+            hasPreviousImage={parts[index - 1]?.type === "image"}
+            hasNextImage={parts[index + 1]?.type === "image"}
+            registerRef={registerRef}
+            onChange={handleTextChange}
+            onRemoveAdjacentImage={removeAdjacentImage}
+            onEnsureNoteSaved={onEnsureNoteSaved}
+            onInserted={onImagesInserted}
+            onError={onError}
+            onArrowUpFromStart={onArrowUpFromStart}
+            markDirty={markDirty}
+          />
+        ) : (
+          <div key={`image-${part.start}-${part.reference.src}`} className="my-2 w-full shrink-0">
+            <img
+              src={resolveMarkdownImageSrc(part.reference.src, imageBaseDir, convertFileSrc)}
+              alt={part.reference.alt}
+              decoding="async"
+              className="mx-auto block max-h-[min(14rem,45vh)] max-w-full rounded bg-paper-warm/30 object-contain"
+            />
+          </div>
+        ),
+      )}
+    </div>
+  );
+}

--- a/src/features/images/noteImageReferences.test.ts
+++ b/src/features/images/noteImageReferences.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "vitest";
+import {
+  extractNoteImageReferences,
+  parseNoteContentParts,
+  visibleNoteText,
+} from "./noteImageReferences";
+
+describe("extractNoteImageReferences", () => {
+  test("extracts app-managed note images in content order", () => {
+    expect(
+      extractNoteImageReferences(
+        ["before", "![](images/note-1/first.png)", "![diagram](images/note-1/second.webp)"].join(
+          "\n",
+        ),
+      ),
+    ).toEqual([
+      { alt: "", src: "images/note-1/first.png" },
+      { alt: "diagram", src: "images/note-1/second.webp" },
+    ]);
+  });
+
+  test("accepts Windows separators and optional Markdown titles", () => {
+    expect(
+      extractNoteImageReferences('![photo](images\\note-1\\photo.jpg "camera upload")'),
+    ).toEqual([{ alt: "photo", src: "images\\note-1\\photo.jpg" }]);
+  });
+
+  test("ignores remote images, code examples, inline prose, and traversal paths", () => {
+    const content = [
+      "![](https://example.com/remote.png)",
+      "text ![](images/note-1/inline.png)",
+      "    ![](images/note-1/indented-code.png)",
+      "![](images/note-1/../../private.png)",
+      "```markdown",
+      "![](images/note-1/example.png)",
+      "```",
+    ].join("\n");
+
+    expect(extractNoteImageReferences(content)).toEqual([]);
+  });
+
+  test("does not close a fenced code block on a fence-like content line", () => {
+    const content = [
+      "```markdown",
+      "```not-a-closing-fence",
+      "![](images/note-1/example.png)",
+      "```",
+    ].join("\n");
+
+    expect(extractNoteImageReferences(content)).toEqual([]);
+  });
+
+  test("keeps canonical offsets while replacing image lines with ordered parts", () => {
+    const content = "before\n![](images/note-1/photo.png)\nafter";
+    const parts = parseNoteContentParts(content);
+
+    expect(parts).toEqual([
+      { type: "text", value: "before", start: 0, end: 6 },
+      {
+        type: "image",
+        raw: "\n![](images/note-1/photo.png)\n",
+        reference: { alt: "", src: "images/note-1/photo.png" },
+        start: 6,
+        end: 36,
+      },
+      { type: "text", value: "after", start: 36, end: 41 },
+    ]);
+    expect(parts.map((part) => (part.type === "text" ? part.value : part.raw)).join("")).toBe(
+      content,
+    );
+    expect(visibleNoteText(content)).toBe("beforeafter");
+  });
+});

--- a/src/features/images/noteImageReferences.ts
+++ b/src/features/images/noteImageReferences.ts
@@ -1,0 +1,104 @@
+export interface NoteImageReference {
+  alt: string;
+  src: string;
+}
+
+export type NoteContentPart =
+  | { type: "text"; value: string; start: number; end: number }
+  | { type: "image"; raw: string; reference: NoteImageReference; start: number; end: number };
+
+const FENCE_OPEN_PATTERN = /^ {0,3}(`{3,}|~{3,})/;
+const FENCE_CLOSE_PATTERN = /^ {0,3}(`{3,}|~{3,})\s*$/;
+const NOTE_IMAGE_PATTERN =
+  /^ {0,3}!\[([^\]]*)\]\(\s*<?(images[\\/][^)\s>]+)>?(?:\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*\)\s*$/;
+
+function parseImageLine(line: string): NoteImageReference | null {
+  const imageMatch = line.match(NOTE_IMAGE_PATTERN);
+  if (!imageMatch) return null;
+
+  const src = imageMatch[2];
+  const pathSegments = src.replace(/\\/g, "/").split("/");
+  if (pathSegments.some((segment) => segment === "." || segment === "..")) return null;
+
+  return { alt: imageMatch[1], src };
+}
+
+export function parseNoteContentParts(content: string): NoteContentPart[] {
+  const parts: NoteContentPart[] = [];
+  let fenceMarker: string | null = null;
+  let textBuffer = "";
+  let position = 0;
+
+  const pushText = () => {
+    const start = position;
+    position += textBuffer.length;
+    parts.push({ type: "text", value: textBuffer, start, end: position });
+    textBuffer = "";
+  };
+
+  const lines = content.match(/[^\n]*(?:\n|$)/g)?.filter(Boolean) ?? [];
+
+  for (const rawLine of lines) {
+    const lineWithPossibleCr = rawLine.endsWith("\n") ? rawLine.slice(0, -1) : rawLine;
+    const line = lineWithPossibleCr.endsWith("\r")
+      ? lineWithPossibleCr.slice(0, -1)
+      : lineWithPossibleCr;
+
+    if (!fenceMarker) {
+      const openingFence = line.match(FENCE_OPEN_PATTERN);
+      if (openingFence) {
+        fenceMarker = openingFence[1];
+        textBuffer += rawLine;
+        continue;
+      }
+    } else {
+      const closingFence = line.match(FENCE_CLOSE_PATTERN);
+      if (
+        closingFence &&
+        closingFence[1][0] === fenceMarker[0] &&
+        closingFence[1].length >= fenceMarker.length
+      ) {
+        fenceMarker = null;
+      }
+      textBuffer += rawLine;
+      continue;
+    }
+
+    const reference = fenceMarker ? null : parseImageLine(line);
+    if (!reference) {
+      textBuffer += rawLine;
+      continue;
+    }
+
+    let separator = "";
+    if (textBuffer.endsWith("\r\n")) {
+      separator = "\r\n";
+      textBuffer = textBuffer.slice(0, -2);
+    } else if (textBuffer.endsWith("\n")) {
+      separator = "\n";
+      textBuffer = textBuffer.slice(0, -1);
+    }
+
+    pushText();
+    const raw = separator + rawLine;
+    const start = position;
+    position += raw.length;
+    parts.push({ type: "image", raw, reference, start, end: position });
+  }
+
+  pushText();
+  return parts;
+}
+
+export function extractNoteImageReferences(content: string): NoteImageReference[] {
+  return parseNoteContentParts(content)
+    .filter((part): part is Extract<NoteContentPart, { type: "image" }> => part.type === "image")
+    .map((part) => part.reference);
+}
+
+export function visibleNoteText(content: string): string {
+  return parseNoteContentParts(content)
+    .filter((part): part is Extract<NoteContentPart, { type: "text" }> => part.type === "text")
+    .map((part) => part.value)
+    .join("");
+}

--- a/src/features/images/useImagePaste.test.ts
+++ b/src/features/images/useImagePaste.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test, vi } from "vitest";
+import { insertTextAtCursor } from "./useImagePaste";
+
+function textarea(value: string, selectionStart: number, selectionEnd = selectionStart) {
+  return {
+    value,
+    selectionStart,
+    selectionEnd,
+    focus: vi.fn(),
+    setSelectionRange: vi.fn(),
+  } as unknown as HTMLTextAreaElement;
+}
+
+describe("insertTextAtCursor", () => {
+  test("inserts image Markdown and updates the controlled value", () => {
+    const target = textarea("note", 4);
+    const setContent = vi.fn();
+
+    insertTextAtCursor(target, setContent, "![](images/note-1/photo.png)");
+
+    const expected = "note\n![](images/note-1/photo.png)\n";
+    expect(target.value).toBe(expected);
+    expect(setContent).toHaveBeenCalledWith(expected);
+    expect(target.setSelectionRange).toHaveBeenCalledWith(expected.length, expected.length);
+  });
+
+  test("replaces the selected text and preserves trailing content", () => {
+    const target = textarea("before old after", 7, 10);
+    const setContent = vi.fn();
+
+    insertTextAtCursor(target, setContent, "![](images/note-1/photo.png)");
+
+    expect(setContent).toHaveBeenCalledWith("before \n![](images/note-1/photo.png)\n after");
+  });
+});

--- a/src/features/images/useImagePaste.ts
+++ b/src/features/images/useImagePaste.ts
@@ -21,6 +21,7 @@ interface UseImagePasteOptions {
   onEnsureNoteSaved: () => Promise<string | null>;
   disabled?: boolean;
   onError?: (message: string) => void;
+  onInserted?: (relativePaths: string[], cursorOffset: number) => void;
   t?: TFunction;
 }
 
@@ -44,13 +45,19 @@ export function insertTextAtCursor(
   setContent: (value: string) => void,
   text: string,
 ) {
-  const before = textarea.value.slice(0, textarea.selectionStart);
+  const selectionStart = textarea.selectionStart;
+  const selectionEnd = textarea.selectionEnd;
+  const before = textarea.value.slice(0, selectionStart);
+  const after = textarea.value.slice(selectionEnd);
   const needsLeadingNewline = before.length > 0 && !before.endsWith("\n");
   const insertion = (needsLeadingNewline ? "\n" : "") + text + "\n";
+  const nextValue = before + insertion + after;
+  const nextCursor = before.length + insertion.length;
 
+  textarea.value = nextValue;
+  setContent(nextValue);
   textarea.focus();
-  document.execCommand("insertText", false, insertion);
-  setContent(textarea.value);
+  textarea.setSelectionRange(nextCursor, nextCursor);
 }
 
 function getImageFiles(dataTransfer: DataTransfer): File[] {
@@ -73,6 +80,7 @@ export function useImagePaste({
   onEnsureNoteSaved,
   disabled,
   onError,
+  onInserted,
   t,
 }: UseImagePasteOptions) {
   const processingRef = useRef(false);
@@ -103,6 +111,10 @@ export function useImagePaste({
         if (markdownLines.length > 0) {
           insertTextAtCursor(textarea, setContent, markdownLines.join("\n"));
           markDirty();
+          onInserted?.(
+            markdownLines.map((line) => line.slice(4, -1)),
+            textarea.selectionStart,
+          );
         }
       } catch (error) {
         const message =
@@ -114,7 +126,7 @@ export function useImagePaste({
         processingRef.current = false;
       }
     },
-    [noteId, textareaRef, setContent, markDirty, onEnsureNoteSaved, onError, t],
+    [noteId, textareaRef, setContent, markDirty, onEnsureNoteSaved, onError, onInserted, t],
   );
 
   const handlePaste = useCallback(


### PR DESCRIPTION
## Summary / 概要

- Render pasted and dropped managed images inline at their exact Quick Note content position.
- Keep canonical Markdown in saved notes while hiding the `![](images/...)` source from the editing UI.
- Preserve cursor placement, replacement selections, surrounding text, and adjacent-image deletion.
- Treat remote images, traversal paths, inline prose, indented code, and fenced code examples as plain text.
- Reuse the existing custom wallpaper configuration in Quick Note windows and apply setting changes live.

## Related Issue / 关联 Issue

N/A

## Affected Platforms / 影响平台

- [x] Windows
- [ ] macOS
- [ ] Linux
- [ ] Platform-agnostic / 平台无关

## Screenshots or Recordings / 截图或录屏

Verified in the native Windows Quick Note window: pasted images appear between the surrounding text without exposing their Markdown source.

## Testing / 测试

1. Paste or drop an image before, between, and after Quick Note text; confirm the image stays at that position and no `![](...)` text is visible.
2. Save and reopen the note; confirm the image order and surrounding text persist, and Backspace/Delete can remove an adjacent image.
3. Choose and adjust a custom background in Settings; confirm the wallpaper and its fit/dim/blur/scale/position update in Quick Note.

## Checklist / 检查清单

### Code quality / 代码质量

您确认您运行并通过了：

- [x] `npx oxfmt --check`
- [x] `npx oxlint`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo test` (an existing backend test process did not complete; no Rust files changed)
- [x] `npm test` (28 files, 106 tests)

Additional verification: `npm run build` and `npm run tauri build -- --no-bundle` passed on Windows.
