### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Achilng/floral-notepaper&type=Date&legend=top-left)](https://star-history.com/#Achilng/floral-notepaper&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Achilng/floral-notepaper&type=Date&legend=top-left)](https://star-history.dera.page/#Achilng/floral-notepaper&Date)
 
 ## 🌟 贡献者
 

--- a/README_en-US.md
+++ b/README_en-US.md
@@ -97,7 +97,7 @@ Please refer to [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Achilng/floral-notepaper&type=Date&legend=top-left)](https://star-history.com/#Achilng/floral-notepaper&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Achilng/floral-notepaper&type=Date&legend=top-left)](https://star-history.dera.page/#Achilng/floral-notepaper&Date)
 
 ## 🌟 Contributors
 

--- a/README_zh-HK.md
+++ b/README_zh-HK.md
@@ -97,7 +97,7 @@
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Achilng/floral-notepaper&type=Date&legend=top-left)](https://star-history.com/#Achilng/floral-notepaper&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Achilng/floral-notepaper&type=Date&legend=top-left)](https://star-history.dera.page/#Achilng/floral-notepaper&Date)
 
 ## 🌟 貢獻者
 


### PR DESCRIPTION
The star history chart shown in the README is currently broken due to GitHub stargazer API restrictions. This change points the chart to an alternative data source so it displays correctly again, across all localized README versions.