### PR TITLE
fix: preserve markdown line spacing and task toggles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "rehype-raw": "^7.0.0",
         "rehype-sanitize": "^6.0.0",
         "rehype-slug": "^6.0.0",
+        "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0",
         "unist-util-visit": "^5.1.0"
@@ -3428,6 +3429,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
@@ -4474,6 +4489,21 @@
         "hast-util-heading-rank": "^3.0.0",
         "hast-util-to-string": "^3.0.0",
         "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
     "rehype-slug": "^6.0.0",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
     "unist-util-visit": "^5.1.0"

--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -1598,11 +1598,19 @@ export function MainWindow({
     });
   };
 
-  const markDirty = () => {
+  const markDirty = useCallback(() => {
     if (!selectedId) return;
     saveStateRef.current = "dirty";
     setSaveState("dirty");
-  };
+  }, [selectedId]);
+
+  const handlePreviewTaskToggle = useCallback(
+    (updatedContent: string) => {
+      setContent(updatedContent);
+      markDirty();
+    },
+    [markDirty],
+  );
 
   const ensureNoteSaved = useCallback(async (): Promise<string | null> => {
     if (selectedId) return selectedId;
@@ -3033,6 +3041,7 @@ export function MainWindow({
                       >
                         <MarkdownPreview
                           content={deferredContent}
+                          onToggleTask={handlePreviewTaskToggle}
                           fontSize={settingsConfig?.fontSize ?? 14}
                           renderHtml={settingsConfig?.renderHtmlMarkdown ?? false}
                           imageBaseDir={imageBaseDir ?? undefined}

--- a/src/features/markdown/MarkdownPreview.test.tsx
+++ b/src/features/markdown/MarkdownPreview.test.tsx
@@ -1,6 +1,7 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, test, vi } from "vitest";
 import { MarkdownPreview } from "./MarkdownPreview";
+import { toggleTaskAtLine } from "./toggleTaskAtLine";
 
 vi.mock("@tauri-apps/plugin-opener", () => ({
   openUrl: vi.fn(),
@@ -28,5 +29,49 @@ describe("MarkdownPreview", () => {
     expect(markup).toContain("markdown-code-scroll");
     expect(preCloseIndex).toBeGreaterThan(-1);
     expect(buttonIndex).toBeGreaterThan(preCloseIndex);
+  });
+
+  test("renders single newlines as line breaks", () => {
+    const markup = renderToStaticMarkup(<MarkdownPreview content={"first line\nsecond line"} />);
+
+    expect(markup).toContain("<br");
+  });
+
+  test("renders single newlines inside lists and blockquotes as line breaks", () => {
+    const markup = renderToStaticMarkup(
+      <MarkdownPreview content={"- 列表第一行\n  列表第二行\n\n> 引用第一行\n> 引用第二行"} />,
+    );
+
+    expect(markup).toContain("<br");
+  });
+
+  test("preserves blank lines between paragraphs and inside blockquotes", () => {
+    const markup = renderToStaticMarkup(
+      <MarkdownPreview content={"first\n\n\nsecond\n\n> 引用第一行\n>\n> 引用第二行"} />,
+    );
+
+    expect(markup.match(/<br/g)).toHaveLength(4);
+  });
+
+  test("keeps task checkboxes read-only without a toggle callback", () => {
+    const markup = renderToStaticMarkup(<MarkdownPreview content={"- [ ] todo\n- [x] done"} />);
+
+    expect(markup).toContain('type="checkbox"');
+    expect(markup).toContain("disabled");
+  });
+
+  test("enables task checkboxes with a toggle callback", () => {
+    const markup = renderToStaticMarkup(
+      <MarkdownPreview content={"- [ ] todo\n- [x] done"} onToggleTask={vi.fn()} />,
+    );
+
+    expect(markup).not.toContain("disabled");
+  });
+
+  test("toggles task state on the matching source line", () => {
+    const source = "- [ ] todo\n- [x] done";
+
+    expect(toggleTaskAtLine(source, 1)).toBe("- [x] todo\n- [x] done");
+    expect(toggleTaskAtLine(source, 2)).toBe("- [ ] todo\n- [ ] done");
   });
 });

--- a/src/features/markdown/MarkdownPreview.tsx
+++ b/src/features/markdown/MarkdownPreview.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import remarkBreaks from "remark-breaks";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
 import rehypeRaw from "rehype-raw";
@@ -12,7 +13,9 @@ import { convertFileSrc } from "@tauri-apps/api/core";
 import type { Components } from "react-markdown";
 import "katex/dist/katex.min.css";
 import remarkAlerts from "./remarkAlerts";
+import remarkBlankLines from "./remarkBlankLines";
 import { resolveMarkdownImageSrc } from "./imageSrc";
+import { toggleTaskAtLine } from "./toggleTaskAtLine";
 
 function CodeBlock({ children, language }: { children: React.ReactNode; language?: string }) {
   const { t } = useTranslation();
@@ -69,9 +72,11 @@ interface MarkdownPreviewProps {
   fontSize?: number;
   renderHtml?: boolean;
   imageBaseDir?: string;
+  onToggleTask?: (updatedContent: string) => void;
 }
 
-const remarkPlugins = [remarkGfm, remarkMath, remarkAlerts];
+const remarkPlugins = [remarkGfm, remarkMath, remarkAlerts, remarkBreaks, remarkBlankLines];
+
 const sanitizeSchema = {
   ...defaultSchema,
   tagNames: [...(defaultSchema.tagNames ?? []), "mark", "center", "font", "u", "abbr"],
@@ -272,9 +277,6 @@ const staticComponents: Components = {
   td: ({ children }) => (
     <td className="px-3 py-1.5 border border-paper-deep/35 text-ink-soft">{children}</td>
   ),
-  input: ({ checked, ...props }) => (
-    <input {...props} checked={checked} disabled className="mr-1.5 accent-bamboo" />
-  ),
 };
 
 export function MarkdownPreview({
@@ -282,11 +284,57 @@ export function MarkdownPreview({
   fontSize = 14,
   renderHtml = false,
   imageBaseDir,
+  onToggleTask,
 }: MarkdownPreviewProps) {
   const { t } = useTranslation();
   const components = useMemo<Components>(
     () => ({
       ...staticComponents,
+      li: ({ children, node, className }) => {
+        const isTask = typeof className === "string" && className.includes("task-list-item");
+        const classes = ["text-ink-soft", "leading-[1.9]"];
+        if (isTask) classes.push("list-none");
+        const line = node?.position?.start?.line;
+        const toggle =
+          isTask && onToggleTask && typeof line === "number"
+            ? () => {
+                const updated = toggleTaskAtLine(content, line);
+                if (updated !== content) onToggleTask(updated);
+              }
+            : undefined;
+        return (
+          <li
+            className={classes.join(" ")}
+            onChange={
+              toggle
+                ? (event) => {
+                    if (
+                      event.target instanceof HTMLInputElement &&
+                      event.target.type === "checkbox"
+                    ) {
+                      toggle();
+                    }
+                  }
+                : undefined
+            }
+          >
+            {children}
+          </li>
+        );
+      },
+      input: ({ checked, disabled: _disabled, type, ...props }) => {
+        const interactive = type === "checkbox" && onToggleTask;
+        return (
+          <input
+            {...props}
+            type={type}
+            checked={checked}
+            disabled={!interactive}
+            onChange={() => {}}
+            className={interactive ? "mr-1.5 accent-bamboo cursor-pointer" : "mr-1.5 accent-bamboo"}
+          />
+        );
+      },
       img: ({ src, alt, ...props }) => {
         const resolvedSrc = resolveMarkdownImageSrc(src, imageBaseDir, convertFileSrc);
         return (
@@ -300,7 +348,7 @@ export function MarkdownPreview({
         );
       },
     }),
-    [imageBaseDir],
+    [content, onToggleTask, imageBaseDir],
   );
   return (
     <div className="font-body markdown-selectable" style={{ fontSize: `${fontSize}px` }}>

--- a/src/features/markdown/remarkBlankLines.ts
+++ b/src/features/markdown/remarkBlankLines.ts
@@ -1,0 +1,44 @@
+import type { Break, ListItem, Paragraph, Root, RootContent, Blockquote } from "mdast";
+import type { Plugin } from "unified";
+
+function blankLineParagraph(count: number): Paragraph {
+  return {
+    type: "paragraph",
+    children: Array.from({ length: count }, () => ({ type: "break" }) as Break),
+  };
+}
+
+function insertBlankLines<T extends RootContent>(children: T[]): T[] {
+  const result: RootContent[] = [];
+  let previousEndLine: number | undefined;
+
+  for (const child of children) {
+    const startLine = child.position?.start?.line;
+    if (previousEndLine && startLine && startLine > previousEndLine + 1) {
+      result.push(blankLineParagraph(startLine - previousEndLine - 1));
+    }
+    result.push(child);
+    const endLine = child.position?.end?.line;
+    if (endLine) previousEndLine = endLine;
+  }
+
+  return result as T[];
+}
+
+const remarkBlankLines: Plugin<[], Root> = () => (tree) => {
+  const visitContainer = (node: Root | Blockquote | ListItem): void => {
+    node.children = insertBlankLines(node.children);
+
+    for (const child of node.children) {
+      if (child.type === "blockquote" || child.type === "listItem") {
+        visitContainer(child);
+      } else if (child.type === "list") {
+        child.children.forEach(visitContainer);
+      }
+    }
+  };
+
+  visitContainer(tree);
+};
+
+export default remarkBlankLines;

--- a/src/features/markdown/toggleTaskAtLine.ts
+++ b/src/features/markdown/toggleTaskAtLine.ts
@@ -1,0 +1,13 @@
+// 任务项源码行以列表标记 + 空格开头，复选框是该行第一个
+// `[ ]`/`[x]`，直接替换行内第一个匹配即可，不受正文内容干扰
+export function toggleTaskAtLine(source: string, lineNumber: number): string {
+  const lines = source.split("\n");
+  const line = lines[lineNumber - 1];
+  if (line === undefined) return source;
+  const toggled = line.includes("[ ]")
+    ? line.replace("[ ]", "[x]")
+    : line.replace(/\[[xX]\]/, "[ ]");
+  if (toggled === line) return source;
+  lines[lineNumber - 1] = toggled;
+  return lines.join("\n");
+}


### PR DESCRIPTION
### 概述

![Markdown 预览修复效果](https://raw.githubusercontent.com/luck-lak/floral-notepaper/pr-385-assets/Docs/pr-385-summary.png)

Fixes #230

标准 Markdown 会把单个换行当作“软换行”，并且会把连续多个空行折叠成一个段落分隔符，导致预览区和编辑区的显示差异比较明显。

这个 PR：

- 使用 `remark-breaks` 把单个换行渲染为可见的换行
- 保留段落之间、引用块内部、列表项内部的空行数量
- 在开启预览交互时，让 GFM 任务复选框可以点击，并回写到对应源码行

### 验证

- [x] `npm test`
- [x] `npm run lint`
- [x] `npx oxfmt --check`
- [x] `npx tsc --noEmit`

### 手动检查

- 单个换行会渲染为可见换行
- 多个空行能保留相同的视觉间距
- 引用块内的空行会被保留
- 任务复选框会更新源笔记，并标记为未保存状态